### PR TITLE
Fix ReadTheDocs build errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../../python'))
+sys.path.insert(0, os.path.abspath('../../'))
 
 import pynq
 

--- a/pynq/interrupt.py
+++ b/pynq/interrupt.py
@@ -59,7 +59,7 @@ class Interrupt(object):
 
         """
         if pinname not in PL.interrupt_pins:
-            raise ValueError("No Pin of name {0} found".format(pinname))
+            raise ValueError("No Pin of name {} found".format(pinname))
 
         parentname = PL.interrupt_pins[pinname]['controller']
         self.number = PL.interrupt_pins[pinname]['index']
@@ -212,7 +212,7 @@ class _InterruptController(object):
             uiodev = _get_uio_device(61 + number)
             if uiodev is None:
                 raise ValueError('Could not find UIO device for interrupt pin '
-                                 'for IRQ number {0}'.format(number))
+                                 'for IRQ number {}'.format(number))
             self.parent = _UioController(uiodev)
             self.number = 0
         else:

--- a/pynq/lib/arduino/arduino_analog.py
+++ b/pynq/lib/arduino/arduino_analog.py
@@ -107,8 +107,8 @@ class Arduino_Analog(object):
         """
         for pin in gr_pin:
             if pin not in range(ARDUINO_NUM_ANALOG_PINS):
-                raise ValueError(f"Analog pin number can only be 0 - "
-                                 f"{ARDUINO_NUM_ANALOG_PINS-1}.")
+                raise ValueError("Analog pin number can only be 0 - {}."
+                                 .format(ARDUINO_NUM_ANALOG_PINS-1))
 
         self.microblaze = Arduino(mb_info, ARDUINO_ANALOG_PROGRAM)
         self.log_interval_ms = 1000

--- a/pynq/lib/arduino/arduino_io.py
+++ b/pynq/lib/arduino/arduino_io.py
@@ -85,8 +85,8 @@ class Arduino_IO(Arduino_DevMode):
         """
         num_pins = ARDUINO_NUM_ANALOG_PINS + ARDUINO_NUM_DIGITAL_PINS
         if index not in range(num_pins):
-            raise ValueError(f"Valid pin indexes are 0 - "
-                             f"{num_pins-1}.")
+            raise ValueError("Valid pin indexes are 0 - {}."
+                             .format(num_pins-1))
         if direction not in ['in', 'out']:
             raise ValueError("Direction can only be 'in', or 'out'.")
 

--- a/pynq/lib/axigpio.py
+++ b/pynq/lib/axigpio.py
@@ -123,8 +123,8 @@ class AxiGPIO(DefaultIP):
 
             """
             if val > self._mask:
-                raise ValueError(
-                    f"{val} to large for {self._stop - self._start} bits")
+                raise ValueError("{} too large for {} bits"
+                                 .format(val, self.stop - self.start))
             self._parent.write(val << self._start, self._mask << self._start)
 
         def on(self):

--- a/pynq/lib/dma.py
+++ b/pynq/lib/dma.py
@@ -34,136 +34,13 @@ import cffi
 import functools
 import signal
 import numpy as np
+import warnings
+from pynq.ps import CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 
 
 __author__ = 'Peter Ogden, Anurag Dubey'
 __copyright__ = 'Copyright 2017, Xilinx'
 __email__ = 'pynq_support@xilinx.com'
-
-
-ffi = cffi.FFI()
-memapi = cffi.FFI()
-
-ffi.cdef("""
-typedef unsigned int* XAxiDma_Bd[20];
-typedef struct {
-        uint32_t ChanBase;           /**< physical base address*/
-        int IsRxChannel;        /**< Is this a receive channel */
-        volatile int RunState;  /**< Whether channel is running */
-        int HasStsCntrlStrm;    /**< Whether has stscntrl stream */
-        int HasDRE;
-        int DataWidth;
-        int Addr_ext;
-        uint32_t MaxTransferLen;
-
-        uint32_t * FirstBdPhysAddr; /**< Physical address of 1st BD in list */
-        uint32_t * FirstBdAddr;  /**< Virtual address of 1st BD in list */
-        uint32_t * LastBdAddr;  /**< Virtual address of last BD in the list */
-        uint32_t Length;         /**< Total size of ring in bytes */
-        uint32_t * Separation;  /**< Number of bytes between the starting
-                                     address of adjacent BDs */
-        XAxiDma_Bd *FreeHead;   /**< First BD in the free group */
-        XAxiDma_Bd *PreHead;    /**< First BD in the pre-work group */
-        XAxiDma_Bd *HwHead;     /**< First BD in the work group */
-        XAxiDma_Bd *HwTail;     /**< Last BD in the work group */
-        XAxiDma_Bd *PostHead;   /**< First BD in the post-work group */
-        XAxiDma_Bd *BdaRestart; /**< BD to load when channel is started */
-        int FreeCnt;            /**< Number of allocatable BDs in free group */
-        int PreCnt;             /**< Number of BDs in pre-work group */
-        int HwCnt;              /**< Number of BDs in work group */
-        int PostCnt;            /**< Number of BDs in post-work group */
-        int AllCnt;             /**< Total Number of BDs for channel */
-        int RingIndex;          /**< Ring Index */
-} XAxiDma_BdRing;
-typedef struct {
-        uint32_t DeviceId;
-        uint32_t * BaseAddr;
-
-        int HasStsCntrlStrm;
-        int HasMm2S;
-        int HasMm2SDRE;
-        int Mm2SDataWidth;
-        int HasS2Mm;
-        int HasS2MmDRE;
-        int S2MmDataWidth;
-        int HasSg;
-        int Mm2sNumChannels;
-        int S2MmNumChannels;
-        int Mm2SBurstSize;
-        int S2MmBurstSize;
-        int MicroDmaMode;
-        int AddrWidth;            /**< Address Width */
-} XAxiDma_Config;
-typedef struct XAxiDma {
-        uint32_t RegBase;            /* Virtual base address of DMA engine */
-        int HasMm2S;            /* Has transmit channel */
-        int HasS2Mm;            /* Has receive channel */
-        int Initialized;        /* Driver has been initialized */
-        int HasSg;
-        XAxiDma_BdRing TxBdRing;     /* BD container management */
-        XAxiDma_BdRing RxBdRing[16]; /* BD container management */
-        int TxNumChannels;
-        int RxNumChannels;
-        int MicroDmaMode;
-        int AddrWidth;            /**< Address Width */
-} XAxiDma;
-unsigned int getMemoryMap(unsigned int phyAddr, unsigned int len);
-unsigned int getPhyAddr(void *buf);
-void frame_free(void *buf);
-int XAxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config);
-void XAxiDma_Reset(XAxiDma * InstancePtr);
-int XAxiDma_ResetIsDone(XAxiDma * InstancePtr);
-int XAxiDma_Pause(XAxiDma * InstancePtr);
-int XAxiDma_Resume(XAxiDma * InstancePtr);
-uint32_t XAxiDma_Busy(XAxiDma *InstancePtr,int Direction);
-uint32_t XAxiDma_SimpleTransfer(XAxiDma *InstancePtr,\
-uint32_t * BuffAddr, uint32_t Length,int Direction);
-int XAxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, int Select);
-int XAxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, int Select);
-int XAxiDma_Selftest(XAxiDma * InstancePtr);
-void DisableInterruptsAll(XAxiDma * InstancePtr);
-""")
-
-memapi.cdef("""
-static uint32_t xlnkBufCnt = 0;
-uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
-uint32_t cma_munmap(void *buf, uint32_t len);
-void *cma_alloc(uint32_t len, uint32_t cacheable);
-uint32_t cma_get_phy_addr(void *buf);
-void cma_free(void *buf);
-uint32_t cma_pages_available();
-""")
-
-LIB_SEARCH_PATH = os.path.dirname(os.path.realpath(__file__))
-libdma = ffi.dlopen(LIB_SEARCH_PATH + "/libdma.so")
-libxlnk = memapi.dlopen("/usr/lib/libsds_lib.so")
-
-DefaultConfig = {
-    'DeviceId': 0,
-    'BaseAddr': ffi.cast("uint32_t *", 0x00000000),
-    'HasStsCntrlStrm': 0,
-    'HasMm2S': 0,
-    'HasMm2SDRE': 0,
-    'Mm2SDataWidth': 32,
-    'HasS2Mm': 1,
-    'HasS2MmDRE': 0,
-    'S2MmDataWidth': 64,
-    'HasSg': 0,
-    'Mm2sNumChannels': 1,
-    'S2MmNumChannels': 1,
-    'Mm2SBurstSize': 16,
-    'S2MmBurstSize': 64,
-    'MicroDmaMode': 0,
-    'AddrWidth': 32
-}
-
-DMA_TO_DEV = 0
-DMA_FROM_DEV = 1
-DMA_BIDIRECTIONAL = 3
-
-DeviceId = 0
-DMA_TRANSFER_LIMIT_BYTES = 8388607
-
 
 class timeout:
     """Internal timeout functions.
@@ -185,7 +62,6 @@ class timeout:
 
     def __exit__(self, type, value, traceback):
         signal.alarm(0)
-
 
 class LegacyDMA:
     """Python class which controls DMA.
@@ -217,7 +93,146 @@ class LegacyDMA:
     Configuration : dict
         Current DMAinstance configuration values.
 
+    Note
+    ----
+    If this class is parsed on an unsupported architecture it will issue
+    a warning and leave the class variables libxlnk and libdma undefined
+
     """
+
+    ffi = cffi.FFI()
+    ffi.cdef("""
+    typedef unsigned int* XAxiDma_Bd[20];
+
+    typedef struct {
+        uint32_t ChanBase;           /**< physical base address*/
+        int IsRxChannel;        /**< Is this a receive channel */
+        volatile int RunState;  /**< Whether channel is running */
+        int HasStsCntrlStrm;    /**< Whether has stscntrl stream */
+        int HasDRE;
+        int DataWidth;
+        int Addr_ext;
+        uint32_t MaxTransferLen;
+
+        uint32_t * FirstBdPhysAddr; /**< Physical address of 1st BD in list */
+        uint32_t * FirstBdAddr;  /**< Virtual address of 1st BD in list */
+        uint32_t * LastBdAddr;  /**< Virtual address of last BD in the list */
+        uint32_t Length;         /**< Total size of ring in bytes */
+        uint32_t * Separation;  /**< Number of bytes between the starting
+                                     address of adjacent BDs */
+        XAxiDma_Bd *FreeHead;   /**< First BD in the free group */
+        XAxiDma_Bd *PreHead;    /**< First BD in the pre-work group */
+        XAxiDma_Bd *HwHead;     /**< First BD in the work group */
+        XAxiDma_Bd *HwTail;     /**< Last BD in the work group */
+        XAxiDma_Bd *PostHead;   /**< First BD in the post-work group */
+        XAxiDma_Bd *BdaRestart; /**< BD to load when channel is started */
+        int FreeCnt;            /**< Number of allocatable BDs in free group */
+        int PreCnt;             /**< Number of BDs in pre-work group */
+        int HwCnt;              /**< Number of BDs in work group */
+        int PostCnt;            /**< Number of BDs in post-work group */
+        int AllCnt;             /**< Total Number of BDs for channel */
+        int RingIndex;          /**< Ring Index */
+    } XAxiDma_BdRing;
+
+    typedef struct {
+        uint32_t DeviceId;
+        uint32_t * BaseAddr;
+
+        int HasStsCntrlStrm;
+        int HasMm2S;
+        int HasMm2SDRE;
+        int Mm2SDataWidth;
+        int HasS2Mm;
+        int HasS2MmDRE;
+        int S2MmDataWidth;
+        int HasSg;
+        int Mm2sNumChannels;
+        int S2MmNumChannels;
+        int Mm2SBurstSize;
+        int S2MmBurstSize;
+        int MicroDmaMode;
+        int AddrWidth;            /**< Address Width */
+    } XAxiDma_Config;
+
+    typedef struct XAxiDma {
+        uint32_t RegBase;            /* Virtual base address of DMA engine */
+        int HasMm2S;            /* Has transmit channel */
+        int HasS2Mm;            /* Has receive channel */
+        int Initialized;        /* Driver has been initialized */
+        int HasSg;
+        XAxiDma_BdRing TxBdRing;     /* BD container management */
+        XAxiDma_BdRing RxBdRing[16]; /* BD container management */
+        int TxNumChannels;
+        int RxNumChannels;
+        int MicroDmaMode;
+        int AddrWidth;            /**< Address Width */
+    } XAxiDma;
+
+    unsigned int getMemoryMap(unsigned int phyAddr, unsigned int len);
+    unsigned int getPhyAddr(void *buf);
+    void frame_free(void *buf);
+    int XAxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config);
+    void XAxiDma_Reset(XAxiDma * InstancePtr);
+    int XAxiDma_ResetIsDone(XAxiDma * InstancePtr);
+    int XAxiDma_Pause(XAxiDma * InstancePtr);
+    int XAxiDma_Resume(XAxiDma * InstancePtr);
+    uint32_t XAxiDma_Busy(XAxiDma *InstancePtr,int Direction);
+    uint32_t XAxiDma_SimpleTransfer(XAxiDma *InstancePtr,\
+    uint32_t * BuffAddr, uint32_t Length,int Direction);
+    int XAxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, int Select);
+    int XAxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, int Select);
+    int XAxiDma_Selftest(XAxiDma * InstancePtr);
+    void DisableInterruptsAll(XAxiDma * InstancePtr);
+    """)
+    LIB_SEARCH_PATH = os.path.dirname(os.path.realpath(__file__))
+    if CPU_ARCH_IS_SUPPORTED:
+        libdma = ffi.dlopen(LIB_SEARCH_PATH + "/libdma.so")
+    else:
+        warnings.warn("Pynq does not support the CPU Architecture: {}"
+                      .format(CPU_ARCH), ResourceWarning)
+        
+    DMA_TO_DEV = 0
+    DMA_FROM_DEV = 1
+    DMA_BIDIRECTIONAL = 3
+    DMA_TRANSFER_LIMIT_BYTES = 8388607
+
+    DeviceId = 0
+    DefaultConfig = {
+        'DeviceId': 0,
+        'BaseAddr': ffi.cast("uint32_t *", 0x00000000),
+        'HasStsCntrlStrm': 0,
+        'HasMm2S': 0,
+        'HasMm2SDRE': 0,
+        'Mm2SDataWidth': 32,
+        'HasS2Mm': 1,
+        'HasS2MmDRE': 0,
+        'S2MmDataWidth': 64,
+        'HasSg': 0,
+        'Mm2sNumChannels': 1,
+        'S2MmNumChannels': 1,
+        'Mm2SBurstSize': 16,
+        'S2MmBurstSize': 64,
+        'MicroDmaMode': 0,
+        'AddrWidth': 32
+    }
+
+    memapi = cffi.FFI()
+
+    memapi.cdef("""
+    static uint32_t xlnkBufCnt = 0;
+    uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
+    uint32_t cma_munmap(void *buf, uint32_t len);
+    void *cma_alloc(uint32_t len, uint32_t cacheable);
+    uint32_t cma_get_phy_addr(void *buf);
+    void cma_free(void *buf);
+    uint32_t cma_pages_available();
+    """)
+
+    if CPU_ARCH_IS_SUPPORTED:
+        libxlnk = memapi.dlopen("/usr/lib/libsds_lib.so")
+    else:
+        warnings.warn("Pynq does not support the CPU Architecture: {}"
+                      .format(CPU_ARCH), ResourceWarning)
 
     def __init__(self, address, direction=DMA_FROM_DEV, attr_dict=None):
         """Initializes a new DMA object.
@@ -236,7 +251,7 @@ class LegacyDMA:
 
         The keys in `attr_dict` should exactly match the ones used in default
         config. All the keys are not required. The default configuration is
-        defined in dma.DefaultConfig dict. Users can reinitialize the DMA
+        defined in self.DefaultConfig dict. Users can reinitialize the DMA
         with new configuratiuon after creating the object.
 
         Parameters
@@ -253,16 +268,16 @@ class LegacyDMA:
         self.direction = direction
         self.bufLength = None
         self.phyAddress = address
-        self.DMAengine = ffi.new("XAxiDma *")
-        self.DMAinstance = ffi.new("XAxiDma_Config *")
+        self.DMAengine = self.ffi.new("XAxiDma *")
+        self.DMAinstance = self.ffi.new("XAxiDma_Config *")
         self.Configuration = {}
         self._gen_config(address, direction, attr_dict)
 
-        status = libdma.XAxiDma_CfgInitialize(self.DMAengine, self.DMAinstance)
+        status = self.libdma.XAxiDma_CfgInitialize(self.DMAengine, self.DMAinstance)
         if status != 0:
             raise RuntimeError("Failed to initialize DMA!")
-        libdma.XAxiDma_Reset(self.DMAengine)
-        libdma.DisableInterruptsAll(self.DMAengine)
+        self.libdma.XAxiDma_Reset(self.DMAengine)
+        self.libdma.DisableInterruptsAll(self.DMAengine)
 
     def _gen_config(self, address, direction, attr_dict):
         """Build configuration and map memory.
@@ -271,14 +286,12 @@ class LegacyDMA:
         should not be called by user.
 
         """
-        global DefaultConfig
-        global DeviceId
-        for key in DefaultConfig.keys():
-            self.DMAinstance.__setattr__(key, DefaultConfig[key])
-        if direction == DMA_TO_DEV:
+        for key in self.DefaultConfig.keys():
+            self.DMAinstance.__setattr__(key, self.DefaultConfig[key])
+        if direction == self.DMA_TO_DEV:
             self.DMAinstance.HasS2Mm = 0
             self.DMAinstance.HasMm2S = 1
-        elif direction == DMA_BIDIRECTIONAL:
+        elif direction == self.DMA_BIDIRECTIONAL:
             self.DMAinstance.HasS2Mm = 1
             self.DMAinstance.HasMm2S = 1
         self._bufPtr = None
@@ -290,14 +303,14 @@ class LegacyDMA:
             else:
                 print("Warning: Expecting 3rd Arg to be a dict.")
 
-        virt = libxlnk.cma_mmap(address, 0x10000)
+        virt = self.libxlnk.cma_mmap(address, 0x10000)
         if virt == -1:
             raise RuntimeError("Memory map of driver failed.")
-        self.DMAinstance.BaseAddr = ffi.cast("uint32_t *", virt)
-        self.DMAinstance.DeviceId = DeviceId
-        DeviceId += 1
+        self.DMAinstance.BaseAddr = self.ffi.cast("uint32_t *", virt)
+        self.DMAinstance.DeviceId = self.DeviceId
+        self.DeviceId += 1
 
-        for key in DefaultConfig.keys():
+        for key in self.DefaultConfig.keys():
             self.Configuration[key] = self.DMAinstance.__getattribute__(key)
 
     def __del__(self):
@@ -314,9 +327,9 @@ class LegacyDMA:
         None
 
         """
-        if self.buf is not None and self.buf is not ffi.NULL:
+        if self.buf is not None and self.buf is not self.ffi.NULL:
             self.free_buf()
-        libdma.XAxiDma_Reset(self.DMAengine)
+        self.libdma.XAxiDma_Reset(self.DMAengine)
 
     def transfer(self, num_bytes=-1, direction=-1):
         """Transfer data using DMA (Non-blocking).
@@ -355,14 +368,14 @@ class LegacyDMA:
             direction = self.direction
         if num_bytes > self.bufLength:
             raise RuntimeError("Buffer size smaller than the transfer size")
-        if num_bytes > DMA_TRANSFER_LIMIT_BYTES:
+        if num_bytes > self.DMA_TRANSFER_LIMIT_BYTES:
             raise RuntimeError("DMA transfer size > {}".format(
-                DMA_TRANSFER_LIMIT_BYTES))
-        if direction not in [DMA_FROM_DEV, DMA_TO_DEV]:
+                self.DMA_TRANSFER_LIMIT_BYTES))
+        if direction not in [self.DMA_FROM_DEV, self.DMA_TO_DEV]:
             raise RuntimeError("Invalid direction for transfer.")
         self.direction = direction
         if self.buf is not None:
-            libdma.XAxiDma_SimpleTransfer(
+            self.libdma.XAxiDma_SimpleTransfer(
                 self.DMAengine,
                 self._bufPtr,
                 num_bytes,
@@ -403,14 +416,14 @@ class LegacyDMA:
 
         """
         if self.buf is None:
-            self.buf = libxlnk.cma_alloc(num_bytes, cacheable)
-            if self.buf == ffi.NULL:
+            self.buf = self.libxlnk.cma_alloc(num_bytes, cacheable)
+            if self.buf == self.ffi.NULL:
                 raise RuntimeError("Memory allocation failed.")
         else:
-            libxlnk.cma_free(self.buf)
-            self.buf = libxlnk.cma_alloc(num_bytes, cacheable)
-        bufPhyAddr = libxlnk.cma_get_phy_addr(self.buf)
-        self._bufPtr = ffi.cast("uint32_t *", bufPhyAddr)
+            self.libxlnk.cma_free(self.buf)
+            self.buf = self.libxlnk.cma_alloc(num_bytes, cacheable)
+        bufPhyAddr = self.libxlnk.cma_get_phy_addr(self.buf)
+        self._bufPtr = self.ffi.cast("uint32_t *", bufPhyAddr)
         self.bufLength = num_bytes
 
     def free_buf(self):
@@ -428,9 +441,9 @@ class LegacyDMA:
         None
 
         """
-        if self.buf is None or self.buf == ffi.NULL:
+        if self.buf is None or self.buf == self.ffi.NULL:
             return
-        libxlnk.cma_free(self.buf)
+        self.libxlnk.cma_free(self.buf)
 
     def wait(self, wait_timeout=10):
         """Block till DMA is busy or a timeout occurs.
@@ -452,7 +465,8 @@ class LegacyDMA:
         Error = "DMA wait timed out."
         with timeout(seconds=wait_timeout, error_message=Error):
             while True:
-                if libdma.XAxiDma_Busy(self.DMAengine, self.direction) == 0:
+                if self.libdma.XAxiDma_Busy(self.DMAengine,
+                                            self.direction) == 0:
                     break
 
     def get_buf(self, width=32):
@@ -474,9 +488,9 @@ class LegacyDMA:
         """
         if self.buf is not None:
             if width == 32:
-                return ffi.cast("unsigned int *", self.buf)
+                return self.ffi.cast("unsigned int *", self.buf)
             elif width == 64:
-                return ffi.cast("long long *", self.buf)
+                return self.ffi.cast("long long *", self.buf)
         else:
             raise RuntimeError("Buffer not created.")
 
@@ -505,7 +519,7 @@ class LegacyDMA:
             self.create_buf(totalsize, cacheable)
         if not self.buf:
             raise RuntimeError("Buffer not created or shape not specified")
-        buffer = ffi.buffer(self.buf, self.bufLength)
+        buffer = self.ffi.buffer(self.buf, self.bufLength)
         ret = np.frombuffer(buffer, dtype=dtype)
         ret.shape = shape
         return ret
@@ -519,7 +533,7 @@ class LegacyDMA:
 
         The keys in `attr_dict` should exactly match the ones used in default
         config. All the keys are not required. The default configuration is
-        defined in dma.DefaultConfig dict. Users can reinitialize the DMA
+        defined in self.DefaultConfig dict. Users can reinitialize the DMA
         with new configuratiuon after creating the object.
 
         Parameters

--- a/pynq/lib/intf/boolean_builder.py
+++ b/pynq/lib/intf/boolean_builder.py
@@ -189,7 +189,7 @@ class BooleanBuilder:
             output_pin_num = self.intf_spec[
                 'non_traceable_outputs'][self.output_pin]
         else:
-            raise ValueError(f"Invalid output pin {expr_out}.")
+            raise ValueError("Invalid output pin {}.".format(expr_out))
 
         # parse the used pins preserving the order
         non_unique_inputs = re.sub("\W+", " ", expr_in).strip().split(' ')
@@ -200,8 +200,8 @@ class BooleanBuilder:
 
         # need 5 inputs to CFGLUT - any unspecified inputs will be don't cares
         for i in range(len(input_pins_with_dontcares), 5):
-            expr_in = f'({expr_in} & X{i})|({expr_in} & ~X{i})'
-            input_pins_with_dontcares.append(f'X{i}')
+            expr_in = '({0} & X{1})|({0} & ~X{1})'.format(expr_in, i)
+            input_pins_with_dontcares.append('X{}'.format(i))
 
         # map to truth table
         p0, p1, p2, p3, p4 = map(exprvar, input_pins_with_dontcares)
@@ -209,7 +209,7 @@ class BooleanBuilder:
 
         # Use regular expression to match and replace whole word only
         for orig_name, p_name in zip(input_pins_with_dontcares,
-                                     [f'p{i}' for i in range(5)]):
+                                     ['p{}'.format(i) for i in range(5)]):
             expr_p = re.sub(r"\b{}\b".format(orig_name), p_name, expr_p)
 
         truth_table = expr2truthtable(eval(expr_p))
@@ -246,8 +246,8 @@ class BooleanBuilder:
                     input_pin_ix = self.intf_spec[
                         'non_traceable_inputs'][truth_table_inputs[i]]
                 else:
-                    raise ValueError(f"Invalid input pin "
-                                     f"{truth_table_inputs[i]}.")
+                    raise ValueError("Invalid input pin {}."
+                                     .format(truth_table_inputs[i]))
             else:
                 input_pin_ix = 0x1f
             mailbox_regs[output_pin_num * 2][msb:lsb] = input_pin_ix
@@ -269,7 +269,7 @@ class BooleanBuilder:
             ['analysis']],
             'foot': {'tick': 1},
             'head': {'tick': 1,
-                     'text': f'Boolean Logic Builder ({self.expr})'}}
+                     'text': 'Boolean Logic Builder ({})'.format(self.expr)}}
 
         # Append four inputs and one output to waveform view
         stimulus_traced = False

--- a/pynq/lib/intf/fsm_builder.py
+++ b/pynq/lib/intf/fsm_builder.py
@@ -78,7 +78,8 @@ def check_pins(fsm_spec, key, intf_spec):
     for i in fsm_spec[key]:
         if i[1] not in intf_spec['traceable_outputs']:
             raise ValueError(
-                f"{i[1]} not in output pin map - please check fsm_spec.")
+                "{} not in output pin map - please check fsm_spec."
+                .format(i[1]))
 
 
 def check_num_bits(num_bits, label, minimum=0, maximum=32):
@@ -99,8 +100,8 @@ def check_num_bits(num_bits, label, minimum=0, maximum=32):
 
     """
     if not minimum <= num_bits <= maximum:
-        raise ValueError(f'{num_bits} bits used for {label}, out of range: ' +
-                         f'[{minimum}, {maximum}].')
+        raise ValueError('{0} bits used for {1}, out of range: [{2}, {3}].'
+                         .format(num_bits, label, minimum, maximum))
 
 
 def check_moore(num_states, num_outputs):
@@ -118,8 +119,9 @@ def check_moore(num_states, num_outputs):
 
     """
     if num_states < num_outputs:
-        raise ValueError(f"Specified FSM is not Moore: " +
-                         f"{num_states} states but {num_outputs} outputs.")
+        raise ValueError("Specified FSM is not Moore: "
+                         "{} states but {} outputs."
+                         .format(num_states, num_outputs))
 
 
 def check_duplicate(fsm_spec, key):
@@ -591,8 +593,9 @@ class FSMBuilder:
         for index, row in enumerate(transitions_copy2):
             input_list = list(row[0])
             if len(input_list) != self.num_input_bits:
-                raise ValueError(f'{self.num_input_bits} input bits required '
-                                 f'for each transition.')
+                raise ValueError('{} input bits required '
+                                 'for each transition.'
+                                 .format(self.num_input_bits))
             wildcard = '-'
             if wildcard in input_list:
                 zero_list, one_list = replace_wildcard(input_list)

--- a/pynq/lib/intf/intf.py
+++ b/pynq/lib/intf/intf.py
@@ -260,7 +260,8 @@ class Intf(PynqMicroblaze):
 
         """
         if name not in self.buffers:
-            raise ValueError(f"No such buffer {name} allocated previously.")
+            raise ValueError("No such buffer {} allocated previously."
+                             .format(name))
         buffer = self.buffers[name]
         buf_temp = self.buf_manager.cma_get_buffer(buffer,
                                                    num_bytes)
@@ -300,7 +301,8 @@ class Intf(PynqMicroblaze):
 
         """
         if name not in self.buffers:
-            raise ValueError(f"No such buffer {name} allocated previously.")
+            raise ValueError("No such buffer {} allocated previously."
+                             .format(name))
         return self.buf_manager.cma_get_phy_addr(self.buffers[name])
 
     def reset_buffers(self):

--- a/pynq/lib/intf/pattern_builder.py
+++ b/pynq/lib/intf/pattern_builder.py
@@ -407,8 +407,8 @@ class PatternBuilder:
                 max_wave_length = len(wave)
 
         if not 1 <= max_wave_length <= MAX_NUM_PATTERN_SAMPLES:
-            raise ValueError(f"Waves should have 1 - "
-                             f"{MAX_NUM_PATTERN_SAMPLES} samples.")
+            raise ValueError("Waves should have 1 - "
+                             "{} samples.".format(MAX_NUM_PATTERN_SAMPLES))
         return name_of_longest_wave, max_wave_length
 
     def _make_same_wave_length(self):
@@ -432,5 +432,7 @@ class PatternBuilder:
             len_diff = self._max_wave_length - len(wave)
             if len_diff > 0:
                 self.stimulus_waves[index] = wave + wave[-1] * len_diff
-                print(f"WaveLane {self.stimulus_names[index]} extended to " +
-                      f"{self._max_wave_length} tokens.")
+                print("WaveLane {0} extended to {1} tokens."
+                      .format(self.stimulus_names[index], 
+                              self._max_wave_length))
+

--- a/pynq/lib/intf/tests/test_all_builders.py
+++ b/pynq/lib/intf/tests/test_all_builders.py
@@ -102,7 +102,8 @@ def test_all_builders():
                                 ['00', 'S3', 'S0', '1'],
                                 ['01', 'S3', 'S2', '1'],
                                 ['1-', '*', 'S0', '']]}
-    print(f"\nConnect {rst} to GND, and {direction} to VCC.")
+    print("\nConnect {} to GND, and {} to VCC."
+          .format(rst, direction))
     input("Hit enter after done ...")
     fsm = FSMBuilder(microblaze_intf, fsm_spec,
                      use_analyzer=True,
@@ -120,8 +121,8 @@ def test_all_builders():
     for i in range(3, 7):
         wavelane1 = dict()
         wavelane2 = dict()
-        wavelane1['name'] = f'clk{i}'
-        wavelane2['name'] = f'clk{i}'
+        wavelane1['name'] = 'clk{}'.format(i)
+        wavelane2['name'] = 'clk{}'.format(i)
         wavelane1['pin'] = all_pins[i]
         wavelane2['pin'] = all_pins[i]
         loopback1['signal'][-1].append(wavelane2)
@@ -152,8 +153,8 @@ def test_all_builders():
         list(PYNQZ1_DIO_SPECIFICATION['non_traceable_outputs'].keys())[0] +
         '=' + ('|'.join(in_pins)))
 
-    print(f'Connect randomly {in_pins} to VCC or GND.')
-    input(f'Hit enter after done ...')
+    print('Connect randomly {} to VCC or GND.'.format(in_pins))
+    input('Hit enter after done ...')
     bgs = [BooleanBuilder(microblaze_intf, expr=expr,
                           use_analyzer=True,
                           num_analyzer_samples=num_samples) for expr in fx]
@@ -231,7 +232,7 @@ def test_all_builders():
     expr = re.sub(r"\b{}\b".format(wavelane['name']),
                   str_replace, expr)
     expr = expr.replace('=', '==')
-    assert eval(expr), f"Boolean builder fails for {fx[0]}."
+    assert eval(expr), "Boolean builder fails for {}.".format(fx[0])
 
     for bg in bgs:
         bg.stop()

--- a/pynq/lib/intf/tests/test_boolean_builder.py
+++ b/pynq/lib/intf/tests/test_boolean_builder.py
@@ -80,7 +80,7 @@ def test_bool_builder():
     ol.download()
 
     # Test 1: manual test
-    input(f'\nDisconnect all the pins. Hit enter after done ...')
+    input('\nDisconnect all the pins. Hit enter after done ...')
     pin_dict = PYNQZ1_DIO_SPECIFICATION['traceable_outputs']
     first_6_pins = [k for k in list(pin_dict.keys())[:6]]
     out_pin = first_6_pins[5]
@@ -90,11 +90,11 @@ def test_bool_builder():
     bool_builder.arm()
     bool_builder.start()
     bool_builder.show_waveform()
-    print(f'Connect all of {in_pins} to GND ...')
-    assert user_answer_yes(f"{out_pin} outputs logic low?"), \
+    print('Connect all of {} to GND ...'.format(in_pins))
+    assert user_answer_yes("{} outputs logic low?".format(out_pin)), \
         "Boolean configurator fails to show logic low."
-    print(f'Connect any of {in_pins} to VCC ...')
-    assert user_answer_yes(f"{out_pin} outputs logic high?"), \
+    print('Connect any of {} to VCC ...'.format(in_pins))
+    assert user_answer_yes("{} outputs logic high?".format(out_pin)), \
         "Boolean configurator fails to show logic high."
 
     bool_builder0 = BooleanBuilder(if_id, expr=or_expr, use_analyzer=False)
@@ -118,8 +118,8 @@ def test_bool_builder():
     for i in range(5):
         fx.append(out_pins[i] + '=' + ('&'.join(sample(in_pins, i+1))))
 
-    print(f'Connect randomly {in_pins} to VCC or GND.')
-    input(f'Hit enter after done ...')
+    print('Connect randomly {} to VCC or GND.'.format(in_pins))
+    input('Hit enter after done ...')
     bgs = [BooleanBuilder(microblaze_intf, expr=fx[i]) for i in range(5)]
 
     for i in range(5):
@@ -149,7 +149,7 @@ def test_bool_builder():
         expr = re.sub(r"\b{}\b".format(wavelane['name']),
                       str_replace, expr)
         expr = expr.replace('=', '==')
-        assert eval(expr), f"Boolean builder fails for {fx[i]}."
+        assert eval(expr), "Boolean builder fails for {}.".format(fx[i])
 
     for bg in bgs:
         bg.stop()
@@ -203,8 +203,9 @@ def test_bool_builder():
     microblaze_intf = Intf(if_id)
     bgs = [BooleanBuilder(microblaze_intf, expr=expr) for expr in fx]
     for voltage in ['VCC', 'GND']:
-        print(f'Disconnect all the pins. Connect only {in_pin} to {voltage}.')
-        input(f'Press enter when done ...')
+        print('Disconnect all the pins. Connect only {} to {}.'
+              .format(in_pin, voltage))
+        input('Press enter when done ...')
         for i in range(num_bgs):
             bgs[i].arm()
         microblaze_intf.start()
@@ -236,7 +237,7 @@ def test_bool_builder():
                           str_replace, expr)
 
             expr = expr.replace('=', '==')
-            assert eval(expr), f"Boolean builder fails for {fx[i]}."
+            assert eval(expr), "Boolean builder fails for {}.".format(fx[i])
 
     for bg in bgs:
         bg.stop()

--- a/pynq/lib/intf/tests/test_fsm_builder.py
+++ b/pynq/lib/intf/tests/test_fsm_builder.py
@@ -132,7 +132,8 @@ def test_fsm_builder():
                        use_analyzer=True,
                        num_analyzer_samples=max_num_samples)
 
-    print(f"\nConnect {rst} to GND, and {direction} to VCC.")
+    print("\nConnect {} to GND, and {} to VCC.".format(rst, direction))
+          
     input("Hit enter after done ...")
 
     fsm_0.config(frequency_mhz=10)
@@ -186,7 +187,8 @@ def test_fsm_builder():
     assert matched, 'Analysis not matching the generated pattern.'
 
     # Test 2: running at 10MHz
-    print(f"Connect both {rst} and {direction} to GND.")
+    print("Connect both {} and {} to GND.".format(rst, direction))
+    
     input("Hit enter after done ...")
     fsm_1 = FSMBuilder(if_id, fsm_spec,
                        use_analyzer=True,
@@ -310,8 +312,8 @@ def test_fsm_builder():
         if fsm_0:
             fsm_0.intf.reset_buffers()
             del fsm_0
-    assert exception_raised, f'Should raise exception for less than ' \
-                             f'{FSM_MIN_NUM_STATES} states.'
+    assert exception_raised, 'Should raise exception for less than ' \
+                             '{} states.'.format(FSM_MIN_NUM_STATES)
 
     # Test 4: test more than the maximum number of states
     exception_raised = False
@@ -322,10 +324,10 @@ def test_fsm_builder():
                           'states': [],
                           'transitions': [['1', '*', 'S0', '']]}
         for i in range(FSM_MAX_NUM_STATES+1):
-            current_state = f'S{i}'
-            next_state = f'S{(i+1)%(FSM_MAX_NUM_STATES+1)}'
+            current_state = 'S{}'.format(i)
+            next_state = 'S{}'.format((i+1)%(FSM_MAX_NUM_STATES+1))
             fsm_spec_state['states'].append(current_state)
-            output_pattern = f'{randint(0,1)}'
+            output_pattern = '{}'.format(randint(0,1))
             transition = ['0', current_state, next_state, output_pattern]
             fsm_spec_state['transitions'].append(transition)
         fsm_0 = FSMBuilder(if_id, fsm_spec_state,
@@ -342,14 +344,15 @@ def test_fsm_builder():
         if fsm_0:
             fsm_0.intf.reset_buffers()
             del fsm_0
-    assert exception_raised, f'Should raise exception for more than ' \
-                             f'{FSM_MAX_NUM_STATES} states.'
+    assert exception_raised, 'Should raise exception for more than ' \
+                             '{} states.'.format(FSM_MAX_NUM_STATES)
 
     # Test 5: test two or maximum number of states
     input_pin = list(pin_dict.keys())[0]
     output_pin = list(pin_dict.keys())[1]
 
-    print(f"Connect {input_pin} to GND, and disconnect other pins.")
+    print("Connect {} to GND, and disconnect "
+          "other pins.".format(input_pin))
     input("Hit enter after done ...")
 
     for num_states in [2, FSM_MAX_NUM_STATES]:
@@ -359,10 +362,10 @@ def test_fsm_builder():
                           'transitions': [['1', '*', 'S0', '']]}
         test_pattern = []
         for i in range(num_states):
-            current_state = f'S{i}'
-            next_state = f'S{(i+1)% num_states}'
+            current_state = 'S{}'.format(i)
+            next_state = 'S{}'.format((i+1)% num_states)
             fsm_spec_state['states'].append(current_state)
-            output_pattern = f'{randint(0,1)}'
+            output_pattern = '{}'.format(randint(0,1))
             transition = ['0', current_state, next_state, output_pattern]
             fsm_spec_state['transitions'].append(transition)
             test_pattern.append(int(output_pattern))
@@ -406,8 +409,8 @@ def test_fsm_builder():
     input_pins = all_pins[:FSM_MAX_INPUT_BITS]
     output_pins = all_pins[FSM_MAX_INPUT_BITS:]
 
-    print(f"Connect {input_pins} to GND.")
-    print(f"Disconnect all other pins.")
+    print("Connect {} to GND.".format(input_pins))
+    print("Disconnect all other pins.")
     input("Hit enter after done ...")
     fsm_spec_inout = {'inputs': [],
                       'outputs': [],
@@ -417,20 +420,22 @@ def test_fsm_builder():
     num_states = 2**(FSM_MAX_STATE_INPUT_BITS - FSM_MAX_INPUT_BITS)
     # prepare the input pins
     for i in range(len(input_pins)):
-        fsm_spec_inout['inputs'].append((f'input{i}', input_pins[i]))
+        fsm_spec_inout['inputs'].append(('input{}'.format(i),
+                                         input_pins[i]))
 
     # prepare the output pins
     for i in range(len(output_pins)):
-        fsm_spec_inout['outputs'].append((f'output{i}', output_pins[i]))
+        fsm_spec_inout['outputs'].append(('output{}'.format(i),
+                                          output_pins[i]))
 
     # prepare the states and transitions
     for i in range(num_states):
-        current_state = f'S{i}'
-        next_state = f'S{(i+1)% num_states}'
+        current_state = 'S{}'.format(i)
+        next_state = 'S{}'.format((i+1)% num_states)
         fsm_spec_inout['states'].append(current_state)
         output_pattern = ''
         for test_lane in test_lanes:
-            random_1bit = f'{randint(0,1)}'
+            random_1bit = '{}'.format(randint(0,1))
             output_pattern += random_1bit
             test_lane += random_1bit
         transition = ['0'*len(input_pins), current_state, next_state,
@@ -458,7 +463,7 @@ def test_fsm_builder():
         if wavegroup and wavegroup[0] == 'analysis':
             for wavelane in wavegroup[1:]:
                 for j in range(len(output_pins)):
-                    if wavelane['name'] == f'output{j}':
+                    if wavelane['name'] == 'output{}'.format(j):
                         test_strings[j] = wavelane['wave']
                         test_arrays[j] = np.array(bitstring_to_int(
                                         wave_to_bitstring(test_strings[j])))
@@ -479,7 +484,7 @@ def test_fsm_builder():
             for i in range(1, len(output_pins)):
                 assert np.array_equal(candidate_arrays[i][1:],
                                       test_arrays[i][1:]), \
-                    f'output{i} not synchronized with other outputs.'
+                    'output{} not synchronized with other outputs.'.format(i)
             matched = True
             break
     assert matched, 'Analysis not matching the generated pattern.'
@@ -492,7 +497,7 @@ def test_fsm_builder():
     input_pin = all_pins[0]
     output_pins = all_pins[1:]
 
-    print(f"Disconnect all the pins.")
+    print("Disconnect all the pins.")
     input("Hit enter after done ...")
     fsm_spec_inout = {'inputs': [],
                       'outputs': [],
@@ -501,20 +506,21 @@ def test_fsm_builder():
     test_lanes = [[] for _ in range(len(output_pins))]
     num_states = 2 ** FSM_MAX_STATE_BITS
     # prepare the input pins
-    fsm_spec_inout['inputs'].append((f'input0', input_pin))
+    fsm_spec_inout['inputs'].append(('input0', input_pin))
 
     # prepare the output pins
     for i in range(len(output_pins)):
-        fsm_spec_inout['outputs'].append((f'output{i}', output_pins[i]))
+        fsm_spec_inout['outputs'].append(('output{}'.format(i), 
+                                          output_pins[i]))
 
     # prepare the states and transitions
     for i in range(num_states):
-        current_state = f'S{i}'
-        next_state = f'S{(i+1)% num_states}'
+        current_state = 'S{}'.format(i)
+        next_state = 'S{}'.format((i+1)% num_states)
         fsm_spec_inout['states'].append(current_state)
         output_pattern = ''
         for test_lane in test_lanes:
-            random_1bit = f'{randint(0,1)}'
+            random_1bit = '{}'.format(randint(0,1))
             output_pattern += random_1bit
             test_lane += random_1bit
         transition = ['-', current_state, next_state, output_pattern]
@@ -542,7 +548,7 @@ def test_fsm_builder():
         if wavegroup and wavegroup[0] == 'analysis':
             for wavelane in wavegroup[1:]:
                 for j in range(len(output_pins)):
-                    if wavelane['name'] == f'output{j}':
+                    if wavelane['name'] == 'output{}'.format(j):
                         test_strings[j] = wavelane['wave']
                         test_arrays[j] = np.array(bitstring_to_int(
                             wave_to_bitstring(test_strings[j])))
@@ -560,7 +566,7 @@ def test_fsm_builder():
             for i in range(1, len(output_pins)):
                 assert np.array_equal(candidate_arrays[i][1:],
                                       test_arrays[i][1:]), \
-                    f'output{i} not synchronized with other outputs.'
+                    'output{} not synchronized with other outputs.'.format(i)
             matched = True
             break
     assert matched, 'Analysis not matching the generated pattern.'

--- a/pynq/lib/intf/tests/test_intf.py
+++ b/pynq/lib/intf/tests/test_intf.py
@@ -92,7 +92,8 @@ def test_intf():
     for index in range(10):
         data_read = intf.read(MAILBOX_OFFSET + 4 * index)
         assert data_write[index] == data_read, \
-            f'Mailbox location {index} read {data_read} != write {data_write}.'
+            'Mailbox location {0} read {1} != write {2}' \
+            .format(index, data_read, data_write)
 
     # Test the capability to allocate buffers
     num_samples = 100

--- a/pynq/lib/intf/tests/test_pattern_builder.py
+++ b/pynq/lib/intf/tests/test_pattern_builder.py
@@ -76,7 +76,7 @@ def test_pattern_builder():
     """
     ol = Overlay('interface.bit')
     ol.download()
-    print(f"\nDisconnect all the pins.")
+    print("\nDisconnect all the pins.")
     input("Hit enter after done ...")
 
     # Test 1
@@ -93,8 +93,8 @@ def test_pattern_builder():
     for i in range(interface_width):
         wavelane1 = dict()
         wavelane2 = dict()
-        wavelane1['name'] = f'clk{i}'
-        wavelane2['name'] = f'clk{i}'
+        wavelane1['name'] = 'clk{}'.format(i)
+        wavelane2['name'] = 'clk{}'.format(i)
         wavelane1['pin'] = all_pins[i]
         wavelane2['pin'] = all_pins[i]
         loopback1['signal'][-1].append(wavelane2)
@@ -167,8 +167,8 @@ def test_pattern_builder():
         for i in range(interface_width):
             wavelane1 = dict()
             wavelane2 = dict()
-            wavelane1['name'] = f'signal{i}'
-            wavelane2['name'] = f'signal{i}'
+            wavelane1['name'] = 'signal{}'.format(i)
+            wavelane2['name'] = 'signal{}'.format(i)
             wavelane1['pin'] = all_pins[i]
             wavelane2['pin'] = all_pins[i]
             loopback1['signal'][-1].append(wavelane2)
@@ -210,8 +210,8 @@ def test_pattern_builder():
         for i in range(interface_width):
             wavelane1 = dict()
             wavelane2 = dict()
-            wavelane1['name'] = f'signal{i}'
-            wavelane2['name'] = f'signal{i}'
+            wavelane1['name'] = 'signal{}'.format(i)
+            wavelane2['name'] = 'signal{}'.format(i)
             wavelane1['pin'] = all_pins[i]
             wavelane2['pin'] = all_pins[i]
             loopback1['signal'][-1].append(wavelane2)

--- a/pynq/lib/intf/tests/test_trace_analyzer.py
+++ b/pynq/lib/intf/tests/test_trace_analyzer.py
@@ -93,7 +93,8 @@ def test_trace_analyzer():
                 analyzer.intf.reset_buffers()
             del analyzer
         assert exception_raised, \
-            f'Should raise exception when capturing {num_samples} sample(s).'
+            'Should raise exception when capturing {} sample(s).' \
+            .format(num_samples)
 
     # Test 2: 1, 2, or MAX_NUM_TRACE_SAMPLES samples
     for num_samples in [1, 2, MAX_NUM_TRACE_SAMPLES]:
@@ -125,7 +126,8 @@ def test_trace_analyzer():
         analyzers[i].analyze()
         analyzers[i].stop(free_buffer=False)
         assert len(analyzers[i].samples) == num_samples[i], \
-            f'Analyzer {i} not getting correct number of samples.'
+            'Analyzer {} not getting correct number of samples.' \
+            .format(i)
     microblaze_intf.reset_buffers()
 
     ol.reset()

--- a/pynq/lib/intf/tests/test_waveform.py
+++ b/pynq/lib/intf/tests/test_waveform.py
@@ -61,8 +61,8 @@ def test_waveform():
     for i in range(interface_width):
         wavelane1 = dict()
         wavelane2 = dict()
-        wavelane1['name'] = f'clk{i}'
-        wavelane2['name'] = f'clk{i}'
+        wavelane1['name'] = 'clk{}'.format(i)
+        wavelane2['name'] = 'clk{}'.format(i)
         wavelane1['pin'] = all_pins[i]
         wavelane2['pin'] = all_pins[i]
         correct_data['signal'][-1].append(wavelane2)

--- a/pynq/lib/intf/trace_analyzer.py
+++ b/pynq/lib/intf/trace_analyzer.py
@@ -146,8 +146,8 @@ class TraceAnalyzer:
                 "Parameter intf_microblaze has to be intf.Intf or dict.")
 
         if not 1 <= num_samples <= MAX_NUM_TRACE_SAMPLES:
-            raise ValueError(f'Number of samples should be in '
-                             f'[1, {MAX_NUM_TRACE_SAMPLES}]')
+            raise ValueError('Number of samples should be in [1, {}]'
+                             .format(MAX_NUM_TRACE_SAMPLES))
 
         self.trace_spec = trace_spec
         self.num_samples = num_samples

--- a/pynq/lib/pmod/pmod_iic.py
+++ b/pynq/lib/pmod/pmod_iic.py
@@ -96,11 +96,11 @@ class Pmod_IIC(Pmod_DevMode):
             
         """
         if scl_pin not in range(PMOD_NUM_DIGITAL_PINS):
-            raise ValueError(f"Valid SCL pin numbers are 0 - "
-                             f"{PMOD_NUM_DIGITAL_PINS-1}.")
+            raise ValueError("Valid SCL pin numbers are 0 - {}."
+                             .format(PMOD_NUM_DIGITAL_PINS-1))
         if sda_pin not in range(PMOD_NUM_DIGITAL_PINS):
-            raise ValueError(f"Valid SDA pin numbers are 0 - "
-                             f"{PMOD_NUM_DIGITAL_PINS-1}.")
+            raise ValueError("Valid SDA pin numbers are 0 - {}."
+                             .format(PMOD_NUM_DIGITAL_PINS-1))
         
         switchconfig = []
         for i in range(PMOD_NUM_DIGITAL_PINS):

--- a/pynq/lib/pmod/pmod_io.py
+++ b/pynq/lib/pmod/pmod_io.py
@@ -80,8 +80,8 @@ class Pmod_IO(Pmod_DevMode):
             
         """
         if index not in range(PMOD_NUM_DIGITAL_PINS):
-            raise ValueError(f"Valid pin indexes are 0 - "
-                             f"{PMOD_NUM_DIGITAL_PINS-1}.")
+            raise ValueError("Valid pin indexes are 0 - {}."
+                             .format(PMOD_NUM_DIGITAL_PINS-1))
         if direction not in ['in', 'out']:
             raise ValueError("Direction can only be 'in', or 'out'.")
 

--- a/pynq/lib/pmod/pmod_led8.py
+++ b/pynq/lib/pmod/pmod_led8.py
@@ -72,8 +72,8 @@ class Pmod_LED8(Pmod_DevMode):
             
         """
         if index not in range(PMOD_NUM_DIGITAL_PINS):
-            raise ValueError(f"Valid pin indexes are 0 - "
-                             f"{PMOD_NUM_DIGITAL_PINS-1}.")
+            raise ValueError("Valid pin indexes are 0 - {}."
+                             .format(PMOD_NUM_DIGITAL_PINS-1))
 
         super().__init__(mb_info, PMOD_SWCFG_DIOALL)
         self.index = index

--- a/pynq/lib/pmod/pmod_pwm.py
+++ b/pynq/lib/pmod/pmod_pwm.py
@@ -67,8 +67,8 @@ class Pmod_PWM(object):
             
         """
         if index not in range(PMOD_NUM_DIGITAL_PINS):
-            raise ValueError(f"Valid pin indexes are 0 - "
-                             f"{PMOD_NUM_DIGITAL_PINS-1}.")
+            raise ValueError("Valid pin indexes are 0 - {}."
+                             .format(PMOD_NUM_DIGITAL_PINS-1))
 
         self.microblaze = Pmod(mb_info, PMOD_PWM_PROGRAM)
         

--- a/pynq/lib/pmod/tests/test_pmod_cable.py
+++ b/pynq/lib/pmod/tests/test_pmod_cable.py
@@ -151,7 +151,8 @@ def test_pmod_cable():
         sleep(0.001)
         recv_data[7-i] = rx[7-i].read()
         assert send_data == recv_data,\
-            f'Sent {send_data} != received {recv_data} at Pin {7-i}.'
+            'Sent {} != received {} at Pin {}' \
+            .format(send_data, recv_data, 7-i)
 
     print('Generating tests for left shifting a \"0\"...')
     send_data = [1, 1, 1, 1, 1, 1, 1, 0]
@@ -163,7 +164,8 @@ def test_pmod_cable():
         sleep(0.001)
         recv_data[7-i] = rx[7-i].read()
         assert send_data == recv_data,\
-            f'Sent {send_data} != received {recv_data} at Pin {7-i}.'
+            'Sent {} != received {} at Pin {}' \
+            .format(send_data, recv_data, 7-i)
 
     print('Generating 100 random tests...')
     for _ in range(100):

--- a/pynq/lib/pynqmicroblaze.py
+++ b/pynq/lib/pynqmicroblaze.py
@@ -158,12 +158,13 @@ class PynqMicroblaze:
 
         # Check program path
         if not os.path.isfile(mb_program):
-            raise ValueError(f'{mb_program} does not exist.')
+            raise ValueError('{} does not exist.'
+                             .format(mb_program))
 
         # Get IP information
         ip_name = mb_info['ip_name']
         if ip_name not in ip_dict.keys():
-            raise ValueError(f"No such IP {ip_name}.")
+            raise ValueError("No such IP {}.".format(ip_name))
         addr_base = ip_dict[ip_name]['phys_addr']
         addr_range = ip_dict[ip_name]['addr_range']
         ip_state = ip_dict[ip_name]['state']
@@ -174,14 +175,16 @@ class PynqMicroblaze:
         # Get reset information
         rst_name = mb_info['rst_name']
         if rst_name not in gpio_dict.keys():
-            raise ValueError(f"No such reset pin {rst_name}.")
+            raise ValueError("No such reset pin {}."
+                             .format(rst_name))
         gpio_uix = gpio_dict[rst_name]['index']
 
         # Get interrupt pin information
         if 'intr_pin_name' in mb_info:
             intr_pin_name = mb_info['intr_pin_name']
             if intr_pin_name not in intr_dict.keys():
-                raise ValueError(f"No such interrupt pin {intr_pin_name}.")
+                raise ValueError("No such interrupt pin {}."
+                                 .format(intr_pin_name))
         else:
             intr_pin_name = None
 
@@ -189,7 +192,8 @@ class PynqMicroblaze:
         if 'intr_ack_name' in mb_info:
             intr_ack_name = mb_info['intr_ack_name']
             if intr_ack_name not in gpio_dict.keys():
-                raise ValueError(f"No such interrupt ACK {intr_ack_name}.")
+                raise ValueError("No such interrupt ACK {}."
+                                 .format(intr_ack_name))
             intr_ack_gpio = gpio_dict[intr_ack_name]['index']
         else:
             intr_ack_gpio = None
@@ -310,11 +314,11 @@ class MicroblazeHierarchy(DefaultHierarchy):
     """
     def __init__(self, description, mbtype="Unknown"):
         super().__init__(description)
-        hierarchy = description['fullpath']
-        self._mb_info = {'ip_name': f'{hierarchy}/mb_bram_ctrl',
-                         'rst_name': f'mb_{hierarchy}_reset',
-                         'intr_pin_name': f'{hierarchy}/dff_en_reset_0/q',
-                         'intr_ack_name': f'mb_{hierarchy}_intr_ack',
+        hier = description['fullpath']
+        self._mb_info = {'ip_name': '{}/mb_bram_ctrl'.format(hier),
+                         'rst_name': 'mb_{}_reset'.format(hier),
+                         'intr_pin_name': '{}/dff_en_reset_0/q'.format(hier),
+                         'intr_ack_name': 'mb_{}_intr_ack'.format(hier),
                          'mbtype': mbtype}
 
     def load(self, program, *args, **kwargs):

--- a/pynq/lib/video.py
+++ b/pynq/lib/video.py
@@ -85,8 +85,8 @@ class VideoMode:
             self.shape = (self.height, self.width, self.bytes_per_pixel)
 
     def __repr__(self):
-        return (f"VideoMode: width={self.width} "
-                f"height={self.height} bpp={self.bits_per_pixel}")
+        return ("VideoMode: width={} height={} bpp={}"
+                .format(self.width, self.height, self.bits_per_pixel))
 
 
 class HDMIInFrontend(DefaultHierarchy):
@@ -111,13 +111,13 @@ class HDMIInFrontend(DefaultHierarchy):
 
         """
         ip_dict = self.description
-        gpio_description = ip_dict['ip'][f'axi_gpio_hdmiin']
+        gpio_description = ip_dict['ip']['axi_gpio_hdmiin']
         gpio_dict = {
             'BASEADDR': gpio_description['phys_addr'],
             'INTERRUPT_PRESENT': 1,
             'IS_DUAL': 1,
         }
-        vtc_description = ip_dict['ip'][f'vtc_in']
+        vtc_description = ip_dict['ip']['vtc_in']
         vtc_capture_addr = vtc_description['phys_addr']
         self._capture = pynq.lib._video._capture(gpio_dict,
                                                  vtc_capture_addr,
@@ -188,8 +188,8 @@ class HDMIOutFrontend(DefaultHierarchy):
         """
         super().__init__(description)
         ip_dict = self.description['ip']
-        vtc_description = ip_dict[f'vtc_out']
-        clock_description = ip_dict[f'axi_dynclk']
+        vtc_description = ip_dict['vtc_out']
+        clock_description = ip_dict['axi_dynclk']
         vtc_capture_addr = vtc_description['phys_addr']
         clock_addr = clock_description['phys_addr']
         self._display = pynq.lib._video._display(vtc_capture_addr,
@@ -225,8 +225,8 @@ class HDMIOutFrontend(DefaultHierarchy):
         if resolution in _outputmodes:
             self._display.mode(_outputmodes[resolution])
         else:
-            raise ValueError(f"Invalid Output resolution "
-                             f"{value.width}x{value.height}")
+            raise ValueError("Invalid Output resolution {}x{}"
+                             .format(value.width, value.height))
 
 
 class _FrameCache:

--- a/pynq/lib/video.py
+++ b/pynq/lib/video.py
@@ -32,12 +32,18 @@ import contextlib
 import functools
 import numpy as np
 import time
+import warnings
 
 from pynq import DefaultIP
 from pynq import DefaultHierarchy
 from pynq import Xlnk
-import pynq.lib._video
+from pynq.ps import CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 
+if CPU_ARCH_IS_SUPPORTED:
+    import pynq.lib._video
+else:
+    warnings.warn("Pynq does not support the CPU Architecture: {}"
+                  .format(CPU_ARCH), ResourceWarning)       
 
 __author__ = "Giuseppe Natale, Yun Rock Qu, Peter Ogden"
 __copyright__ = "Copyright 2016, Xilinx"

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -193,4 +193,4 @@ class MMIO:
 
         """
         if self.debug:
-            print('MMIO Debug: {0}'.format(s.format(*args)))
+            print('MMIO Debug: {}'.format(s.format(*args)))

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -31,9 +31,10 @@ import collections
 import importlib.util
 import os
 import re
+import warnings
 from copy import deepcopy
 from .mmio import MMIO
-from .ps import Clocks
+from .ps import Clocks, CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 from .pl import PL
 from .pl import Bitstream
 from .pl import _TCL
@@ -262,11 +263,6 @@ class DefaultOverlay(PL):
 
         An overlay instantiates a bitstream object as a member initially.
 
-        Note
-        ----
-        This class requires a Vivado '.tcl' file to be next to bitstream file
-        with same name (e.g. base.bit and base.tcl).
-
         Parameters
         ----------
         bitfile_name : str
@@ -275,7 +271,20 @@ class DefaultOverlay(PL):
             Whether the overlay should be downloaded. If None then the
             overlay will be downloaded if it isn't already loaded.
 
+        Note
+        ----
+        This class requires a Vivado '.tcl' file to be next to bitstream file
+        with same name (e.g. base.bit and base.tcl).
+
+        If this method is called on an unsupported architecture it will warn and
+        return without initialization.
+
         """
+        if not CPU_ARCH_IS_SUPPORTED:
+            warnings.warn("Pynq does not support the CPU Architecture: {}"
+                          .format(CPU_ARCH), ResourceWarning)
+            return
+
         super().__init__()
 
         # Set the bitstream

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -55,7 +55,7 @@ def _subhierarchy(description, hierarchy):
     """
     return {k.partition('/')[2]: v
             for k, v in description.items()
-            if k.startswith(f'{hierarchy}/')}
+            if k.startswith('{}/'.format(hierarchy))}
 
 
 def _hierarchical_description(description, path):
@@ -87,19 +87,19 @@ def _hierarchical_description(description, path):
     ipnames = {k for k, v in description.items() if k.count('/') ==
                0 and 'type' in v}
     if path:
-        prefix = f'{path}/'
+        prefix = '{}/'.format(path)
     else:
         prefix = ''
 
     hierarchy_dict = dict()
     for h in hierarchies:
         hierarchy_dict[h] = _hierarchical_description(
-            _subhierarchy(description, h), f'{prefix}{h}')
+            _subhierarchy(description, h), '{}{}'.format(prefix, h))
 
     ip_dict = dict()
     for ip in ipnames:
         ipdescription = deepcopy(description[ip])
-        ipdescription['fullpath'] = f'{prefix}{ip}'
+        ipdescription['fullpath'] = '{}{}'.format(prefix, ip)
         ipdescription['interrupts'] = dict()
         ipdescription['gpio'] = dict()
         ip_dict[ip] = ipdescription
@@ -257,7 +257,7 @@ class DefaultOverlay(PL):
         {str: {'controller' : str, 'index' : int}}.
 
     """
-
+        
     def __init__(self, bitfile_name, download):
         """Return a new Overlay object.
 
@@ -527,7 +527,7 @@ class _IPMap:
             return gpio
         else:
             raise AttributeError(
-                f"Could not find IP or hierarchy {key} in overlay")
+                "Could not find IP or hierarchy {} in overlay".format(key))
 
     def _keys(self):
         """The set of keys that can be accessed through the IP map
@@ -556,7 +556,8 @@ def _classname(class_):
     stored in the `_classaliases` dictionaries.
 
     """
-    rawname = f"{class_.__module__}.{class_.__name__}"
+    rawname = "{}.{}".format(class_.__module__, class_.__name__)
+                                            
     if rawname in _classaliases:
         return _class_aliases[rawname]
     else:
@@ -582,15 +583,17 @@ def _build_docstring(description, name, type_):
 
     """
     lines = []
-    lines.append(f"Default documentation for {type_} {name}. The following")
-    lines.append(f"attributes are available on this {type_}:")
+    lines.append("Default documentation for {} {}. The following"
+                 .format(type_, name))
+    lines.append("attributes are available on this {}:".format(type_))
     lines.append("")
 
     lines.append("IP Blocks")
     lines.append("----------")
     if description['ip']:
         for ip, details in description['ip'].items():
-            lines.append(f"{ip : <20} : {_classname(details['driver'])}")
+            lines.append("{0 : <20} : {1}"
+                         .format(ip, _classname(details['driver'])))
     else:
         lines.append("None")
     lines.append("")
@@ -599,8 +602,8 @@ def _build_docstring(description, name, type_):
     lines.append("-----------")
     if description['hierarchies']:
         for hierarchy, details in description['hierarchies'].items():
-            lines.append(
-                f"{hierarchy : <20} : {_classname(details['driver'])}")
+            lines.append("{0 : <20} : {1}"
+                         .format(hierarchy, _classname(details['driver'])))
     else:
         lines.append("None")
     lines.append("")
@@ -609,7 +612,8 @@ def _build_docstring(description, name, type_):
     lines.append("----------")
     if description['interrupts']:
         for interrupt in description['interrupts'].keys():
-            lines.append(f"{interrupt : <20} : pynq.interrupt.Interrupt")
+            lines.append("{0 : <20} : pynq.interrupt.Interrupt"
+                         .format(interrupt))
     else:
         lines.append("None")
     lines.append("")
@@ -618,7 +622,7 @@ def _build_docstring(description, name, type_):
     lines.append("------------")
     if description['gpio']:
         for gpio in description['gpio'].keys():
-            lines.append(f"{gpio : <20} : pynq.gpio.GPIO")
+            lines.append("{0 : <20} : pynq.gpio.GPIO".format(gpio))
     else:
         lines.append("None")
     lines.append("")

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -157,7 +157,7 @@ class _TCL:
         family_gpio_dict = {"xc7z": "GPIO_O",
                             "xczu": "emio_gpio_o"}
         hier_use_pat = "create_hier_cell"
-        hier_proc_def_pat = f"proc {hier_use_pat}"
+        hier_proc_def_pat = "proc {}".format(hier_use_pat)
         hier_def_regex = "create_hier_cell_(?P<name>[^ ]*)"
         hier_proc_end_pat = "}\n"
         hier_use_regex = ("create_hier_cell_(?P<hier_name>[^ ]*) ([^ ].*) " +
@@ -348,7 +348,7 @@ class _TCL:
                 gpio_names.append(m.group(1))
         for n, i in gpio_dict.items():
             if n in gpio_names:
-                output_net = self.pins[f'{n}/Dout']
+                output_net = self.pins['{}/Dout'.format(n)]
                 output_pins = self.nets[output_net]
                 self.gpio_dict[n] = {'index': i, 'state': None,
                                      'pins': output_pins}
@@ -683,8 +683,8 @@ class PL(metaclass=PLMeta):
         All the addressable IPs from PS7. Key is the name of the IP; value is
         a dictionary mapping the physical address, address range, IP type, 
         configuration dictionary, and the state associated with that IP:
-        {str: {'phys_addr' : int, 'addr_range' : int, 
-               'type' : str, 'config' : dict, 'state' : str}}.
+        {str: {'phys_addr' : int, 'addr_range' : int, \ 
+        'type' : str, 'config' : dict, 'state' : str}}.
     gpio_dict : dict
         All the GPIO pins controlled by PS7. Key is the name of the GPIO pin;
         value is a dictionary mapping user index (starting from 0),

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -31,12 +31,13 @@ import os
 import re
 import mmap
 import math
+import warnings
 from copy import deepcopy
 from datetime import datetime
 from multiprocessing.connection import Listener
 from multiprocessing.connection import Client
 from .mmio import MMIO
-from .ps import Clocks
+from .ps import Clocks, CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 
 __author__ = "Yun Rock Qu"
 __copyright__ = "Copyright 2016, Xilinx"
@@ -123,10 +124,16 @@ class _TCL:
             The tcl filename to parse. This is opened directly so should be
             fully qualified
 
+        Note
+        ----
+        If this method is called on an unsupported architecture it will warn and
+        return without initialization
+
         """
+        
         if not isinstance(tcl_name, str):
             raise TypeError("tcl_name has to be a string")
-
+        
         # Initialize result variables
         self.intc_names = []
         self.interrupt_controllers = {}
@@ -383,21 +390,29 @@ class PLMeta(type):
     This is not a class for users. Hence there is no attribute or method
     exposed to users.
 
+    Note
+    ----
+    If this metaclass is parsed on an unsupported architecture it will issue
+    a warning and leave class variables undefined
+
     """
     _bitfile_name = BS_BOOT
     _timestamp = ""
-
-    _tcl = _TCL(TCL_BOOT)
-    _ip_dict = _tcl.ip_dict
-    _gpio_dict = _tcl.gpio_dict
-    _interrupt_controllers = _tcl.interrupt_controllers
-    _interrupt_pins = _tcl.interrupt_pins
-    _status = 1
-
-    _server = None
-    _host = None
-    _remote = None
-
+    
+    if CPU_ARCH_IS_SUPPORTED:
+        _tcl = _TCL(TCL_BOOT)
+        _ip_dict = _tcl.ip_dict
+        _gpio_dict = _tcl.gpio_dict
+        _interrupt_controllers = _tcl.interrupt_controllers
+        _interrupt_pins = _tcl.interrupt_pins
+        _status = 1
+        _server = None
+        _host = None
+        _remote = None
+    else:
+        warnings.warn("Pynq does not support the CPU Architecture: {}"
+                     .format(CPU_ARCH), ResourceWarning)
+    
     @property
     def bitfile_name(cls):
         """The getter for the attribute `bitfile_name`.
@@ -407,7 +422,17 @@ class PLMeta(type):
         str
             The absolute path of the bitstream currently on PL.
 
+        Note
+        ----
+        If this method is called on an unsupported architecture it will warn 
+        and return an empty string
+
         """
+        if not CPU_ARCH_IS_SUPPORTED:
+            warnings.warn("Pynq does not support the CPU Architecture: {}"
+                          .format(CPU_ARCH), ResourceWarning)
+            return ""
+        
         cls.client_request()
         cls.server_update()
         return cls._bitfile_name
@@ -771,13 +796,16 @@ class Bitstream(PL):
 
         Note
         ----
-        The class variables held by the singleton PL will also be updated.
+        The class variables held by the singleton PL will also be updated. In
+        addition, if this method is called on an unsupported architecture it
+        will warn and return.
 
         Returns
         -------
         None
 
         """
+
         # Compose bitfile name, open bitfile
         with open(self.bitfile_name, 'rb') as f:
             buf = f.read()

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -28,6 +28,7 @@
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import os
 from .mmio import MMIO
 
 
@@ -35,6 +36,11 @@ __author__ = "Yun Rock Qu"
 __copyright__ = "Copyright 2017, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
+# Pynq Family Constants
+ZYNQ_ARCH = "armv7l"
+CPU_ARCH = os.uname().machine
+CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH]
+              
 # Clock constants
 SRC_CLK_MHZ = 50.0
 DEFAULT_CLK_MHZ = 100.0

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -29,6 +29,7 @@
 
 import numpy as np
 import os
+import warnings
 from .mmio import MMIO
 
 
@@ -139,6 +140,7 @@ class Register:
             The width of the register, e.g., 32 (default) or 64.
 
         """
+        
         self.address = address
         self.width = width
 
@@ -160,6 +162,7 @@ class Register:
             The integer index, or slice to access the register value.
 
         """
+        
         curr_val = int.from_bytes(self._buffer, byteorder='little')
         if isinstance(index, int):
             mask = 1 << index
@@ -208,6 +211,7 @@ class Register:
             The integer index, or slice to access the register value.
 
         """
+        
         curr_val = int.from_bytes(self._buffer, byteorder='little')
         if isinstance(index, int):
             if value != 0 and value != 1:
@@ -254,6 +258,7 @@ class Register:
         is a string in hex format.
 
         """
+
         curr_val = int.from_bytes(self._buffer, byteorder='little')
         return hex(curr_val)
 
@@ -264,21 +269,30 @@ class ClocksMeta(type):
     Since this is the meta class for all the clocks, no attributes or methods
     are exposed to users. Users should use the class `Clocks` instead.
 
-    """
-    arm_pll_reg = Register(SCLR_BASE_ADDRESS + ARM_PLL_DIV_OFFSET)
-    ddr_pll_reg = Register(SCLR_BASE_ADDRESS + DDR_PLL_DIV_OFFSET)
-    io_pll_reg = Register(SCLR_BASE_ADDRESS + IO_PLL_DIV_OFFSET)
-    arm_clk_reg = Register(SCLR_BASE_ADDRESS + ARM_CLK_REG_OFFSET)
-    fclk0_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[0])
-    fclk1_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[1])
-    fclk2_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[2])
-    fclk3_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[3])
+    Note
+    ----
+    If this class is parsed on an unsupported architecture it will issue
+    a warning and leave class variables undefined
 
-    arm_pll_fdiv = arm_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
-    ddr_pll_fdiv = ddr_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
-    io_pll_fdiv = io_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
-    arm_clk_sel = arm_clk_reg[ARM_CLK_SEL_MSB:ARM_CLK_SEL_LSB]
-    arm_clk_div = arm_clk_reg[ARM_CLK_DIV_MSB:ARM_CLK_DIV_LSB]
+    """
+    if CPU_ARCH_IS_SUPPORTED:
+        arm_pll_reg = Register(SCLR_BASE_ADDRESS + ARM_PLL_DIV_OFFSET)
+        ddr_pll_reg = Register(SCLR_BASE_ADDRESS + DDR_PLL_DIV_OFFSET)
+        io_pll_reg = Register(SCLR_BASE_ADDRESS + IO_PLL_DIV_OFFSET)
+        arm_clk_reg = Register(SCLR_BASE_ADDRESS + ARM_CLK_REG_OFFSET)
+        fclk0_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[0])
+        fclk1_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[1])
+        fclk2_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[2])
+        fclk3_reg = Register(SCLR_BASE_ADDRESS + CLK_CTRL_REG_OFFSET[3])
+        
+        arm_pll_fdiv = arm_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
+        ddr_pll_fdiv = ddr_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
+        io_pll_fdiv = io_pll_reg[PLL_DIV_MSB:PLL_DIV_LSB]
+        arm_clk_sel = arm_clk_reg[ARM_CLK_SEL_MSB:ARM_CLK_SEL_LSB]
+        arm_clk_div = arm_clk_reg[ARM_CLK_DIV_MSB:ARM_CLK_DIV_LSB]
+    else:
+        warnings.warn("Pynq does not support the CPU Architecture: {}"
+                      .format(CPU_ARCH), ResourceWarning)
 
     @property
     def cpu_mhz(cls):

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -182,11 +182,11 @@ class Register:
             else:
                 raise ValueError("Slicing step is not valid.")
             if start not in range(self.width):
-                raise ValueError(f"Slicing endpoint {start} is not in range 0"
-                                 f" - {self.width}.")
+                raise ValueError("Slicing endpoint {} is not in range 0".format(start),
+                                 " - {}.".format(self.width))
             if stop not in range(self.width):
-                raise ValueError(f"Slicing endpoint {stop} is not in range 0"
-                                 f" - {self.width}.")
+                raise ValueError("Slicing endpoint {stop} is not in range 0".format(stop),
+                                 " - {}.".format(self.width))
 
             if start >= stop:
                 mask = ((1 << (start - stop + 1)) - 1) << stop
@@ -233,11 +233,11 @@ class Register:
             else:
                 raise ValueError("Slicing step is not valid.")
             if start not in range(self.width):
-                raise ValueError(f"Slicing endpoint {start} is not in range 0"
-                                 f" - {self.width}.")
+                raise ValueError("Slicing endpoint {} is not in range 0".format(start),
+                                 " - {}.".format(self.width))
             if stop not in range(self.width):
-                raise ValueError(f"Slicing endpoint {stop} is not in range 0"
-                                 f" - {self.width}.")
+                raise ValueError("Slicing endpoint {} is not in range 0".format(stop),
+                                 " - {}.".format(self.width))
 
             if start >= stop:
                 mask = ((1 << (start - stop + 1)) - 1) << stop

--- a/pynq/tests/test_pl.py
+++ b/pynq/tests/test_pl.py
@@ -187,19 +187,19 @@ def test_overlay1():
 
     ol1.download()
     assert not ol1.bitstream.timestamp == '', \
-        f'Overlay 1 ({bitfile1}) has an empty timestamp.'
+        'Overlay 1 ({}) has an empty timestamp.'.format(bitfile1)
     assert ol1.is_loaded(), \
-        f'Overlay 1 ({bitfile1}) should be loaded.'
+        'Overlay 1 ({}) should be loaded.'.format(bitfile1)
     assert Clocks.cpu_mhz == cpu_mhz, \
         'CPU frequency should not be changed.'
     assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        f'FCLK0 frequency not correct after downloading {bitfile1}.'
+        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        f'FCLK1 frequency not correct after downloading {bitfile1}.'
+        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        f'FCLK2 frequency not correct after downloading {bitfile1}.'
+        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        f'FCLK3 frequency not correct after downloading {bitfile1}.'
+        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
 
 
 @pytest.mark.run(order=30)
@@ -216,19 +216,19 @@ def test_overlay2():
 
     ol2.download()
     assert not ol2.bitstream.timestamp == '', \
-        f'Overlay 2 ({bitfile1}) has an empty timestamp.'
+        'Overlay 2 ({}) has an empty timestamp.'.format(bitfile1)
     assert ol2.is_loaded(), \
-        f'Overlay 2 ({bitfile1}) should be loaded.'
+        'Overlay 2 ({}) should be loaded.'.format(bitfile1)
     assert Clocks.cpu_mhz == cpu_mhz, \
         'CPU frequency should not be changed.'
     assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        f'FCLK0 frequency not correct after downloading {bitfile1}.'
+        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        f'FCLK1 frequency not correct after downloading {bitfile1}.'
+        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        f'FCLK2 frequency not correct after downloading {bitfile1}.'
+        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        f'FCLK3 frequency not correct after downloading {bitfile1}.'
+        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
 
 
 @pytest.mark.run(order=39)
@@ -245,19 +245,19 @@ def test_overlay3():
 
     ol3.download()
     assert not ol3.bitstream.timestamp == '', \
-        f'Overlay 3 ({bitfile2}) has an empty timestamp.'
+        'Overlay 3 ({}) has an empty timestamp.'.format(bitfile2)
     assert ol3.is_loaded(), \
-        f'Overlay 3 ({bitfile2}) should be loaded.'
+        'Overlay 3 ({}) should be loaded.'.format(bitfile2)
     assert Clocks.cpu_mhz == cpu_mhz, \
         'CPU frequency should not be changed.'
     assert Clocks.fclk0_mhz == bitfile2_fclk0_mhz, \
-        f'FCLK0 frequency not correct after downloading {bitfile2}.'
+        'FCLK0 frequency not correct after downloading {}.'.format(bitfile2)
     assert Clocks.fclk1_mhz == bitfile2_fclk1_mhz, \
-        f'FCLK1 frequency not correct after downloading {bitfile2}.'
+        'FCLK1 frequency not correct after downloading {}.'.format(bitfile2)
     assert Clocks.fclk2_mhz == bitfile2_fclk2_mhz, \
-        f'FCLK2 frequency not correct after downloading {bitfile2}.'
+        'FCLK2 frequency not correct after downloading {}.'.format(bitfile2)
     assert Clocks.fclk3_mhz == bitfile2_fclk3_mhz, \
-        f'FCLK3 frequency not correct after downloading {bitfile2}.'
+        'FCLK3 frequency not correct after downloading {}.'.format(bitfile2)
 
 
 @pytest.mark.run(order=49)
@@ -274,19 +274,19 @@ def test_end():
 
     ol1.download()
     assert not ol1.bitstream.timestamp == '', \
-        f'Overlay 1 ({bitfile1}) has an empty timestamp.'
+        'Overlay 1 ({}) has an empty timestamp.'.format(bitfile1)
     assert ol1.is_loaded(), \
-        f'Overlay 1 ({bitfile1}) should be loaded.'
+        'Overlay 1 ({}) should be loaded.'.format(bitfile1)
     assert Clocks.cpu_mhz == cpu_mhz, \
         'CPU frequency should not be changed.'
     assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        f'FCLK0 frequency not correct after downloading {bitfile1}.'
+        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        f'FCLK1 frequency not correct after downloading {bitfile1}.'
+        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        f'FCLK2 frequency not correct after downloading {bitfile1}.'
+        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
     assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        f'FCLK3 frequency not correct after downloading {bitfile1}.'
+        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
 
     del ol1
     del ol2

--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -38,10 +38,9 @@ import cffi
 import resource
 import functools
 import numbers
+import warnings
 import numpy as np
-
-if os.getuid() != 0:
-    raise RuntimeError("Root permission needed by the library.")
+from .ps import CPU_ARCH_IS_SUPPORTED
 
 def sig_handler(signum, frame):
     print("Invalid Memory Access!")
@@ -62,7 +61,12 @@ uint32_t cma_pages_available();
 void _xlnk_reset();
 """)
 
-libxlnk = ffi.dlopen("/usr/lib/libsds_lib.so")
+if not CPU_ARCH_IS_SUPPORTED:
+    warnings.warn("Unsupported CPU Architecture")
+elif os.getuid() != 0:
+    raise RuntimeError("Root permission needed by the library.")
+else:
+    libxlnk = ffi.dlopen("/usr/lib/libsds_lib.so")    
 
 class CMABuffer(np.ndarray):
     def __del__(self):

--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -40,33 +40,13 @@ import functools
 import numbers
 import warnings
 import numpy as np
-from .ps import CPU_ARCH_IS_SUPPORTED
+from .ps import CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 
 def sig_handler(signum, frame):
     print("Invalid Memory Access!")
     Xlnk().xlnk_reset()
     sys.exit(127)
 signal.signal(signal.SIGSEGV, sig_handler)
-
-ffi = cffi.FFI()
-
-ffi.cdef("""
-static uint32_t xlnkBufCnt = 0;
-uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
-uint32_t cma_munmap(void *buf, uint32_t len);
-void *cma_alloc(uint32_t len, uint32_t cacheable);
-uint32_t cma_get_phy_addr(void *buf);
-void cma_free(void *buf);
-uint32_t cma_pages_available();
-void _xlnk_reset();
-""")
-
-if not CPU_ARCH_IS_SUPPORTED:
-    warnings.warn("Unsupported CPU Architecture")
-elif os.getuid() != 0:
-    raise RuntimeError("Root permission needed by the library.")
-else:
-    libxlnk = ffi.dlopen("/usr/lib/libsds_lib.so")    
 
 class CMABuffer(np.ndarray):
     def __del__(self):
@@ -95,8 +75,35 @@ class Xlnk:
     ----------
     bufmap : dict
         Mapping of allocated memory to the buffer sizes in bytes.
-        
+
+    ffi : cffi instance
+        Shared-object interface for the compiled CMA shared object
+
+    Note
+    ----
+    If this class is parsed on an unsupported architecture it will issue
+    a warning and leave the class variable libxlnk undefined
+
     """
+
+    ffi = cffi.FFI()
+
+    ffi.cdef("""
+    static uint32_t xlnkBufCnt = 0;
+    uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
+    uint32_t cma_munmap(void *buf, uint32_t len);
+    void *cma_alloc(uint32_t len, uint32_t cacheable);
+    uint32_t cma_get_phy_addr(void *buf);
+    void cma_free(void *buf);
+    uint32_t cma_pages_available();
+    void _xlnk_reset();
+    """)
+    if CPU_ARCH_IS_SUPPORTED:
+        libxlnk = ffi.dlopen("/usr/lib/libsds_lib.so")
+    else:
+        warnings.warn("Pynq does not support the CPU Architecture: {}"
+                      .format(CPU_ARCH), ResourceWarning)
+    
     def __init__(self):
         """Initialize new Xlnk object.
 
@@ -105,6 +112,9 @@ class Xlnk:
         None
 
         """
+        if os.getuid() != 0:
+            raise RuntimeError("Root permission needed by the library.")
+
         self.bufmap = {}
 
     def __del__(self):
@@ -118,7 +128,7 @@ class Xlnk:
 
         """
         for key in self.bufmap.keys():
-            libxlnk.cma_free(key)
+            self.libxlnk.cma_free(key)
     
     def __check_buftype(self, buf):
         """Internal method to check for a valid buffer.
@@ -187,12 +197,12 @@ class Xlnk:
             
         """
         if data_type != "void":
-            length = ffi.sizeof(data_type) * length
-        buf = libxlnk.cma_alloc(length, cacheable)
-        if buf == ffi.NULL:
+            length = self.ffi.sizeof(data_type) * length
+        buf = self.libxlnk.cma_alloc(length, cacheable)
+        if buf == self.ffi.NULL:
             raise RuntimeError("Failed to allocate Memory!")
         self.bufmap[buf] = length
-        return ffi.cast(data_type + "*", buf)
+        return self.ffi.cast(data_type + "*", buf)
         
     def cma_get_buffer(self, buf, length):
         """Get a buffer object.
@@ -215,7 +225,7 @@ class Xlnk:
 
         """
         self.__check_buftype(buf)
-        return ffi.buffer(buf, length)
+        return self.ffi.buffer(buf, length)
     
     def cma_array(self, shape, dtype=np.uint32):
         if isinstance(shape, numbers.Integral):
@@ -251,7 +261,7 @@ class Xlnk:
 
         """
         self.__check_buftype(buf_ptr)
-        return libxlnk.cma_get_phy_addr(buf_ptr)
+        return self.libxlnk.cma_get_phy_addr(buf_ptr)
 
     @staticmethod
     def cma_memcopy(dest, src, nbytes):
@@ -274,7 +284,7 @@ class Xlnk:
         None
 
         """
-        ffi.memmove(dest, src, nbytes)
+        self.ffi.memmove(dest, src, nbytes)
     
     @staticmethod
     def cma_cast(data, data_type = "void"):
@@ -297,7 +307,7 @@ class Xlnk:
             Pointer to buffer with specified data type.
             
         """
-        return ffi.cast(data_type+"*", data)
+        return self.ffi.cast(data_type+"*", data)
       
     def cma_free(self, buf):
         """Free a previously allocated buffer.
@@ -318,7 +328,7 @@ class Xlnk:
         if buf in self.bufmap:
             self.bufmap.pop(buf, None)
         self.__check_buftype(buf)
-        libxlnk.cma_free(buf)
+        self.libxlnk.cma_free(buf)
     
     def cma_stats(self):
         """Get current CMA memory Stats.
@@ -336,7 +346,7 @@ class Xlnk:
 
         """
         stats = {}
-        free_pages = libxlnk.cma_pages_available()
+        free_pages = self.libxlnk.cma_pages_available()
         stats['CMA Memory Available'] = resource.getpagesize() * free_pages
         memused = 0
         for key in self.bufmap:
@@ -358,4 +368,4 @@ class Xlnk:
 
         """
         self.bufmap = {}
-        libxlnk._xlnk_reset()
+        self.libxlnk._xlnk_reset()

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ import sys
 import os
 import site
 import stat
+import warnings
 from datetime import datetime
 
 ''' Board specific package delivery setup '''
@@ -51,6 +52,11 @@ else:
     board_folder = 'boards/{}/'.format(board)
     pynq_data_files = [(os.path.join('{}/pynq'.format(site.getsitepackages()[0]), root.replace(board_folder, '')),
                         [os.path.join(root, f) for f in files]) for root, dirs, files in os.walk(board_folder)]
+
+# Pynq Family Constants
+ZYNQ_ARCH = "armv7l"
+CPU_ARCH = os.uname().machine
+CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH]
 
 ''' Notebook Delivery '''
 default_nb_dir = '/home/xilinx/jupyter_notebooks'
@@ -186,12 +192,29 @@ def run_make(src_path, dst_path, output_lib):
     shutil.copyfile(src_path + output_lib, dst_path + output_lib)
 
 
-if len(sys.argv) > 1 and sys.argv[1] == 'install':
+if len(sys.argv) > 1 and sys.argv[1] == 'install' and CPU_ARCH_IS_SUPPORTED:
     run_make("pynq/lib/_pynq/_apf/", "pynq/lib/", "libdma.so")
     run_make("pynq/lib/_pynq/_audio/", "pynq/lib/", "libaudio.so")
 
     backup_notebooks()
     fill_notebooks_dir()
+elif(not CPU_ARCH_IS_SUPPORTED):
+    warnings.warn("Pynq does not support the CPU Architecture: {}"
+                  .format(CPU_ARCH), ResourceWarning)
+
+if CPU_ARCH_IS_SUPPORTED:
+    ext_modules = [
+        Extension('pynq.lib._video', video,
+                  include_dirs=['pynq/lib/_pynq/inc',
+                                'pynq/lib/_pynq/bsp/ps7_cortexa9_0/include'],
+                  libraries=['sds_lib'],
+                  library_dirs=['/usr/lib'],
+        ),
+    ]
+else:
+    warnings.warn("Pynq does not support the CPU Architecture: {}"
+                  .format(CPU_ARCH), ResourceWarning)
+    ext_modules = []
 
 setup(name='pynq',
       version='1.5',
@@ -210,14 +233,7 @@ setup(name='pynq',
               'stop_pl_server.py = pynq.pl:_stop_server'
           ]
       },
-      ext_modules=[
-          Extension('pynq.lib._video', video,
-                    include_dirs=['pynq/lib/_pynq/inc',
-                                  'pynq/lib/_pynq/bsp/ps7_cortexa9_0/include'],
-                    libraries=['sds_lib'],
-                    library_dirs=['/usr/lib'],
-                    ),
-      ],
+      ext_modules=ext_modules,
       data_files=pynq_data_files
       )
 

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ def fill_notebooks_dir():
 
     # boards/BOARD/OVERLAY_NAME/notebooks/*
     for ol, nb_dir in overlay_notebook_folders:
-        pynq_notebook_files.extend([(os.path.join(notebooks_dir, root.replace(nb_dir, f'{ol}/')),
+        pynq_notebook_files.extend([(os.path.join(notebooks_dir, root.replace(nb_dir, '{}/'.format(ol))),
                                      [os.path.join(root, f) for f in files]) for root, dirs, files in os.walk(nb_dir)])
 
     # docs/source/<subset of notebooks>
@@ -163,7 +163,8 @@ def fill_notebooks_dir():
 
     # rename and copy getting started notebooks
     for ix, getting_started_nb in enumerate(getting_started_notebooks):
-        new_nb_name = f'{ix+1}_{getting_started_nb.split("_",1)[1]}'
+        base_name = getting_started_nb.split("_",1)[1]
+        new_nb_name = '{}_{}'.format(ix + 1, base_name)
         src_file = os.path.join(notebooks_getting_started_dir, getting_started_nb)
         dst_file = os.path.join(notebooks_getting_started_dir, new_nb_name)
         shutil.move(src_file, dst_file)


### PR DESCRIPTION
Fix ReadTheDocs build errors

* Added a standard architecture-check in ps.py
* Added build guards to prevent exceptions when executing on RTD virtual machines (x86_64)
* Added warnings when guards detect an unsupported architecture using the aptly-named warnings package
* Added Notes in doc-strings to alert users of abnormal behavior when unsupported architectures are used
* Changed python3.6 style format strings to python3.5-style format strings
* Corrected a path for the new repository structure
* Refactored guards in xlnx.py 
* Moved cffi/libffi calls into xlnx.py class scope from global scope and added guards
* Moved cffi/libxlnk/libmemapi into dma.py class scope from global scope and added guards