### PR TITLE
Make Video Frames Cacheable

### DIFF
--- a/pynq/lib/video.py
+++ b/pynq/lib/video.py
@@ -250,7 +250,7 @@ class _FrameCache:
             if _FrameCache._xlnk is None:
                 _FrameCache._xlnk = Xlnk()
             frame = _FrameCache._xlnk.cma_array(
-                shape=self._mode.shape, dtype=np.uint8)
+                shape=self._mode.shape, dtype=np.uint8, cacheable=1)
         frame.original_freebuffer = frame.freebuffer
         frame.freebuffer = functools.partial(
             _FrameCache.returnframe, self, frame)
@@ -310,6 +310,7 @@ class AxiVDMA(DefaultIP):
 
         def __getitem__(self, index):
             frame = self._frames[index]
+            frame.invalidate()
             return frame
 
         def takeownership(self, index):
@@ -321,6 +322,7 @@ class AxiVDMA(DefaultIP):
         def __setitem__(self, index, frame):
             if self._frames[index] is not None:
                 self._frames[index].freebuffer()
+            frame.flush()
             self._frames[index] = frame
             if frame is not None:
                 self._mmio.write(self._offset + 4 * index,

--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -93,6 +93,20 @@ class ContiguousArray(np.ndarray):
         """
         self.freebuffer()
 
+    def flush(self):
+        """Flush the underlying memory if necessary
+
+        """
+        if self.cacheable:
+            Xlnk.libxlnk.cma_flush_cache(self.pointer, self.nbytes)
+
+    def invalidate(self):
+        """Invalidate the underlying memory if necessary
+
+        """
+        if self.cacheable:
+            Xlnk.libxlnk.cma_invalidate_cache(self.pointer, self.nbytes)
+
     def __enter__(self):
         return self
         
@@ -127,12 +141,14 @@ class Xlnk:
 
     ffi.cdef("""
     static uint32_t xlnkBufCnt = 0;
-    uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
-    uint32_t cma_munmap(void *buf, uint32_t len);
+    unsigned long cma_mmap(uint32_t phyAddr, uint32_t len);
+    unsigned long cma_munmap(void *buf, uint32_t len);
     void *cma_alloc(uint32_t len, uint32_t cacheable);
-    uint32_t cma_get_phy_addr(void *buf);
+    unsigned long cma_get_phy_addr(void *buf);
     void cma_free(void *buf);
     uint32_t cma_pages_available();
+    void cma_flush_cache(void* buf, int size);
+    void cma_invalidate_cache(void* buf, int size);
     void _xlnk_reset();
     """)
     if CPU_ARCH_IS_SUPPORTED:
@@ -264,7 +280,7 @@ class Xlnk:
         self.__check_buftype(buf)
         return self.ffi.buffer(buf, length)
     
-    def cma_array(self, shape, dtype=np.uint32):
+    def cma_array(self, shape, dtype=np.uint32, cacheable=0):
         """Get a contiguously allocated numpy array
 
         Create a numpy array with physically contiguously array. The
@@ -281,6 +297,8 @@ class Xlnk:
             The dimensions of the array to construct
         dtype : numpy.dtype or str
             The data type to construct - defaults to 32-bit unsigned int
+        cacheable : int
+            Whether the buffer should be cacheable - defaults to 0
 
         Returns
         -------
@@ -293,13 +311,14 @@ class Xlnk:
         dtype = np.dtype(dtype)
         elements = functools.reduce(lambda value, total: value * total, shape)
         length = elements * dtype.itemsize
-        buffer_pointer = self.cma_alloc(length)
+        buffer_pointer = self.cma_alloc(length, cacheable=cacheable)
         buffer = self.cma_get_buffer(buffer_pointer, length)
         array = np.frombuffer(buffer, dtype=dtype).reshape(shape)
         view = array.view(ContiguousArray)
         view.allocator = self
         view.pointer = buffer_pointer
         view.physical_address = self.cma_get_phy_addr(view.pointer)
+        view.cacheable = cacheable
         return view
 
     def cma_get_phy_addr(self, buf_ptr):

--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -98,14 +98,14 @@ class ContiguousArray(np.ndarray):
 
         """
         if self.cacheable:
-            Xlnk.libxlnk.cma_flush_cache(self.pointer, self.nbytes)
+            Xlnk.libxlnk.cma_flush_cache(self.pointer, self.physical_address, self.nbytes)
 
     def invalidate(self):
         """Invalidate the underlying memory if necessary
 
         """
         if self.cacheable:
-            Xlnk.libxlnk.cma_invalidate_cache(self.pointer, self.nbytes)
+            Xlnk.libxlnk.cma_invalidate_cache(self.pointer, self.physical_address, self.nbytes)
 
     def __enter__(self):
         return self
@@ -147,8 +147,8 @@ class Xlnk:
     unsigned long cma_get_phy_addr(void *buf);
     void cma_free(void *buf);
     uint32_t cma_pages_available();
-    void cma_flush_cache(void* buf, int size);
-    void cma_invalidate_cache(void* buf, int size);
+    void cma_flush_cache(void* buf, unsigned int phys_addr, int size);
+    void cma_invalidate_cache(void* buf, unsigned int phys_addr, int size);
     void _xlnk_reset();
     """)
     if CPU_ARCH_IS_SUPPORTED:

--- a/sdbuild/packages/libsds/xlnkutils/libxlnk_cma.h
+++ b/sdbuild/packages/libsds/xlnkutils/libxlnk_cma.h
@@ -52,5 +52,5 @@ uint32_t cma_pages_available();
 /*
  * Extra functions in case user needs to flush or invalidate Cache.
  */
-void xlnkFlushCache(void *buf, int size);
-void xlnkInvalidateCache(void *buf, int size);
+void cma_flush_cache(void *buf, int size);
+void cma_invalidate_cache(void *buf, int size);

--- a/sdbuild/packages/libsds/xlnkutils/libxlnk_cma.h
+++ b/sdbuild/packages/libsds/xlnkutils/libxlnk_cma.h
@@ -52,5 +52,5 @@ uint32_t cma_pages_available();
 /*
  * Extra functions in case user needs to flush or invalidate Cache.
  */
-void cma_flush_cache(void *buf, int size);
-void cma_invalidate_cache(void *buf, int size);
+void cma_flush_cache(void *buf, unsigned int phys_addr, int size);
+void cma_invalidate_cache(void *buf, unsigned int phys_addr, int size);

--- a/sdbuild/packages/libsds/xlnkutils/wrapper.c
+++ b/sdbuild/packages/libsds/xlnkutils/wrapper.c
@@ -17,8 +17,8 @@ void cf_xlnk_init(int arg);
 /* Functional prototpes from xlnk */
 
 unsigned long xlnkGetBufPhyAddr(void*);
-extern void xlnkFlushCache(void *buf, int size);
-extern void xlnkInvalidateCache(void *addr, int size);
+extern void xlnkFlushCache(unsigned int phys_addr, int size);
+extern void xlnkInvalidateCache(unsigned int phys_addr, int size);
 
 /* Required to avoid undefined symbol error */
 void add_sw_estimates(void) {}
@@ -86,7 +86,7 @@ void open_xlnk(void) {
     cf_xlnk_open(1);
 }
 
-void cma_flush_cache(void* buf, int size) {
+void cma_flush_cache(void* buf, unsigned int phys_addr, int size) {
 #ifdef __aarch64__
     uintptr_t begin = (uintptr_t)buf;
     uintptr_t line = begin &~0x3FULL;
@@ -106,14 +106,14 @@ void cma_flush_cache(void* buf, int size) {
     : "cc", "memory"
     );
 #else
-    xlnkFlushCache(buf, size);
+    xlnkFlushCache(phys_addr, size);
 #endif
 }
 
-void cma_invalidate_cache(void* buf, int size) {
+void cma_invalidate_cache(void* buf, unsigned int phys_addr, int size) {
 #ifdef __aarch64__
     cma_flush_cache(buf, size);
 #else
-    xlnkInvalidateCache(buf, size);
+    xlnkInvalidateCache(phys_addr, size);
 #endif
 }


### PR DESCRIPTION
This code adds a new `cacheable` option to the `cma_array` function and uses it for video frames and modifies the AxiDMA and VideoDMA to flush/invalidate as appropriate.