### PR TITLE
fix some small typo bugs

### DIFF
--- a/pynq/lib/led.py
+++ b/pynq/lib/led.py
@@ -61,7 +61,7 @@ class LED(object):
         
         """
         if index not in range(4):
-            raise Value("Index for onboard LEDs should be 0 - 3.")
+            raise ValueError("Index for onboard LEDs should be 0 - 3.")
             
         self.index = index
         if LED._mmio is None:

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -469,7 +469,7 @@ class ClocksMeta(type):
         fclk_div1 = clk_reg[CLK_DIV1_MSB:CLK_DIV1_LSB]
         if fclk_src in [0, 1]:
             fclk_mult = cls.io_pll_fdiv
-        elif src == 2:
+        elif fclk_src == 2:
             fclk_mult = cls.arm_pll_fdiv
         else:
             fclk_mult = cls.ddr_pll_fdiv


### PR DESCRIPTION
fix some small typo bugs
- `Value` to `ValueError` in `led.py`
- `src` to `fclk_src` in `ps.py`