### PR TITLE
Adding a test and variables for CPU architecture

### DIFF
--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -35,6 +35,11 @@ __author__ = "Yun Rock Qu"
 __copyright__ = "Copyright 2017, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
+# Pynq Family Constants
+ZYNQ_ARCH = "armv7l"
+CPU_ARCH = os.uname().machine
+CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH]
+              
 # Clock constants
 SRC_CLK_MHZ = 50.0
 DEFAULT_CLK_MHZ = 100.0


### PR DESCRIPTION
* Modifications in ps.py should make it easier to test for non-Xilinx
platforms, such as Read The Docs