### PR TITLE
fixed usb wifi error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can <a href="https://files.digilent.com/Products/PYNQ/pynq_z1_image_2016_09_
 
 ## Quick Start
 
-See the <a href="http://pynq.readthedocs.io/en/latest/2_getting_started.html" target="_blank">Quickstart guide</a> for details on writing the image to an SD card, and getting started with the PYNQ-Z1 board.
+See the <a href="http://pynq.readthedocs.io/en/latest/1_getting_started.html" target="_blank">Quickstart guide</a> for details on writing the image to an SD card, and getting started with the PYNQ-Z1 board.
 
 ## Modify Python
 

--- a/python/pynq/drivers/usb_wifi.py
+++ b/python/pynq/drivers/usb_wifi.py
@@ -58,7 +58,7 @@ class Usb_Wifi(object):
         If no device is found, wifi_port is not assigned.
 
         """
-
+        self.wifi_port = None
         net_devices = sproc.check_output('ip a', shell=True).decode()
 
         for line in net_devices.splitlines():
@@ -66,7 +66,10 @@ class Usb_Wifi(object):
             if m:
                 if m.group(2) != 'lo' and m.group(2) != 'eth0':
                     self.wifi_port = m.group(2)
-        print(self.wifi_port)
+
+        if not self.wifi_port:
+            raise ValueError("""Wifi device not found. Re-attach the device
+            or check device compatibility.""")
 
     def gen_network_file(self, ssid, password):
         """Generate the network authentication file.


### PR DESCRIPTION
@yunqu 
Fixed merge error on arduino analog and rebased to image_2017_01.
I modified self.wifi_port to be None is no device is present, and removed the print to not add verbose parameter.

I don't know what caused the double commit pull request, but it should be ok