### PR TITLE
REVISION script update

### DIFF
--- a/sdbuild/packages/pynq/get_revision.sh
+++ b/sdbuild/packages/pynq/get_revision.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "Release $(date +'%Y_%m_%d') $(git describe)"
+echo "Release $(date +'%Y_%m_%d') $(git rev-parse --short --verify HEAD)"


### PR DESCRIPTION
update the REVISION script to contain only the date and the last commit hash ID.  
Tag information is removed.