### PR TITLE
Double-quote arguments to prevent word splitting

### DIFF
--- a/pynq/lib/usb_wifi.py
+++ b/pynq/lib/usb_wifi.py
@@ -91,7 +91,7 @@ class Usb_Wifi(object):
         """
 
         # get bash string into string format for key search
-        wifikey_str = sproc.check_output('wpa_passphrase {} {}'.format(ssid,
+        wifikey_str = sproc.check_output('wpa_passphrase "{}" "{}"'.format(ssid,
                                          password), shell=True)
         wifikey_tokens = wifikey_str.decode().split('\n')
 


### PR DESCRIPTION
SSID and password may contain spaces. This prevents word splitting.