### PR TITLE
Fixed inter-document references that were causing warnings

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -1,62 +1,126 @@
-***********
+********
 Appendix
-***********
-
-.. contents:: Table of Contents
-   :depth: 2
-
+********
 
 Technology Backgrounder
-========================
+=======================
 
 Overlays and Design Re-use
 --------------------------
 
-The 'magic' of mapping an application to an APSoC, without designing custom hardware, is achieved by using *FPGA overlays*. FPGA overlays are FPGA designs that are both highly configurable and highly optimized for a given domain.  The availability of a suitable overlay removes the need for a software designer to develop a new bitstream. Software and system designers can customize the functionality of an existing overlay *in software* once the API for the overlay bitstream is available.
+The 'magic' of mapping an application to an APSoC, without designing custom
+hardware, is achieved by using *FPGA overlays*. FPGA overlays are FPGA designs
+that are both highly configurable and highly optimized for a given domain.  The
+availability of a suitable overlay removes the need for a software designer to
+develop a new bitstream. Software and system designers can customize the
+functionality of an existing overlay *in software* once the API for the overlay
+bitstream is available.
 
-An FPGA overlay is a domain-specific FPGA design that has been created to be highly configurable so that it can be used in  as many different applications as possible.  It has been crafted to maximize post-bitstream programmability which is exposed via its API.  The API provides a new entry-point for application-focused software and systems engineers to exploit APSoCs in their solutions.  With an API they only have to write software to program configure the functions of an overlay for their applications.
+An FPGA overlay is a domain-specific FPGA design that has been created to be
+highly configurable so that it can be used in as many different applications as
+possible.  It has been crafted to maximize post-bitstream programmability which
+is exposed via its API.  The API provides a new entry-point for
+application-focused software and systems engineers to exploit APSoCs in their
+solutions.  With an API they only have to write software to program configure
+the functions of an overlay for their applications.
 
-By analogy with the Linux kernel and device drivers, FPGA overlays are designed by relatively few engineers so that they can be re-used by many others. In this way, a relatively small number of overlay designers can support a much larger community of APSoC designers.  Overlays exist to promote re-use. Like kernels and device drivers, these hardware-level artefacts are not static, but evolve and improve over time.
+By analogy with the Linux kernel and device drivers, FPGA overlays are designed
+by relatively few engineers so that they can be re-used by many others. In this
+way, a relatively small number of overlay designers can support a much larger
+community of APSoC designers.  Overlays exist to promote re-use. Like kernels
+and device drivers, these hardware-level artefacts are not static, but evolve
+and improve over time.
 
 Characteristics of Good Overlays
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------
 
-Creating one FPGA design and its corresponding API to serve the needs of many applications in a given domain is what defines a successful overlay.  This, one-to-many relationship between the overlay and its users, is different from the more common one-to-one mapping between a bitstream and its application.  
+Creating one FPGA design and its corresponding API to serve the needs of many
+applications in a given domain is what defines a successful overlay.  This,
+one-to-many relationship between the overlay and its users, is different from
+the more common one-to-one mapping between a bitstream and its application.
 
-Consider the example of an overlay created for controlling drones.  Instead of creating a design that is optimized for controlling just a single type of drone, the hardware architects recognize the many common requirements shared by different drone controllers. They create a design for controlling drones that is a flexible enough to be used with several different drones.  In effect, they create a drone-control overlay.  They expose, to the users of their bitstream, an API through which the users can determine in software the parameters critical to their application.  For example, a drone control overlay might support up to eight, pulse-width-modulated (PWM) motor control circuits.  The software programmer can determine how many of the control circuits to enable and how to tune the individual motor control parameters to the needs of his particular drone.
+Consider the example of an overlay created for controlling drones.  Instead of
+creating a design that is optimized for controlling just a single type of drone,
+the hardware architects recognize the many common requirements shared by
+different drone controllers. They create a design for controlling drones that is
+a flexible enough to be used with several different drones.  In effect, they
+create a drone-control overlay.  They expose, to the users of their bitstream,
+an API through which the users can determine in software the parameters critical
+to their application.  For example, a drone control overlay might support up to
+eight, pulse-width-modulated (PWM) motor control circuits.  The software
+programmer can determine how many of the control circuits to enable and how to
+tune the individual motor control parameters to the needs of his particular
+drone.
 
-The design of a good overlay shares many common elements with the design of a class in object-oriented software.  Determining the fundamental data structure, the private methods and the public interface are common requirements.  The quality of the class is determined both by its overall usefulness and the coherency of the API it exposes.  Well-engineered classes and overlays are inherently useful and are easy to learn and deploy.  
+The design of a good overlay shares many common elements with the design of a
+class in object-oriented software.  Determining the fundamental data structure,
+the private methods and the public interface are common requirements.  The
+quality of the class is determined both by its overall usefulness and the
+coherency of the API it exposes.  Well-engineered classes and overlays are
+inherently useful and are easy to learn and deploy.
 
-Pynq adopts a holistic approach by considering equally the design of the overlays, the APIs exported by the overlays, and how well these APIs interact with new and existing Python design patterns and idioms to simplify and improve the APSoC design process.  One of the key challenges is to identify and refine good abstractions.  The goal is to find abstractions that improve design coherency by exposing commonality, even among loosely-related tasks.  As new overlays and APIs are published, we expect that the open-source software community will further improve and extend them in new and unexpected ways.  
+Pynq adopts a holistic approach by considering equally the design of the
+overlays, the APIs exported by the overlays, and how well these APIs interact
+with new and existing Python design patterns and idioms to simplify and improve
+the APSoC design process.  One of the key challenges is to identify and refine
+good abstractions.  The goal is to find abstractions that improve design
+coherency by exposing commonality, even among loosely-related tasks.  As new
+overlays and APIs are published, we expect that the open-source software
+community will further improve and extend them in new and unexpected ways.
 
-Note that FPGA overlays are not a novel concept.  They have been studied for over a decade and many academic papers have been published on the topic.
+Note that FPGA overlays are not a novel concept.  They have been studied for
+over a decade and many academic papers have been published on the topic.
 
 The Case for Productivity-layer Languages
 -----------------------------------------
 
-Successive generations of All Programmable Systems on Chip embed more processors and greater processing power. As larger applications are integrated into APSoCs, the embedded code increases also. Embedded code that is speed or size critical, will continue to be written in C/C++.  These 'efficiency-layer or systems languages' are needed to write fast, low-level drivers, for example. However, the proportion of embedded code that is neither speed-critical or size-critical, is increasing more rapidly. We refer to this broad class of code as *embedded applications code*.   
+Successive generations of All Programmable Systems on Chip embed more processors
+and greater processing power. As larger applications are integrated into APSoCs,
+the embedded code increases also. Embedded code that is speed or size critical,
+will continue to be written in C/C++.  These 'efficiency-layer or systems
+languages' are needed to write fast, low-level drivers, for example. However,
+the proportion of embedded code that is neither speed-critical or size-critical,
+is increasing more rapidly. We refer to this broad class of code as *embedded
+applications code*.
 
-Programming embedded applications code in higher-level, 'productivity-layer languages' makes good sense.  It simply extends the generally-accepted best-practice of always programming at the highest possible level of abstraction.  Python is currently a premier productivity-layer language.  It is now available in different variants for a range of embedded systems, hence its adoption in Pynq.  Pynq runs CPython on Linux on the ARM® processors in Zynq® devices.  To further increase productivity and portability, Pynq uses the Jupyter Notebook, an open-source web framework to rapidly develop systems, document their behavior and disseminate the results.
+Programming embedded applications code in higher-level, 'productivity-layer
+languages' makes good sense.  It simply extends the generally-accepted
+best-practice of always programming at the highest possible level of
+abstraction.  Python is currently a premier productivity-layer language.  It is
+now available in different variants for a range of embedded systems, hence its
+adoption in Pynq.  Pynq runs CPython on Linux on the ARM® processors in Zynq®
+devices.  To further increase productivity and portability, Pynq uses the
+Jupyter Notebook, an open-source web framework to rapidly develop systems,
+document their behavior and disseminate the results.
 
-
-
-Writing the SD card image
-==========================
+.. _writing-the-sd-card:
+   
+Writing the SD Card Image
+=========================
 
 Windows
---------------------------
+-------
 
-* Insert the Micro SD card into your SD card reader and check which drive letter was assigned. You can find this by opening Computer/My Computer in Windows Explorer. 
-* Download the `Win32DiskImager utility from the Sourceforge Project page <https://sourceforge.net/projects/win32diskimager/>`_
-* Extract the *Win32DiskImager* executable from the zip file and run the Win32DiskImager utility as administrator. (Right-click on the file, and select Run as administrator.)
+* Insert the Micro SD card into your SD card reader and check which drive letter
+  was assigned. You can find this by opening Computer/My Computer in Windows
+  Explorer.
+* Download the `Win32DiskImager utility from the Sourceforge Project page
+  <https://sourceforge.net/projects/win32diskimager/>`_
+* Extract the *Win32DiskImager* executable from the zip file and run the
+  Win32DiskImager utility as administrator. (Right-click on the file, and select
+  Run as administrator.)
 * Select the PYNQ-Z1 image file (.img).
-* Select the drive letter of the SD card. Be careful to select the correct drive. If you select the wrong drive you can overwrite data on that drive. This could be another USB stick, or memory card connected to your computer, or your computer's hard disk. 
+* Select the drive letter of the SD card. Be careful to select the correct
+  drive. If you select the wrong drive you can overwrite data on that
+  drive. This could be another USB stick, or memory card connected to your
+  computer, or your computer's hard disk.
 * Click **Write** and wait for the write to complete.
 
-MAC
----------------------------
+MAC / OS X
+----------
 
-On Mac OS, you can use dd, or the graphical tool ImageWriter to write to your Micro SD card.
+On Mac OS, you can use dd, or the graphical tool ImageWriter to write to your
+Micro SD card.
 
 * First open a terminal and unzip the image:
 
@@ -65,14 +129,24 @@ On Mac OS, you can use dd, or the graphical tool ImageWriter to write to your Mi
       unzip pynq_z1_image_2016_09_14.zip -d ./
       
 ImageWriter
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^
 
 Note the Micro SD card must be formatted as FAT32.
       
 * Insert the Micro SD card into your SD card reader 
-* From the Apple menu, choose "About This Mac", then click on "More info..."; if you are using Mac OS X 10.8.x Mountain Lion or newer, then click on "System Report".
-* Click on "USB" (or "Card Reader" if using a built-in SD card reader) then search for your SD card in the upper-right section of the window. Click on it, then search for the BSD name in the lower-right section; it will look something like **diskn** where n is a number (for example, disk4). Make sure you take a note of this number.
-* Unmount the partition so that you will be allowed to overwrite the disk. To do this, open Disk Utility and unmount it; do not eject it, or you will have to reconnect it. Note that on Mac OS X 10.8.x Mountain Lion, "Verify Disk" (before unmounting) will display the BSD name as `/dev/disk1s1` or similar, allowing you to skip the previous two steps.
+* From the Apple menu, choose "About This Mac", then click on "More info..."; if
+  you are using Mac OS X 10.8.x Mountain Lion or newer, then click on "System
+  Report".
+* Click on "USB" (or "Card Reader" if using a built-in SD card reader) then
+  search for your SD card in the upper-right section of the window. Click on it,
+  then search for the BSD name in the lower-right section; it will look
+  something like **diskn** where n is a number (for example, disk4). Make sure
+  you take a note of this number.
+* Unmount the partition so that you will be allowed to overwrite the disk. To do
+  this, open Disk Utility and unmount it; do not eject it, or you will have to
+  reconnect it. Note that on Mac OS X 10.8.x Mountain Lion, "Verify Disk"
+  (before unmounting) will display the BSD name as `/dev/disk1s1` or similar,
+  allowing you to skip the previous two steps.
 * From the terminal, run the following command:
 
    .. code-block:: console
@@ -90,7 +164,7 @@ If this command fails, try using disk instead of rdisk:
 Wait for the card to be written. This may take some time. 
 
 Command Line
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 * Open a terminal, then run:
    
@@ -99,7 +173,8 @@ Command Line
       diskutil list
 
 * Identify the disk (not partition) of your SD card e.g. disk4, not disk4s1.
-* Unmount your SD card by using the disk identifier, to prepare for copying data to it:
+* Unmount your SD card by using the disk identifier, to prepare for copying data
+  to it:
 
    .. code-block:: console
       
@@ -113,15 +188,19 @@ Command Line
    
       sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>
 
-   where disk is your BSD name e.g. sudo dd bs=1m if=pynq_z1_image_2016_09_07.img of=/dev/rdisk4
+   where disk is your BSD name e.g. sudo dd bs=1m
+   if=pynq_z1_image_2016_09_07.img of=/dev/rdisk4
 
-This may result in a dd: invalid number '1m' error if you have GNU coreutils installed. In that case, you need to use a block size of 1M in the bs= section, as follows:
+This may result in a dd: invalid number '1m' error if you have GNU coreutils
+installed. In that case, you need to use a block size of 1M in the bs= section,
+as follows:
 
    .. code-block:: console
       
       sudo dd bs=1M if=image.img of=/dev/rdisk<disk# from diskutil>
 
-Wait for the card to be written. This may take some time. You can check the progress by sending a SIGINFO signal (press Ctrl+T).
+Wait for the card to be written. This may take some time. You can check the
+progress by sending a SIGINFO signal (press Ctrl+T).
 
 If this command still fails, try using disk instead of rdisk, for example:
 
@@ -131,12 +210,14 @@ If this command still fails, try using disk instead of rdisk, for example:
 
 
 Linux
----------------------------
+-----
 
 dd
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^
 
-Please note the dd tool can overwrite any partition on your machine. Please be careful when specifying the drive in the instructions below. If you select the wrong drive, you could lose data from, or delete your primary Linux partition. 
+Please note the dd tool can overwrite any partition on your machine. Please be
+careful when specifying the drive in the instructions below. If you select the
+wrong drive, you could lose data from, or delete your primary Linux partition.
 
 * Run `df -h` to see what devices are currently mounted.
 
@@ -144,63 +225,83 @@ Please note the dd tool can overwrite any partition on your machine. Please be c
 
 * Run df -h again. 
 
-The new device that has appeared is your Micro SD card. The left column gives the device name; it will be listed as something like /dev/mmcblk0p1 or /dev/sdd1. The last part (p1 or 1 respectively) is the partition number but you want to write to the whole SD card, not just one partition. You need to remove that part from the name. e.g. Use /dev/mmcblk0 or /dev/sdd as the device name for the whole SD card. 
+The new device that has appeared is your Micro SD card. The left column gives
+the device name; it will be listed as something like /dev/mmcblk0p1 or
+/dev/sdd1. The last part (p1 or 1 respectively) is the partition number but you
+want to write to the whole SD card, not just one partition. You need to remove
+that part from the name. e.g. Use /dev/mmcblk0 or /dev/sdd as the device name
+for the whole SD card.
 
-Now that you've noted what the device name is, you need to unmount it so that files can't be read or written to the SD card while you are copying over the SD image.
+Now that you've noted what the device name is, you need to unmount it so that
+files can't be read or written to the SD card while you are copying over the SD
+image.
 
-* Run `umount /dev/sdd1`, replacing sdd1 with whatever your SD card's device name is (including the partition number).
+* Run `umount /dev/sdd1`, replacing sdd1 with whatever your SD card's device
+  name is (including the partition number).
 
 If your SD card shows up more than once in the output of df due to having multiple partitions on the SD card, you should unmount all of these partitions.
 
-* In the terminal, write the image to the card with the command below, making sure you replace the input file if= argument with the path to your .img file, and the /dev/sdd in the output file of= argument with the right device name. This is very important, as you will lose all data on the hard drive if you provide the wrong device name. Make sure the device name is the name of the whole Micro SD card as described above, not just a partition of it; for example, sdd, not sdds1, and mmcblk0, not mmcblk0p1.
+* In the terminal, write the image to the card with the command below, making
+  sure you replace the input file if= argument with the path to your .img file,
+  and the /dev/sdd in the output file of= argument with the right device
+  name. This is very important, as you will lose all data on the hard drive if
+  you provide the wrong device name. Make sure the device name is the name of
+  the whole Micro SD card as described above, not just a partition of it; for
+  example, sdd, not sdds1, and mmcblk0, not mmcblk0p1.
 
 `sudo dd bs=4M if=pynq_z1_image_2016_09_07.img of=/dev/sdd`
 
-Please note that block size set to 4M will work most of the time; if not, please try 1M, although this will take considerably longer.
+Please note that block size set to 4M will work most of the time; if not, please
+try 1M, although this will take considerably longer.
 
-The dd command does not give any information of its progress and so may appear to have frozen; it could take a few minutes to finish writing to the card. 
+The dd command does not give any information of its progress and so may appear
+to have frozen; it could take a few minutes to finish writing to the card.
 
-Instead of dd you can use `dcfldd`; it will give a progress report about how much has been written.
+Instead of dd you can use `dcfldd`; it will give a progress report about how
+much has been written.
 
+.. _assign-your-computer-a-static-ip:
 
-Assign your laptop/PC a static IP address
-===========================================
+Assign your computer a static IP address
+========================================
 
-Instructions may vary slightly depending on the version of operating system you have. You can also search on google for instructions on how to change your network settings.
+Instructions may vary slightly depending on the version of operating system you
+have. You can also search on google for instructions on how to change your
+network settings.
 
-You need to set the IP address of your laptop/pc to be in the same range as the board. e.g. if the board is 192.168.2.99, the laptop/PC can be 192.168.2.x where x is 0-255 (excluding 99, as this is already taken by the board). 
+You need to set the IP address of your laptop/pc to be in the same range as the
+board. e.g. if the board is 192.168.2.99, the laptop/PC can be 192.168.2.x where
+x is 0-255 (excluding 99, as this is already taken by the board).
 
-You should record your original settings, in case you need to revert to them when finished using PYNQ. 
+You should record your original settings, in case you need to revert to them
+when finished using PYNQ.
 
 Windows
---------------------------
+-------
 
 * Go to Control Panel -> Network and Internet -> Network Connections
 * Find your Ethernet network interface, usually `Local Area Connection`
 * Double click on the network interface to open it, and click on *Properties*
 * Select Internet Protocol Version 4 (TCP/IPv4) and click *Properties*
 * Select *Use the following IP address*
-* Set the Ip address to 192.168.2.1 (or any other address in the same range as the board)
+* Set the Ip address to 192.168.2.1 (or any other address in the same range as
+  the board)
 * Set the subnet mask to 255.255.255.0 and click **OK**
 
 Mac OS
---------------------------
-
-OS X
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+------
 
 * Open *System Preferences* then open *Network*
 * Click on the connection you want to set manually, usually `Ethernet`
 * From the Configure IPv4 drop down choose Manually
-* Set the IP address to 192.168.2.1 (or any other address in the same range as the board)
+* Set the IP address to 192.168.2.1 (or any other address in the same range as
+  the board)
 * Set the subnet mask to 255.255.255.0 and click **OK**
 
 The other settings can be left blank.
 
-
-
 Linux
---------------------------
+-----
 
 * Edit this file (replace gedit with your preferred text editor):
 
@@ -216,7 +317,8 @@ The file usually looks like this:
       iface eth0 inet dynamic
 
 
-* Make the following change to set the eth0 interface to the static IP address 192.168.2.1
+* Make the following change to set the eth0 interface to the static IP address
+  192.168.2.1
 
    .. code-block:: console
    

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -1,19 +1,21 @@
-.. _faq:
+.. _faqs:
 
-##################################
+*********************************
 Frequently Asked Questions (FAQs)
-##################################
+*********************************
 
-*******************************
-Connecting to the board
-*******************************
+Troubleshooting
+===============
 
-I can't connect to my board 
-=============================================
+I can't connect to my board!
+----------------------------
   
-1. Check the board is powered on (Red LED LD13) and that the bitstream has been loaded (Green "DONE" LED LD12)
+1. Check the board is powered on (Red LED LD13) and that the bitstream has been
+   loaded (Green "DONE" LED LD12)
 
-2. Your board and PC/laptop must be on the same network, or have a direct network connection. Check that you can *ping* the board (hostname, or IP address) from a command prompt or terminal on your host PC
+2. Your board and PC/laptop must be on the same network, or have a direct
+   network connection. Check that you can *ping* the board (hostname, or IP
+   address) from a command prompt or terminal on your host PC
    
    .. code-block:: console
    
@@ -27,34 +29,52 @@ or
       
    (The default IP address of the board is : 192.168.2.99)
    
-3. Log on to the board through a terminal, and check the system is running. i.e. that the Linux shell is accessible. See below for details on logging on with a terminal.
+3. Log on to the board through a terminal, and check the system is
+   running. i.e. that the Linux shell is accessible. See below for details on
+   logging on with a terminal.
 
-4. From a terminal, check you can ping the board from your host PC, and also ping your host PC from the board
+4. From a terminal, check you can ping the board from your host PC, and also
+   ping your host PC from the board
 
-   If you can't ping the board, or the host PC, check your network settings. 
+   If you can't ping the board, or the host PC, check your network settings.
          
-   * You must ensure board your PC and board are connected to the same network, and have IP addresses in the same range. If your network cables is connected directly to your PC/laptop and board, you may need to set a static IP address for your PC/laptop manually. See the  `Appendix: Assign your PC/Laptop a static ip address <appendix.html#assign-your-laptop-pc-a-static-ip-address>`_
+   * You must ensure board your PC and board are connected to the same network,
+     and have IP addresses in the same range. If your network cables is
+     connected directly to your PC/laptop and board, you may need to set a
+     static IP address for your PC/laptop manually. See
+     :ref:`assign-your-computer-a-static-ip`.
          
-   * If you have a proxy setup, you may need to add a rule to bypass the board hostname/ip address. 
+   * If you have a proxy setup, you may need to add a rule to bypass the board
+     hostname/ip address.
       
-   * If you are using a docking station, when your laptop is docked, the Ethernet port on the PC may be disabled.  
+   * If you are using a docking station, when your laptop is docked, the
+     Ethernet port on the PC may be disabled.
    
-My board is not powering on (No Red LED)
-==========================================
-The board can be powered by USB cable, or power adapter (7 - 15V V 2.1mm centre-positive barrel jack). Make sure Jumper JP5 is set to USB or REG (for power adapter). If powering the board via USB, make sure the USB port is fully powered. Laptops in low power mode may reduce the available power to a USB port. 
+My board is not powering on (No Red LED)!
+-----------------------------------------
 
-The bitstream is not loading (No Green LED)
-============================================ 
-* Check the Micro-SD card is inserted correctly (the socket is spring loaded, so push it in until you feel it click into place). 
+The board can be powered by USB cable, or power adapter (7 - 15V V 2.1mm
+centre-positive barrel jack). Make sure Jumper JP5 is set to USB or REG (for
+power adapter). If powering the board via USB, make sure the USB port is fully
+powered. Laptops in low power mode may reduce the available power to a USB port.
+
+The bitstream is not loading (No Green LED)!
+--------------------------------------------
+
+* Check the Micro-SD card is inserted correctly (the socket is spring loaded, so
+  push it in until you feel it click into place).
 * Check jumper JP4 is set to SD (board boots from Micro SD card).
 * Connect a terminal and verify that the Linux boot starts.
 
-If the Linux boot does not start, or fails, you may need to flash the Micro SD card with the PYNQ-Z1 image. 
+If the Linux boot does not start, or fails, you may need to flash the Micro SD
+card with the PYNQ-Z1 image.
 
-The hostname of the board is not resolving/not found
-=====================================================
+The hostname of the board is not resolving/not found!
+-----------------------------------------------------
 
-It may take the hostname (pynq) some time to resolve on your network. If you know the IP address of the board, it may be faster to use the IP address to navigate to the Jupyter portal instead of the hostname. 
+It may take the hostname (pynq) some time to resolve on your network. If you
+know the IP address of the board, it may be faster to use the IP address to
+navigate to the Jupyter portal instead of the hostname.
 
 e.g. In your browser, go to:
 
@@ -62,107 +82,125 @@ e.g. In your browser, go to:
    
       http://192.168.2.99:9090
 
-You need to know the IP address of the board first. You can find the IP by connecting a terminal to the board. You can run `ifconfig` in the Linux shell on the board to check the network settings. Check the settings for *eth0* and look for an IP address. 
+You need to know the IP address of the board first. You can find the IP by
+connecting a terminal to the board. You can run `ifconfig` in the Linux shell on
+the board to check the network settings. Check the settings for *eth0* and look
+for an IP address.
 
-I don't have an Ethernet port on my PC/Laptop
-==================================================
-If you don't have an Ethernet port, you can get a USB to Ethernet adapter. 
+I don't have an Ethernet port on my PC/Laptop!
+----------------------------------------------
 
-If you have a wireless router with Ethernet ports (LAN), you can connect your PYNQ-Z1 board to an Ethernet port on your router, and connect to it from your PC using WiFi. (You may need to change settings on your Router to enable the Wireless network to communicate with your LAN - check your equipment documentation for details.)
+If you don't have an Ethernet port, you can get a USB to Ethernet adapter.
+
+If you have a wireless router with Ethernet ports (LAN), you can connect your
+PYNQ-Z1 board to an Ethernet port on your router, and connect to it from your PC
+using WiFi. (You may need to change settings on your Router to enable the
+Wireless network to communicate with your LAN - check your equipment
+documentation for details.)
    
-You can also connect a WiFi dongle to the board, and set up the board to connect to the wireless network. Your host PC can then connect to the same wireless network to connect to the board. 
+You can also connect a WiFi dongle to the board, and set up the board to connect
+to the wireless network. Your host PC can then connect to the same wireless
+network to connect to the board.
 
 How do I setup my computer to connect to the board?
-=====================================================
+---------------------------------------------------
 
-If you are connecting your board to your network (i.e. you have plugged the Ethernet cable into the board, and the other end into a network switch, or home router), then you should not need to setup anything on your computer. Usually, both your computer, and board will be assigned an IP address automatically, and they will be able to communicate with each other. 
+If you are connecting your board to your network (i.e. you have plugged the
+Ethernet cable into the board, and the other end into a network switch, or home
+router), then you should not need to setup anything on your computer. Usually,
+both your computer, and board will be assigned an IP address automatically, and
+they will be able to communicate with each other.
 
-If you connect your board directly to your computer with an ethernet cable, then you need to make sure that they have IP addresses in the same range. The board will assign itself a static IP address (by default 192.168.2.99), and you will need to assign a static IP address in the same range to the computer.  This allows your computer and board to communicate to each other over the Ethernet cable. 
+If you connect your board directly to your computer with an ethernet cable, then
+you need to make sure that they have IP addresses in the same range. The board
+will assign itself a static IP address (by default 192.168.2.99), and you will
+need to assign a static IP address in the same range to the computer.  This
+allows your computer and board to communicate to each other over the Ethernet
+cable.
 
-See the  `Appendix: Assign your PC/Laptop a static ip address <appendix.html#assign-your-laptop-pc-a-static-ip-address>`_
+See :ref:`assign-your-computer-a-static-ip`
 
-I can't connect to the Jupyter portal
-=======================================
-My Board is powered on, and I see the Red and Green LEDs, but I can't connect to the Jupyter Portal, or see the Samba shared drive:
+I can't connect to the Jupyter portal!
+--------------------------------------
 
-By default, the board has DHCP enabled. If you plug the board into a home router, or network switch connected to your network, it should be allocated an IP address automatically. If not, it should fall back to a static IP address of `192.168.2.99`
+My Board is powered on, and I see the Red and Green LEDs, but I can't connect to
+the Jupyter Portal, or see the Samba shared drive:
+
+By default, the board has DHCP enabled. If you plug the board into a home
+router, or network switch connected to your network, it should be allocated an
+IP address automatically. If not, it should fall back to a static IP address of
+`192.168.2.99`
    
-If you plug the Ethernet cable directly to your computer, you will need to configure your network card to have an IP in the same address range. e.g. `192.168.2.1`
+If you plug the Ethernet cable directly to your computer, you will need to
+configure your network card to have an IP in the same address
+range. e.g. `192.168.2.1`
    
-My board is connected, and I have verified the IP addresses on the board and my network interface, but I cannot connect to the board.
+My board is connected, and I have verified the IP addresses on the board and my
+network interface, but I cannot connect to the board.
 
 VPN
-=====
-If your PC/laptop is connected to a VPN, and your board is not on the same VPN network, this will block access to local IP addresses. You need to disable the VPN, or set it to bypass the board address.
+^^^
+
+If your PC/laptop is connected to a VPN, and your board is not on the same VPN
+network, this will block access to local IP addresses. You need to disable the
+VPN, or set it to bypass the board address.
 
 Proxy
-==========
-If your board is connected to a network that uses a proxy, you need to set the proxy variables on the board
+^^^^^
+
+If your board is connected to a network that uses a proxy, you need to set the
+proxy variables on the board
 
    .. code-block:: console
    
       set http_proxy=my_http_proxy:8080
       set https_proxy=my_https_proxy:8080
 
-How do I connect to the board using a terminal?
-======================================================
-To do this, you need to connect to the board using a terminal.
-   
-To connect a terminal:
-Connect a Micro USB cable to the board and your PC/Laptop, and use a terminal emulator (puTTY, TeraTerm etc) to connect to the board. 
-   
-   Terminal Settings: 
-   
-   * 115200 baud
-   * 8 data bits
-   * 1 stop bit
-   * No Parity
-   * No Flow Control
-   
-
-Once you connect to the board, you can configure the network interface in Linux
-   
-***************************
 Board/Jupyter settings
-***************************
+======================
 
 How do I modify the board settings?
-======================================================
-Linux is installed on the board. Connect to the board using a terminal, and change the settings as you would for any other Linux machine.  
+-----------------------------------
+
+Linux is installed on the board. Connect to the board using a terminal, and
+change the settings as you would for any other Linux machine.
    
 How do I find the IP address of the board?
-======================================================
+------------------------------------------
 
-Connect to the board using a terminal (see above) and type 'hostname -I' to find the IP address for the eth0 Ethernet adapter or the WiFi dongle.
+Connect to the board using a terminal (see above) and type 'hostname -I' to find
+the IP address for the eth0 Ethernet adapter or the WiFi dongle.
    
 How do I set/change the static IP address on the board?
-========================================================
+-------------------------------------------------------
 
-The Static IP address is set in ``/etc/dhcp/dhclient.conf``  - you can modify the board's static IP here.
+The Static IP address is set in ``/etc/dhcp/dhclient.conf`` - you can modify the
+board's static IP here.
    
 How do I find my hostname?
-======================================================
+--------------------------
 
 Connect to the board using a terminal and run ``hostname``
    
 How do I change the hostname?
-======================================================
+-----------------------------
 
-If you have multiple boards on the same network, you should give them different host names. 
-You can change the hostname by editing the Linux hostname file:
+If you have multiple boards on the same network, you should give them different
+host names.  You can change the hostname by editing the Linux hostname file:
 
    .. code-block:: console
    
       /etc/hostname
    
 What is the user account and password?
-======================================================
+--------------------------------------
 
-Username and password for all Linux, jupyter and samba logins are: ``xilinx/xilinx``
+Username and password for all Linux, jupyter and samba logins are:
+``xilinx/xilinx``
    
 
-How do I enable/disable the Jupyter notebook password
-======================================================
+How do I enable/disable the Jupyter notebook password?
+------------------------------------------------------
 
 The Jupyter configuration file can be found at 
 
@@ -170,7 +208,8 @@ The Jupyter configuration file can be found at
    
       /root/.jupyter/jupyter_notebook_config.py
 
-You can add or comment out the c.NotebookApp.password to bypass the password authentication when connecting to the Jupyter Portal.
+You can add or comment out the c.NotebookApp.password to bypass the password
+authentication when connecting to the Jupyter Portal.
 
    .. code-block:: console
 
@@ -178,8 +217,9 @@ You can add or comment out the c.NotebookApp.password to bypass the password aut
 
 
 How do I change the Jupyter notebook password
-======================================================
-A hashed password is saved in the Jupyter Notebook configuration file. 
+---------------------------------------------
+
+A hashed password is saved in the Jupyter Notebook configuration file.
 
    .. code-block:: console
 
@@ -200,22 +240,48 @@ You can then add or modify the line in the `jupyter_notebook_config.py` file
 
       c.NotebookApp.password =u'sha1:6c2164fc2b22:ed55ecf07fc0f985ab46561483c0e888e8964ae6'
      
-*******************************
+
 General Questions
-*******************************     
-      
+=================
+
 Does Pynq support Python 2.7?
-======================================================
-Python 2.7 is loaded on Zynq® and Python 2.7 scripts can be executed. The PYNQ v1.5 release, is based on Python 3.6.  No attempts have been made to ensure backward compatibility with Python 2.7.
+-----------------------------
+
+Python 2.7 is loaded on Zynq® and Python 2.7 scripts can be executed. The PYNQ
+v2.0 release, is based on Python 3.6.  No attempts have been made to ensure
+backward compatibility with Python 2.7.
 
 
-How do I write the Micro SD card image
-=========================================
-You can find instructions in the `Appendix: Writing the SD card image <appendix.html#writing-the-sd-card-image>`_ 
+How do I write the Micro SD card image?
+---------------------------------------
+
+You can find instructions in :ref:`writing-the-sd-card`
 
 What type of Micro SD card do I need?
-=========================================
+-------------------------------------
 
-We recommend you use a card at least 8GB in size and at least class 4 speed rating. 
+We recommend you use a card at least 8GB in size and at least class 4 speed
+rating.
 
 
+How do I connect to the board using a terminal?
+-----------------------------------------------
+
+To do this, you need to connect to the board using a terminal.
+   
+To connect a terminal:
+
+Connect a Micro USB cable to the board and your PC/Laptop, and use a terminal
+emulator (puTTY, TeraTerm etc) to connect to the board.
+   
+   Terminal Settings: 
+   
+   * 115200 baud
+   * 8 data bits
+   * 1 stop bit
+   * No Parity
+   * No Flow Control
+   
+
+Once you connect to the board, you can configure the network interface in Linux
+   

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -49,11 +49,10 @@ To make your own PYNQ Micro-SD card:
         * Linux/MacOS: Use the built in *dd* command\*
    
 \* For detailed instructions for writing the SD card using different operating
-systems, see the `Appendix: Writing the SD card image
-<appendix.html#writing-the-sd-card-image>`_.
+systems, see :ref:`writing-the-sd-card`.
    
 Board Setup
---------------
+-----------
 
    .. image:: images/pynqz1_setup.jpg
       :align: center
@@ -130,8 +129,7 @@ without Internet access.
 | 3. Browse to  http://192.168.2.99:9090                 |
 +--------------------------------------------------------+
 
-\* See `Appendix: Assign your PC/Laptop a static IP address
-<appendix.html#assign-your-laptop-pc-a-static-ip-address>`_
+\* See :ref:`assign-your-computer-a-static-IP`
 
 Turning On the PYNQ-Z1
 ----------------------
@@ -344,6 +342,5 @@ your settings.
 Troubleshooting
 ===============
 
-If you are having problems, please see the `Frequently asked questions
-<faqs.html>`_ or go the `PYNQ support forum <http://www.pynq.io/support.html>`_
+If you are having problems, please see the :ref:`faqs` or go the `PYNQ support forum <http://www.pynq.io/support.html>`_
 

--- a/docs/source/overlay_design_methodology/microblaze_soft_processors/building_applications.rst
+++ b/docs/source/overlay_design_methodology/microblaze_soft_processors/building_applications.rst
@@ -12,9 +12,22 @@ can be built using a Makefile flow.
 IO Processors
 -------------
 
-As described in the previous section, an IOP can be used as a flexible controller for different types of external peripherals. The ARM® Cortex®-A9 is an application processor, which runs Pynq and Jupyter notebook on a Linux OS. This scenario is not well suited to real-time applications, which is a common requirement for an embedded systems.  In the base overlay there are three IOPs. As well as acting as a flexible controller, an IOP can be used as dedicated real-time controller.
+As described in the previous section, an IOP can be used as a flexible
+controller for different types of external peripherals. The ARM® Cortex®-A9 is
+an application processor, which runs Pynq and Jupyter notebook on a Linux
+OS. This scenario is not well suited to real-time applications, which is a
+common requirement for an embedded systems.  In the base overlay there are three
+IOPs. As well as acting as a flexible controller, an IOP can be used as
+dedicated real-time controller.
 
-IOPs can also be used standalone to offload some processing from the main processor. However, note that the MicroBlaze processor inside an IOP in the base overlay is running at 100 MHz, compared to the Dual-Core ARM Cortex-A9 running at 650 MHz. The clock speed, and different processor architectures and features should be taken into account when offloading pure application code. e.g. Vector processing on the ARM Cortex-A9 Neon processing unit will be much more efficient than running on the MicroBlaze. The MicroBlaze is most appropriate for low-level, background, or real-time applications.
+IOPs can also be used standalone to offload some processing from the main
+processor. However, note that the MicroBlaze processor inside an IOP in the base
+overlay is running at 100 MHz, compared to the Dual-Core ARM Cortex-A9 running
+at 650 MHz. The clock speed, and different processor architectures and features
+should be taken into account when offloading pure application code. e.g. Vector
+processing on the ARM Cortex-A9 Neon processing unit will be much more efficient
+than running on the MicroBlaze. The MicroBlaze is most appropriate for
+low-level, background, or real-time applications.
 
      
 Software Requirements
@@ -29,7 +42,7 @@ Vivado WebPack
 
 The full source code for all supported IOP peripherals is available from the
 project GitHub. Pynq ships with precompiled IOP executables to support various
-peripherals (see `Pynq Modules <modules.html>`_), so Xilinx software is only
+peripherals (see :ref:`pynq-libraries`), so Xilinx software is only
 needed if you intend to modify existing code, or build your own IOP
 applications/peripheral drivers.
 

--- a/docs/source/overlay_design_methodology/overlay_design.rst
+++ b/docs/source/overlay_design_methodology/overlay_design.rst
@@ -82,7 +82,7 @@ programmability. For example, an IOP can be used on Pmod, and Arduino
 interfaces. IP from the PYNQ DIO overlay can be reused to provide run-time
 configurability.
 
-See the previous section on `PYNQ IP <../pynq_ip_index.html>`_
+See the section :ref:`pynq-libraries`
 
 Zynq PS Settings
 ----------------

--- a/docs/source/pynq_libraries.rst
+++ b/docs/source/pynq_libraries.rst
@@ -1,3 +1,5 @@
+.. _pynq-libraries:
+
 **************
 PYNQ Libraries
 **************


### PR DESCRIPTION
* Changed inter-document references to use the :ref: command
* Standardized line length to 80 chars
* corrected heading levels in appendix and FAQ