### PR TITLE
raise warnings for clock management

### DIFF
--- a/pynq/notebooks/common/zynq_clocks.ipynb
+++ b/pynq/notebooks/common/zynq_clocks.ipynb
@@ -61,7 +61,9 @@
    "metadata": {},
    "source": [
     "### Set Clock Rates\n",
-    "The easiest way is to set the attributes directly. Random clock rates are used in the following examples; the clock manager will set the clock rates with best effort."
+    "The easiest way is to set the attributes directly. Random clock rates are used in the following examples; the clock manager will set the clock rates with best effort.\n",
+    "\n",
+    "If the desired frequency and the closest possible clock rate differs more than 1%, a warning will be raised."
    ]
   },
   {
@@ -77,7 +79,7 @@
       "FCLK0: 27.027027MHz\n",
       "FCLK1: 31.250000MHz\n",
       "FCLK2: 14.492754MHz\n",
-      "FCLK3: 52.631579MHz\n"
+      "FCLK3: 0.251953MHz\n"
      ]
     }
    ],
@@ -85,7 +87,7 @@
     "Clocks.fclk0_mhz = 27.123456\n",
     "Clocks.fclk1_mhz = 31.436546\n",
     "Clocks.fclk2_mhz = 14.597643\n",
-    "Clocks.fclk3_mhz = 53.894231\n",
+    "Clocks.fclk3_mhz = 0.251954\n",
     "\n",
     "print(f'CPU:   {Clocks.cpu_mhz:.6f}MHz')\n",
     "print(f'FCLK0: {Clocks.fclk0_mhz:.6f}MHz')\n",


### PR DESCRIPTION
1. Raise warnings when clock rate cannot be set within 1% of the desired frequency.
2. Updated notebook.