### PR TITLE
Add REVISION as part of pynq install rather than in the initial rootfs

### DIFF
--- a/sdbuild/packages/pynq/get_revision.sh
+++ b/sdbuild/packages/pynq/get_revision.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Release $(date +'%Y_%m_%d') $(git describe)"

--- a/sdbuild/packages/pynq/pre.sh
+++ b/sdbuild/packages/pynq/pre.sh
@@ -11,3 +11,4 @@ sudo cp -r $WORKDIR/PYNQ $target/home/xilinx/pynq_git
 sudo cp $script_dir/pl_server.sh $target/usr/local/bin
 sudo cp $script_dir/pl_server.service $target/lib/systemd/system
 sudo cp $script_dir/pynq_hostname.sh $target/usr/local/bin
+sudo bash -c "(cd $WORKDIR/PYNQ && $script_dir/get_revision.sh) > $target/home/xilinx/REVISION"

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -91,8 +91,6 @@ do
   $dry_run sudo patch $target/${f%.diff} < ${WORKDIR}/config_diff/$f
 done
 
-$script_dir/get_revision.sh > $target/home/xilinx/REVISION
-
 $dry_run cp ${WORKDIR}/boot_files/* $target/boot
 
 $script_dir/kill_chroot_processes.sh $target

--- a/sdbuild/scripts/get_revision.sh
+++ b/sdbuild/scripts/get_revision.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "Release $(date +'%Y_%m_%d') $(git describe) $(git rev-parse --short --verify HEAD)"


### PR DESCRIPTION
This means that the REVISION file will be correct when we only partially rebuild the image.