### PR TITLE
Sort out some jupyter environment issues

### DIFF
--- a/sdbuild/Makefile
+++ b/sdbuild/Makefile
@@ -50,7 +50,10 @@ ${WORKDIR}/multistrap.config: ${MULTISTRAP_CONFIG} | ${WORKDIR}
 ${WORKDIR}/PYNQ: | ${WORKDIR}
 	git clone ../ $@
 
-${WORKDIR}/rootfs-stage1.img: ${WORKDIR}/multistrap.config ${BOOT_FILES}  ${KERNEL_DEB} | ${WORKDIR} ${WORKDIR}/config_diff ${CCACHEDIR}
+${WORKDIR}/board | ${WORKDIR}
+	echo ${BOARD} > $@
+
+${WORKDIR}/rootfs-stage1.img: ${WORKDIR}/multistrap.config ${WORKDIR}/board ${BOOT_FILES}  ${KERNEL_DEB} | ${WORKDIR} ${WORKDIR}/config_diff ${CCACHEDIR}
 	sudo -E ${SCRIPT_DIR}/create_mount_img.sh ${WORKDIR}/rootfs-stage1.img ${WORKDIR}/rootfs_staging
 	sudo -E ${SCRIPT_DIR}/create_rootfs.sh ${WORKDIR}/rootfs_staging
 	sudo -E ${SCRIPT_DIR}/unmount_image.sh ${WORKDIR}/rootfs_staging ${WORKDIR}/rootfs-stage1.img

--- a/sdbuild/packages/jupyter/start_jupyter.sh
+++ b/sdbuild/packages/jupyter/start_jupyter.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Source the environment as the init system won't
+set -a
 . /etc/environment
+set +a
 notebook_args=
 notebook_version=$(jupyter notebook --version | grep -o '^[0-9]*')
 

--- a/sdbuild/patchsets/wily/etc/environment.diff
+++ b/sdbuild/patchsets/wily/etc/environment.diff
@@ -5,5 +5,5 @@
 +PATH="/opt/sigrok/bin:/opt/microblaze-xilinx-elf/bin:/opt/python3.6/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
 +LC_ALL=en_US.UTF-8
 +LANG=en_US.UTF-8
-+BOARD=Pynq-Z1
++PYNQ_JUPYTER_NOTEBOOKS=/home/xilinx/jupyter_notebooks
 +PYNQ_PYTHON=python3.6

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -6,6 +6,7 @@ set -e
 
 target=$1
 
+board=$(cat ${WORKDIR}/board)
 fss="proc dev"
 
 # Make sure that our version of QEMU is on the PATH
@@ -45,6 +46,7 @@ adduser --home /home/xilinx xilinx --disabled-password --gecos "Xilinx User,,,,"
 echo -e "xilinx\\nxilinx" | passwd xilinx
 echo -e "xilinx\\nxilinx" | smbpasswd -a xilinx
 echo -e "xilinx\\nxilinx" | passwd root
+echo "BOARD=${BOARD}" >> /etc/environment
 
 adduser xilinx adm
 adduser xilinx sudo


### PR DESCRIPTION
This sorts out the environment so that Jupyter will pick it up, stops hard-coding the board into the image instead using the board specified in the boot configuration, and adds a  PYNQ_JUPYTER_NOTEBOOKS variable.