### PR TITLE
[sdbuild] : Remove lib32bz2-1.0 from the check environment 

### DIFF
--- a/sdbuild/scripts/check_Env.sh
+++ b/sdbuild/scripts/check_Env.sh
@@ -22,7 +22,6 @@ multistrap
 git
 lib32z1
 lib32ncurses5
-lib32bz2-1.0
 lib32stdc++6
 libgnutls-dev
 libssl-dev


### PR DESCRIPTION
lib32bz2-1.0 is no longer supported and is not required.