### PR TITLE
Changed Value to ValueError to properly printout error message

### DIFF
--- a/python/pynq/board/rgbled.py
+++ b/python/pynq/board/rgbled.py
@@ -74,7 +74,7 @@ class RGBLED(object):
         
         """
         if not index in [4,5]:
-            raise Value("Index for onboard RGBLEDs should be 4 - 5.")
+            raise ValueError("Index for onboard RGBLEDs should be 4 - 5.")
             
         self.index = index
         if RGBLED._mmio is None:


### PR DESCRIPTION
I noticed that an incorrect error message was being printed when an invalid index was used in RGBLED.