### PR TITLE
[sdbuild] : Add Matplotlib in python_packages list

### DIFF
--- a/sdbuild/packages/python_packages/qemu.sh
+++ b/sdbuild/packages/python_packages/qemu.sh
@@ -13,6 +13,7 @@ pygraphviz --install-option=--include-path=/usr/include/graphviz --install-optio
 beautifulsoup4
 Bottleneck
 cffi
+matplotlib
 chardet
 html5lib
 jupyter


### PR DESCRIPTION
Matplotlib is a dependency for deltasigma but still it is better to explicitly add it to the required python_packages list.