### PR TITLE
Notebook 5.0.0 and higher require an additional option when run as root

### DIFF
--- a/scripts/linux/2_jupyter_server.sh
+++ b/scripts/linux/2_jupyter_server.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-su -c 'cd ~xilinx ; jupyter notebook > /var/log/jupyter.log  2>&1 &' -s /bin/bash root
+# Source the environment as the init system won't
+. /etc/environment
+notebook_args=
+notebook_version=$(jupyter notebook --version | grep -o '^[0-9]*')
+
+if [ $notebook_version -ge 5 ]; then
+  notebook_args=--allow-root
+fi
+
+su -c "cd ~xilinx ; jupyter notebook $notebook_args > /var/log/jupyter.log  2>&1 &" -s /bin/bash root
 
 script_name=`readlink -f "$0"`
 


### PR DESCRIPTION
For security reasons jupyter notebook server no longer runs as root
unless an explicit option is provided. This change modifies the boot
script to test for the version and add it if necessary.