### PR TITLE
fix pl server bugs when closing sockets

### DIFF
--- a/scripts/linux/stop_pl_server.py
+++ b/scripts/linux/stop_pl_server.py
@@ -46,5 +46,3 @@ if os.path.exists("/home/xilinx/pynq/bitstream/.log"):
         PL.server_update(0)
     except ConnectionRefusedError:
         pass
-    
-    os.remove("/home/xilinx/pynq/bitstream/.log")


### PR DESCRIPTION
Delete the command where `.log` file is explicitly removed. This fixes the error message when `start_pl_server.py` is running in the background.