### PR TITLE
Updating pytests to not download bitstream while collecting tests

### DIFF
--- a/pynq/lib/arduino/tests/test_arduino.py
+++ b/pynq/lib/arduino/tests/test_arduino.py
@@ -40,7 +40,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag = True
 except IOError:
     flag = False
@@ -62,7 +62,6 @@ def test_arduino_microblaze():
     
     """
     ol = Overlay('base.bit')
-    ol.download()
 
     for mb_info in [ARDUINO]:
         exception_raised = False

--- a/pynq/lib/arduino/tests/test_arduino_devmode.py
+++ b/pynq/lib/arduino/tests/test_arduino_devmode.py
@@ -47,7 +47,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('interface.bit')
+    _ = Overlay('interface.bit', download=False)
     flag = True
 except IOError:
     flag = False
@@ -65,7 +65,6 @@ def test_arduino_devmode():
 
     """
     ol = Overlay('base.bit')
-    ol.download()
 
     for mb_info in [ARDUINO]:
         assert Arduino_DevMode(mb_info, ARDUINO_SWCFG_DIOALL) is not None

--- a/pynq/lib/logictools/tests/test_all.py
+++ b/pynq/lib/logictools/tests/test_all.py
@@ -64,7 +64,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/logictools/tests/test_boolean_generator.py
+++ b/pynq/lib/logictools/tests/test_boolean_generator.py
@@ -48,7 +48,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/logictools/tests/test_fsm_generator.py
+++ b/pynq/lib/logictools/tests/test_fsm_generator.py
@@ -52,7 +52,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/logictools/tests/test_logictools.py
+++ b/pynq/lib/logictools/tests/test_logictools.py
@@ -44,7 +44,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag = True
 except IOError:
     flag = False

--- a/pynq/lib/logictools/tests/test_pattern_generator.py
+++ b/pynq/lib/logictools/tests/test_pattern_generator.py
@@ -46,7 +46,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/logictools/tests/test_trace_analyzer.py
+++ b/pynq/lib/logictools/tests/test_trace_analyzer.py
@@ -45,7 +45,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    ol = Overlay('logictools.bit')
+    ol = Overlay('logictools.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/pmod/tests/test_pmod.py
+++ b/pynq/lib/pmod/tests/test_pmod.py
@@ -41,7 +41,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag = True
 except IOError:
     flag = False
@@ -63,7 +63,6 @@ def test_pmod_microblaze():
     
     """
     ol = Overlay('base.bit')
-    ol.download()
 
     for mb_info in [PMODA, PMODB]:
         exception_raised = False

--- a/pynq/lib/pmod/tests/test_pmod_als.py
+++ b/pynq/lib/pmod/tests/test_pmod_als.py
@@ -44,7 +44,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/pmod/tests/test_pmod_cable.py
+++ b/pynq/lib/pmod/tests/test_pmod_cable.py
@@ -45,7 +45,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False
@@ -92,7 +92,6 @@ def test_pmod_cable():
     
     """
     ol = Overlay('base.bit')
-    ol.download()
     print('\nTesting Pmod IO cable...')
     assert not send_id == recv_id, \
         "The sender port cannot be the receiver port."

--- a/pynq/lib/pmod/tests/test_pmod_dac_adc.py
+++ b/pynq/lib/pmod/tests/test_pmod_dac_adc.py
@@ -46,7 +46,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/pmod/tests/test_pmod_devmode.py
+++ b/pynq/lib/pmod/tests/test_pmod_devmode.py
@@ -50,7 +50,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag = True
 except IOError:
     flag = False
@@ -68,7 +68,6 @@ def test_pmod_devmode():
 
     """
     ol = Overlay('base.bit')
-    ol.download()
 
     for mb_info in [PMODA, PMODB]:
         assert Pmod_DevMode(mb_info, PMOD_SWCFG_IIC0_TOPROW) is not None

--- a/pynq/lib/pmod/tests/test_pmod_led8.py
+++ b/pynq/lib/pmod/tests/test_pmod_led8.py
@@ -47,7 +47,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/pmod/tests/test_pmod_oled.py
+++ b/pynq/lib/pmod/tests/test_pmod_oled.py
@@ -43,7 +43,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False

--- a/pynq/lib/pmod/tests/test_pmod_tmp2.py
+++ b/pynq/lib/pmod/tests/test_pmod_tmp2.py
@@ -43,7 +43,7 @@ __email__ = "pynq_support@xilinx.com"
 
 
 try:
-    _ = Overlay('base.bit')
+    _ = Overlay('base.bit', download=False)
     flag0 = True
 except IOError:
     flag0 = False


### PR DESCRIPTION
This makes sure the bitstream is not downloaded while collecting all the tests. Otherwise the collection phase will get busy and slow.