### PR TITLE
update pytests for basic modules, fix pytests

### DIFF
--- a/pynq/tests/test_gpio.py
+++ b/pynq/tests/test_gpio.py
@@ -27,15 +27,17 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__author__      = "Yun Rock Qu"
-__copyright__   = "Copyright 2016, Xilinx"
-__email__       = "pynq_support@xilinx.com"
-
 
 import os
 import math
 import pytest
 from pynq.gpio import GPIO, GPIO_MIN_USER_PIN
+
+
+__author__ = "Yun Rock Qu"
+__copyright__ = "Copyright 2016, Xilinx"
+__email__ = "pynq_support@xilinx.com"
+
 
 @pytest.mark.run(order=3)
 def test_gpio():
@@ -48,30 +50,31 @@ def test_gpio():
     
     """
     # Find the GPIO base pin
+    index = 0
     for root, dirs, files in os.walk('/sys/class/gpio'):
-            for name in dirs:
-                if 'gpiochip' in name:
-                    index = int(''.join(x for x in name if x.isdigit()))
+        for name in dirs:
+            if 'gpiochip' in name:
+                index = int(''.join(x for x in name if x.isdigit()))
+                break
     base = GPIO.get_gpio_base()
+    assert base == index, 'GPIO base not parsed correctly.'
+
     gpio_min = base + GPIO_MIN_USER_PIN
-    gpio_max = 2**(math.ceil(math.log(gpio_min, 2)))
-            
+    gpio_max = 2**int(math.ceil(math.log(gpio_min, 2)))
+
     for index in range(gpio_min, gpio_max):
         g = GPIO(index, 'in')
-        with pytest.raises(Exception) as error_infor:
+        with pytest.raises(Exception):
             # GPIO type is 'in'. Hence g.write() is illegal. 
-            # Test will pass if exception is raised.
             g.write()
         del g
         
         g = GPIO(index, 'out')
-        with pytest.raises(Exception) as error_infor:
+        with pytest.raises(Exception):
             # GPIO type is 'out'. Hence g.read() is illegal. 
-            # Test will pass if exception is raised.
             g.read()
-        with pytest.raises(Exception) as error_infor:
+        with pytest.raises(Exception):
             # write() only accepts integer 0 or 1 (not 'str'). 
-            # Test will pass if exception is raised.
             g.write('1')
         
         del g

--- a/pynq/tests/test_pl.py
+++ b/pynq/tests/test_pl.py
@@ -27,22 +27,25 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+import os
+import pytest
+from pynq import PL
+from pynq import Overlay
+from pynq import Clocks
+from pynq.pl import BS_BOOT
+from pynq.ps import DEFAULT_CLK_MHZ
+
+
 __author__ = "Yun Rock Qu"
 __copyright__ = "Copyright 2016, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
-import os
-import pytest
-from pynq import Overlay
-from pynq import Clocks
-from pynq.ps import DEFAULT_CLK_MHZ
 
-bitfile1 = 'base.bit'
-bitfile2 = 'interface.bit'
-
+bitfile1 = BS_BOOT
+bitfile2 = PL.bitfile_name
 ol1 = Overlay(bitfile1)
-ol2 = Overlay(bitfile1)
-ol3 = Overlay(bitfile2)
+ol2 = Overlay(bitfile2)
 
 cpu_mhz = 0
 bitfile1_fclk0_mhz = DEFAULT_CLK_MHZ
@@ -63,231 +66,83 @@ def test_overlay():
     files to pass the tests.
     
     """
-    global ol1, ol2, ol3
+    global ol1, ol2
     global cpu_mhz
     global bitfile1_fclk0_mhz, bitfile1_fclk1_mhz
     global bitfile1_fclk2_mhz, bitfile1_fclk3_mhz
     global bitfile2_fclk0_mhz, bitfile2_fclk1_mhz
     global bitfile2_fclk2_mhz, bitfile2_fclk3_mhz
 
-    ol1.download()
-    assert bitfile1 in ol1.bitfile_name, \
-        'Bitstream is not in the overlay.'
-    assert len(ol1.ip_dict) > 0,\
-        'Overlay gets empty IP dictionary.'
-    assert len(ol1.gpio_dict) > 0,\
-        'Overlay gets empty GPIO dictionary.'
-    assert ol1.ip_dict['mb_bram_ctrl_1']['phys_addr'] == \
-        int('0x40000000', 16), 'Overlay gets wrong IP base address.'
-    assert ol1.ip_dict['mb_bram_ctrl_1']['addr_range'] == \
-        int('0x10000', 16), 'Overlay gets wrong IP address range.'
-    for i in ol1.ip_dict:
-        assert ol1.ip_dict[i]['state'] is None,\
-            'Overlay gets wrong IP state.'
-        # Set "TEST" for IP states
-        ol1.ip_dict[i]['state'] = "TEST"
-    for i in ol1.gpio_dict:
-        assert ol1.gpio_dict[i]['state'] is None, \
-            'Overlay gets wrong GPIO state.'
-        # Set "TEST" for GPIO states
-        ol1.gpio_dict[i]['state'] = "TEST"
-    ol1.reset()
-    for i in ol1.ip_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol1.ip_dict[i]['state'] is None,\
-            'Overlay cannot reset IP dictionary.'
-    for i in ol1.gpio_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol1.gpio_dict[i]['state'] is None,\
-            'Overlay cannot reset GPIO dictionary.'
-    cpu_mhz = Clocks.cpu_mhz
-    bitfile1_fclk0_mhz = Clocks.fclk0_mhz
-    bitfile1_fclk1_mhz = Clocks.fclk1_mhz
-    bitfile1_fclk2_mhz = Clocks.fclk2_mhz
-    bitfile1_fclk3_mhz = Clocks.fclk3_mhz
-
-    ol2.download()
-    assert bitfile1 in ol2.bitfile_name, \
-        'Bitstream is not in the overlay.'
-    assert len(ol2.ip_dict) > 0, \
-        'Overlay gets empty IP dictionary.'
-    assert len(ol2.gpio_dict) > 0, \
-        'Overlay gets empty GPIO dictionary.'
-    assert ol2.ip_dict['mb_bram_ctrl_1']['phys_addr'] == \
-        int('0x40000000', 16), 'Overlay gets wrong IP base address.'
-    assert ol2.ip_dict['mb_bram_ctrl_1']['addr_range'] == \
-        int('0x10000', 16), 'Overlay gets wrong IP address range.'
-    for i in ol2.ip_dict:
-        assert ol2.ip_dict[i]['state'] is None, \
-            'Overlay gets wrong IP state.'
-        # Set "TEST" for IP states
-        ol2.ip_dict[i]['state'] = "TEST"
-    for i in ol2.gpio_dict:
-        assert ol2.gpio_dict[i]['state'] is None, \
-            'Overlay gets wrong GPIO state.'
-        # Set "TEST" for GPIO states
-        ol2.gpio_dict[i]['state'] = "TEST"
-    ol2.reset()
-    for i in ol2.ip_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol2.ip_dict[i]['state'] is None, \
-            'Overlay cannot reset IP dictionary.'
-    for i in ol2.gpio_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol2.gpio_dict[i]['state'] is None, \
-            'Overlay cannot reset GPIO dictionary.'
-
-    ol3.download()
-    assert bitfile2 in ol3.bitfile_name, \
-        'Bitstream is not in the overlay.'
-    assert len(ol3.ip_dict) > 0, \
-        'Overlay gets empty IP dictionary.'
-    assert len(ol3.gpio_dict) > 0, \
-        'Overlay gets empty GPIO dictionary.'
-    assert ol3.ip_dict['mb_bram_ctrl_1']['phys_addr'] == \
-        int('0x40000000', 16), 'Overlay gets wrong IP base address.'
-    assert ol3.ip_dict['mb_bram_ctrl_1']['addr_range'] == \
-        int('0x10000', 16), 'Overlay gets wrong IP address range.'
-    for i in ol3.ip_dict:
-        assert ol3.ip_dict[i]['state'] is None, \
-            'Overlay gets wrong IP state.'
-        # Set "TEST" for IP states
-        ol3.ip_dict[i][2] = "TEST"
-    for i in ol3.gpio_dict:
-        assert ol3.gpio_dict[i]['state'] is None, \
-            'Overlay gets wrong GPIO state.'
-        # Set "TEST" for GPIO states
-        ol3.gpio_dict[i]['state'] = "TEST"
-    ol3.reset()
-    for i in ol3.ip_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol3.ip_dict[i]['state'] is None, \
-            'Overlay cannot reset IP dictionary.'
-    for i in ol3.gpio_dict:
-        # "TEST" should have been cleared by reset()
-        assert ol3.gpio_dict[i]['state'] is None, \
-            'Overlay cannot reset GPIO dictionary.'
-    bitfile2_fclk0_mhz = Clocks.fclk0_mhz
-    bitfile2_fclk1_mhz = Clocks.fclk1_mhz
-    bitfile2_fclk2_mhz = Clocks.fclk2_mhz
-    bitfile2_fclk3_mhz = Clocks.fclk3_mhz
+    for ol in [ol1, ol2]:
+        ol.download()
+        assert len(ol.ip_dict) > 0,\
+            'Overlay gets empty IP dictionary.'
+        assert len(ol.gpio_dict) > 0,\
+            'Overlay gets empty GPIO dictionary.'
+        for ip in ol.ip_dict:
+            for key in ['addr_range', 'phys_addr', 'state', 'type']:
+                assert key in ol.ip_dict[ip], \
+                    'Key {} missing in IP {}.'.format(key, ip)
+            assert ol.ip_dict[ip]['state'] is None,\
+                'Overlay gets wrong IP state.'
+            # Set "TEST" for IP states
+            ol.ip_dict[ip]['state'] = "TEST"
+        for gpio in ol.gpio_dict:
+            for key in ['index', 'state']:
+                assert key in ol.gpio_dict[gpio], \
+                    'Key {} missing in GPIO {}.'.format(key, gpio)
+            assert ol.gpio_dict[gpio]['state'] is None, \
+                'Overlay gets wrong GPIO state.'
+            # Set "TEST" for GPIO states
+            ol.gpio_dict[gpio]['state'] = "TEST"
+        ol.reset()
+        for ip in ol.ip_dict:
+            # "TEST" should have been cleared by reset()
+            assert ol.ip_dict[ip]['state'] is None,\
+                'Overlay cannot reset IP dictionary.'
+        for gpio in ol.gpio_dict:
+            # "TEST" should have been cleared by reset()
+            assert ol.gpio_dict[gpio]['state'] is None,\
+                'Overlay cannot reset GPIO dictionary.'
+        cpu_mhz = Clocks.cpu_mhz
+        bitfile1_fclk0_mhz = Clocks.fclk0_mhz
+        bitfile1_fclk1_mhz = Clocks.fclk1_mhz
+        bitfile1_fclk2_mhz = Clocks.fclk2_mhz
+        bitfile1_fclk3_mhz = Clocks.fclk3_mhz
+        assert not ol.bitstream.timestamp == '', \
+            'Overlay ({}) has an empty timestamp.'.format(ol.bitfile_name)
+        assert ol.is_loaded(), \
+            'Overlay ({}) should be loaded.'.format(ol.bitfile_name)
+        assert Clocks.cpu_mhz == cpu_mhz, \
+            'CPU frequency should not be changed.'
+        assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
+            'FCLK0 frequency not correct after downloading {}.'.format(
+                ol.bitfile_name)
+        assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
+            'FCLK1 frequency not correct after downloading {}.'.format(
+                ol.bitfile_name)
+        assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
+            'FCLK2 frequency not correct after downloading {}.'.format(
+                ol.bitfile_name)
+        assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
+            'FCLK3 frequency not correct after downloading {}.'.format(
+                ol.bitfile_name)
 
 
-@pytest.mark.run(order=10)
-def test_overlay1():
-    """Download the bitstream for the first overlay, and then test.
-    
-    Need the corresponding `*.tcl` file to pass the tests.
-    
-    """
-    global ol1
-    global cpu_mhz
-    global bitfile1_fclk0_mhz, bitfile1_fclk1_mhz
-    global bitfile1_fclk2_mhz, bitfile1_fclk3_mhz
-
-    ol1.download()
-    assert not ol1.bitstream.timestamp == '', \
-        'Overlay 1 ({}) has an empty timestamp.'.format(bitfile1)
-    assert ol1.is_loaded(), \
-        'Overlay 1 ({}) should be loaded.'.format(bitfile1)
-    assert Clocks.cpu_mhz == cpu_mhz, \
-        'CPU frequency should not be changed.'
-    assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
-
-
-@pytest.mark.run(order=30)
-def test_overlay2():
-    """Change to another overlay, and then test.
-    
-    Need the corresponding `*.tcl` file to pass the tests.
-    
-    """
-    global ol2
-    global cpu_mhz
-    global bitfile1_fclk0_mhz, bitfile1_fclk1_mhz
-    global bitfile1_fclk2_mhz, bitfile1_fclk3_mhz
-
-    ol2.download()
-    assert not ol2.bitstream.timestamp == '', \
-        'Overlay 2 ({}) has an empty timestamp.'.format(bitfile1)
-    assert ol2.is_loaded(), \
-        'Overlay 2 ({}) should be loaded.'.format(bitfile1)
-    assert Clocks.cpu_mhz == cpu_mhz, \
-        'CPU frequency should not be changed.'
-    assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
-
-
-@pytest.mark.run(order=39)
-def test_overlay3():
-    """Change to another overlay, and then test.
-
-    Need the corresponding `*.tcl` file to pass the tests.
-
-    """
-    global ol3
-    global cpu_mhz
-    global bitfile2_fclk0_mhz, bitfile2_fclk1_mhz
-    global bitfile2_fclk2_mhz, bitfile2_fclk3_mhz
-
-    ol3.download()
-    assert not ol3.bitstream.timestamp == '', \
-        'Overlay 3 ({}) has an empty timestamp.'.format(bitfile2)
-    assert ol3.is_loaded(), \
-        'Overlay 3 ({}) should be loaded.'.format(bitfile2)
-    assert Clocks.cpu_mhz == cpu_mhz, \
-        'CPU frequency should not be changed.'
-    assert Clocks.fclk0_mhz == bitfile2_fclk0_mhz, \
-        'FCLK0 frequency not correct after downloading {}.'.format(bitfile2)
-    assert Clocks.fclk1_mhz == bitfile2_fclk1_mhz, \
-        'FCLK1 frequency not correct after downloading {}.'.format(bitfile2)
-    assert Clocks.fclk2_mhz == bitfile2_fclk2_mhz, \
-        'FCLK2 frequency not correct after downloading {}.'.format(bitfile2)
-    assert Clocks.fclk3_mhz == bitfile2_fclk3_mhz, \
-        'FCLK3 frequency not correct after downloading {}.'.format(bitfile2)
-
-
-@pytest.mark.run(order=49)
+@pytest.mark.run(order=-1)
 def test_end():
     """Wrapping up by changing the overlay back.
     
     This is the last test to be performed.
     
     """
-    global ol1, ol2, ol3
-    global cpu_mhz
-    global bitfile1_fclk0_mhz, bitfile1_fclk1_mhz
-    global bitfile1_fclk2_mhz, bitfile1_fclk3_mhz
+    global ol1, ol2
 
-    ol1.download()
-    assert not ol1.bitstream.timestamp == '', \
-        'Overlay 1 ({}) has an empty timestamp.'.format(bitfile1)
-    assert ol1.is_loaded(), \
-        'Overlay 1 ({}) should be loaded.'.format(bitfile1)
-    assert Clocks.cpu_mhz == cpu_mhz, \
-        'CPU frequency should not be changed.'
-    assert Clocks.fclk0_mhz == bitfile1_fclk0_mhz, \
-        'FCLK0 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk1_mhz == bitfile1_fclk1_mhz, \
-        'FCLK1 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk2_mhz == bitfile1_fclk2_mhz, \
-        'FCLK2 frequency not correct after downloading {}.'.format(bitfile1)
-    assert Clocks.fclk3_mhz == bitfile1_fclk3_mhz, \
-        'FCLK3 frequency not correct after downloading {}.'.format(bitfile1)
+    ol2.download()
+
+    # Clear the javascript files copied during tests if any
+    if os.system("rm -rf ./js"):
+        raise RuntimeError('Cannot remove WaveDrom javascripts.')
 
     del ol1
     del ol2
-    del ol3

--- a/pynq/tests/test_su.py
+++ b/pynq/tests/test_su.py
@@ -27,14 +27,16 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__author__      = "Yun Rock Qu"
-__copyright__   = "Copyright 2016, Xilinx"
-__email__       = "pynq_support@xilinx.com"
-
 
 import os
 import pytest
-    
+
+
+__author__ = "Yun Rock Qu"
+__copyright__ = "Copyright 2016, Xilinx"
+__email__ = "pynq_support@xilinx.com"
+
+
 @pytest.mark.run(order=1)
 def test_superuser():
     """Test whether the user have the root privilege.
@@ -44,4 +46,4 @@ def test_superuser():
     To pass all of the pytests, need the root access.
     
     """
-    assert os.geteuid()==0, "Need ROOT access in order to run tests." 
+    assert os.geteuid() == 0, "Need ROOT access in order to run tests."

--- a/pynq/tests/util.py
+++ b/pynq/tests/util.py
@@ -27,19 +27,28 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__author__      = "Yun Rock Qu"
-__copyright__   = "Copyright 2016, Xilinx"
-__email__       = "pynq_support@xilinx.com"
+__author__ = "Yun Rock Qu"
+__copyright__ = "Copyright 2016, Xilinx"
+__email__ = "pynq_support@xilinx.com"
 
 
 def user_answer_yes(text):
     answer = input(text + ' ([yes]/no)>>> ').lower()
     return answer == 'y' or answer == 'yes' or answer == ''
-    
+
+
 def user_answer_no(text):
     answer = input(text + ' (yes/[no])>>> ').lower()
     return answer == 'n' or answer == 'no' or answer == ''
 
-def get_pmod_id(text):
-    return input("Type in the interface ID of the {} (A or B): "
-                 .format(text)).strip().upper()
+
+def get_interface_id(text, options):
+    options_str = [str(x) for x in options]
+    options_text = '/'.join(options_str)
+    ret_str = input(
+        "Type in the interface ID of the {} ({}): ".format(
+            text, options_text))
+    ret_str = ret_str.strip().upper()
+    if ret_str not in options_str:
+        raise ValueError('Please use a valid interface ID.')
+    return ret_str


### PR DESCRIPTION
The files are reorganized, with pep8 rule.

Removed pytests ordering, leaving only the order for the basic modules.

Removed dependency on available overlay, making portable to other boards / overlays.