### PR TITLE
 Allow absolute paths for IOP binary files 

### DIFF
--- a/python/pynq/iop/iop.py
+++ b/python/pynq/iop/iop.py
@@ -27,11 +27,6 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__author__      = "Yun Rock Qu"
-__copyright__   = "Copyright 2016, Xilinx"
-__email__       = "yunq@xilinx.com"
-
-
 import asyncio
 import os
 import sys
@@ -41,6 +36,11 @@ from pynq import GPIO
 from pynq import PL
 from pynq import Interrupt
 from pynq.iop import iop_const
+
+
+__author__ = "Yun Rock Qu"
+__copyright__ = "Copyright 2016, Xilinx"
+__email__ = "yunq@xilinx.com"
 
 
 class _IOPInterruptEvent:
@@ -104,7 +104,7 @@ class _IOP:
     """
 
     def __init__(self, iop_name, addr_base, addr_range, gpio_uix,
-                 mb_program, intr_pin = None, intr_ack_gpio = None):
+                 mb_program, intr_pin=None, intr_ack_gpio=None):
         """Create a new _IOP object.
 
         Parameters

--- a/python/pynq/iop/iop.py
+++ b/python/pynq/iop/iop.py
@@ -122,7 +122,7 @@ class _IOP:
 
         """
         self.iop_name = iop_name
-        self.mb_program = iop_const.BIN_LOCATION + mb_program
+        self.mb_program = mb_program
         self.state = 'IDLE'
         self.gpio = GPIO(GPIO.get_gpio_pin(gpio_uix), "out")
         self.mmio = MMIO(addr_base, addr_range)
@@ -246,11 +246,15 @@ def request_iop(iop_id, mb_program):
     gpio_uix, _ = gpio_dict[rst_pin]
     intr_ack_gpio, _ = gpio_dict[intr_ack_pin]
 
+    mb_path = mb_program
+    if not os.path.isabs(mb_path):
+        mb_path = os.path.join(iop_const.BIN_LOCATION, mb_path)
+
     if (ip_state is None) or \
-            (ip_state == (iop_const.BIN_LOCATION + mb_program)):
+            (ip_state == mb_path):
         # case 1
         return _IOP(iop, addr_base, addr_range, gpio_uix,
-                    mb_program, intr_pin, intr_ack_gpio)
+                    mb_path, intr_pin, intr_ack_gpio)
     else:
         # case 2
         raise LookupError('Another program {} already running on IOP.'


### PR DESCRIPTION
Checks if a microblaze bin path is absolute and only joins the path on the front if it isn't. This could be done with a single path.join as any absolute path in a join discards what comes before but I think this way is slightly clearer.