### PR TITLE
get_phy_addr method for xlnk

### DIFF
--- a/python/pynq/drivers/xlnk.py
+++ b/python/pynq/drivers/xlnk.py
@@ -208,13 +208,13 @@ class xlnk:
         """Get the physical address of a buffer.
         
         Used to get the physical address of a memory buffer allocated with
-        `cma_alloc`.
+        `cma_alloc`. The return value can be used to access the buffer from the
+        programmable logic.
 
         Parameters
         ----------
         buf_ptr : cffi.FFI.CData
-            A void pointer pointing to the memory buffer. Return value of
-            `cma_alloc`.
+            A void pointer pointing to the memory buffer. 
             
         Returns
         -------

--- a/python/pynq/drivers/xlnk.py
+++ b/python/pynq/drivers/xlnk.py
@@ -203,6 +203,30 @@ class xlnk:
         """
         self.__check_buftype(buf)
         return(ffi.buffer(buf, length))
+    
+    def cma_get_phy_addr(self, buf_ptr)
+        """Get the physical address of a buffer.
+        
+        Used to get the physical address of a memory buffer allocated with
+        `cma_alloc`. The return value can be used to access the buffer from the
+        programmable logic.
+
+        Parameters
+        ----------
+        buf_ptr : cffi.FFI.CData
+            A void pointer pointing to the memory buffer. Return value of
+            `cma_alloc`.
+            
+        Returns
+        -------
+        unsigned int
+            The physical address of the memory buffer.
+
+        """
+        self.__check_buftype(buf_ptr)
+        if "void *" not in str(buf_ptr):
+            raise RuntimeError("Unkown pointer type")
+        return(libxlnk.cma_get_phy_addr(buf_ptr))
 
     @staticmethod
     def cma_memcopy(dest, src, nbytes):

--- a/python/pynq/drivers/xlnk.py
+++ b/python/pynq/drivers/xlnk.py
@@ -204,7 +204,7 @@ class xlnk:
         self.__check_buftype(buf)
         return(ffi.buffer(buf, length))
     
-    def cma_get_phy_addr(self, buf_ptr)
+    def cma_get_phy_addr(self, buf_ptr):
         """Get the physical address of a buffer.
         
         Used to get the physical address of a memory buffer allocated with

--- a/python/pynq/drivers/xlnk.py
+++ b/python/pynq/drivers/xlnk.py
@@ -208,8 +208,7 @@ class xlnk:
         """Get the physical address of a buffer.
         
         Used to get the physical address of a memory buffer allocated with
-        `cma_alloc`. The return value can be used to access the buffer from the
-        programmable logic.
+        `cma_alloc`.
 
         Parameters
         ----------
@@ -219,7 +218,7 @@ class xlnk:
             
         Returns
         -------
-        unsigned int
+        int
             The physical address of the memory buffer.
 
         """


### PR DESCRIPTION
I was looking into using the xlnk class for an implementation of us and it seems that the get_phy_addr method is missing.
Best,
Benedikt