### PR TITLE
LegacyDMA fix

### DIFF
--- a/pynq/lib/_pynq/_apf/Makefile
+++ b/pynq/lib/_pynq/_apf/Makefile
@@ -1,17 +1,19 @@
 CC = arm-linux-gnueabihf-gcc
 CPP = arm-linux-gnueabihf-g++
 
-INC := ../bsp/ps7_cortexa9_0/include
-SRC_DIR1 := ../bsp/ps7_cortexa9_0/libsrc/axidma_v9_1/src/xaxidma.c
-SRC_DIR2 := ../bsp/ps7_cortexa9_0/libsrc/standalone_v5_4/src/xil_io.c
-OBJ1 := xaxidma.o
-OBJ2 := xil_io.o
+INC_SRC = -I ../inc/ 
+INC_BSP = -I ../bsp/ps7_cortexa9_0/include/
+OBJ := axidma.o xil_io.o
 
-all:
-	$(CC) -fPIC -c $(SRC_DIR1) -I $(INC) -o $(OBJ1)
-	$(CC) -fPIC -c $(SRC_DIR2) -I $(INC) -o $(OBJ2)
-	$(CC) -g3 -gstabs -shared -fPIC -rdynamic $(OBJ1) $(OBJ2) -Wl,--start-group $(LIBS) -Wl,--end-group -o libdma.so
+all: $(OBJ)
+	$(CC) -g3 -gstabs -shared -fPIC -rdynamic $(OBJ) -Wl,--start-group $(LIBS) -Wl,--end-group -o libdma.so
 	rm *.o
+
+axidma.o:
+	$(CC) -fPIC $(INC_SRC) $(INC_BSP) -c -g3 -gstabs axidma.c
+
+xil_io.o:
+	$(CC) -fPIC $(INC_BSP) -c -g3 -gstabs ../bsp/ps7_cortexa9_0/libsrc/standalone_v6_5/src/xil_io.c
 
 clean:
 	rm -f *.o

--- a/pynq/lib/_pynq/_apf/axidma.c
+++ b/pynq/lib/_pynq/_apf/axidma.c
@@ -1,0 +1,965 @@
+/******************************************************************************
+ *  Copyright (c) 2018, Xilinx, Inc.
+ *  All rights reserved.
+ * 
+ *  Redistribution and use in source and binary forms, with or without 
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice, 
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright 
+ *      notice, this list of conditions and the following disclaimer in the 
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its 
+ *      contributors may be used to endorse or promote products derived from 
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file axidma.c
+*
+* This file overwrites some of the functions in xaxidma.c, with the major
+* changes of disabling XAxiDma_BdRingStart() function. Also, it addes a ew
+* function for disabling interrupts. 
+* The data type is also modified to be consistent with Python data types.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who  Date     Changes
+* ----- ---- -------- -------------------------------------------------------
+* 1.00  yrq  01/25/2018  Refactor the function change out of the xaxidma code
+* </pre>
+*
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+
+#include "axidma.h"
+
+/************************** Constant Definitions *****************************/
+
+/* Loop counter to check reset done
+ */
+#define XAXIDMA_RESET_TIMEOUT	500
+
+/**************************** Type Definitions *******************************/
+
+
+/***************** Macros (Inline Functions) Definitions *********************/
+
+
+/************************** Function Prototypes ******************************/
+static int AxiDma_Start(XAxiDma * InstancePtr);
+static int AxiDma_Started(XAxiDma * InstancePtr);
+
+/************************** Variable Definitions *****************************/
+
+/*****************************************************************************/
+/**
+ * This function initializes a DMA engine.  This function must be called
+ * prior to using a DMA engine. Initializing a engine includes setting
+ * up the register base address, setting up the instance data, and ensuring the
+ * hardware is in a quiescent state.
+ *
+ * @param	InstancePtr is a pointer to the DMA engine instance to be
+ *		worked on.
+ * @param	Config is a pointer to an XAxiDma_Config structure. It contains
+ *		the information about the hardware build, including base
+ *		address,and whether status control stream (StsCntrlStrm), MM2S
+ *		and S2MM are included in the build.
+ *
+ * @return
+ * 		- XST_SUCCESS for successful initialization
+ * 		- XST_INVALID_PARAM if pointer to the configuration structure
+ *		is NULL
+ * 		- XST_DMA_ERROR if reset operation failed at the end of
+ *		initialization
+ *
+ * @note	We assume the hardware building tool will check and error out
+ *		for a hardware build that has no transfer channels.
+ *****************************************************************************/
+int AxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config)
+{
+	UINTPTR BaseAddr;
+	int TimeOut;
+	int Index;
+	u32 MaxTransferLen;
+
+	InstancePtr->Initialized = 0;
+
+	if(!Config) {
+		return XST_INVALID_PARAM;
+	}
+
+	BaseAddr = Config->BaseAddr;
+
+	/* Setup the instance */
+	memset(InstancePtr, 0, sizeof(XAxiDma));
+	InstancePtr->RegBase = BaseAddr;
+
+	/* Get hardware setting information from the configuration structure
+	 */
+	InstancePtr->HasMm2S = Config->HasMm2S;
+	InstancePtr->HasS2Mm = Config->HasS2Mm;
+
+	InstancePtr->HasSg = Config->HasSg;
+
+	InstancePtr->MicroDmaMode = Config->MicroDmaMode;
+	InstancePtr->AddrWidth = Config->AddrWidth;
+
+	/* Get the number of channels */
+	InstancePtr->TxNumChannels = Config->Mm2sNumChannels;
+	InstancePtr->RxNumChannels = Config->S2MmNumChannels;
+
+	/* This condition is for IP version < 6.00a */
+	if (!InstancePtr->TxNumChannels)
+		InstancePtr->TxNumChannels = 1;
+	if (!InstancePtr->RxNumChannels)
+		InstancePtr->RxNumChannels = 1;
+
+	if ((InstancePtr->RxNumChannels > 1) ||
+		(InstancePtr->TxNumChannels > 1)) {
+		MaxTransferLen =
+			XAXIDMA_MCHAN_MAX_TRANSFER_LEN;
+	}
+	else {
+		MaxTransferLen =
+			XAXIDMA_MAX_TRANSFER_LEN;
+	}
+
+	/* Initialize the ring structures */
+	InstancePtr->TxBdRing.RunState = AXIDMA_CHANNEL_HALTED;
+	InstancePtr->TxBdRing.IsRxChannel = 0;
+	if (!InstancePtr->MicroDmaMode) {
+		InstancePtr->TxBdRing.MaxTransferLen = MaxTransferLen;
+	}
+	else {
+		/* In MicroDMA mode, Maximum length that can be transferred
+		 * is '(Memory Data Width / 4) * Burst Size'
+		 */
+		InstancePtr->TxBdRing.MaxTransferLen =
+				((Config->Mm2SDataWidth / 4) *
+				 Config->Mm2SBurstSize);
+	}
+	InstancePtr->TxBdRing.RingIndex = 0;
+
+	for (Index = 0; Index < InstancePtr->RxNumChannels; Index++) {
+		InstancePtr->RxBdRing[Index].RunState
+						 = AXIDMA_CHANNEL_HALTED;
+		InstancePtr->RxBdRing[Index].IsRxChannel = 1;
+		InstancePtr->RxBdRing[Index].RingIndex = Index;
+	}
+
+	if (InstancePtr->HasMm2S) {
+		InstancePtr->TxBdRing.ChanBase =
+				BaseAddr + XAXIDMA_TX_OFFSET;
+		InstancePtr->TxBdRing.HasStsCntrlStrm =
+					Config->HasStsCntrlStrm;
+		if (InstancePtr->AddrWidth > 32)
+			InstancePtr->TxBdRing.Addr_ext = 1;
+		else
+			InstancePtr->TxBdRing.Addr_ext = 0;
+
+		InstancePtr->TxBdRing.HasDRE = Config->HasMm2SDRE;
+		InstancePtr->TxBdRing.DataWidth =
+			((unsigned int)Config->Mm2SDataWidth >> 3);
+	}
+
+	if (InstancePtr->HasS2Mm) {
+		for (Index = 0;
+			Index < InstancePtr->RxNumChannels; Index++) {
+			InstancePtr->RxBdRing[Index].ChanBase =
+					BaseAddr + XAXIDMA_RX_OFFSET;
+			InstancePtr->RxBdRing[Index].HasStsCntrlStrm =
+					Config->HasStsCntrlStrm;
+			InstancePtr->RxBdRing[Index].HasDRE =
+					Config->HasS2MmDRE;
+			InstancePtr->RxBdRing[Index].DataWidth =
+			((unsigned int)Config->S2MmDataWidth >> 3);
+
+			if (!InstancePtr->MicroDmaMode) {
+				InstancePtr->RxBdRing[Index].MaxTransferLen =
+							MaxTransferLen;
+			}
+			else {
+			/* In MicroDMA mode, Maximum length that can be transferred
+			 * is '(Memory Data Width / 4) * Burst Size'
+			 */
+				InstancePtr->RxBdRing[Index].MaxTransferLen =
+						((Config->S2MmDataWidth / 4) *
+						Config->S2MmBurstSize);
+			}
+			if (InstancePtr->AddrWidth > 32)
+				InstancePtr->RxBdRing[Index].Addr_ext = 1;
+			else
+				InstancePtr->RxBdRing[Index].Addr_ext = 0;
+		}
+	}
+
+	/* Reset the engine so the hardware starts from a known state
+	 */
+	AxiDma_Reset(InstancePtr);
+
+	/* At the initialization time, hardware should finish reset quickly
+	 */
+	TimeOut = XAXIDMA_RESET_TIMEOUT;
+
+	while (TimeOut) {
+
+		if(AxiDma_ResetIsDone(InstancePtr)) {
+			break;
+		}
+
+		TimeOut -= 1;
+
+	}
+
+	if (!TimeOut) {
+		xdbg_printf(XDBG_DEBUG_ERROR, "Failed reset in"
+							"initialize\r\n");
+
+		/* Need system hard reset to recover
+		 */
+		InstancePtr->Initialized = 0;
+		return XST_DMA_ERROR;
+	}
+
+	/* Initialization is successful
+	 */
+	InstancePtr->Initialized = 1;
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+* Reset both TX and RX channels of a DMA engine.
+*
+* Reset one channel resets the whole AXI DMA engine.
+*
+* Any DMA transaction in progress will finish gracefully before engine starts
+* reset. Any other transactions that have been submitted to hardware will be
+* discarded by the hardware.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return	None
+*
+* @note		After the reset:
+*		- All interrupts are disabled.
+*		- Engine is halted
+*
+******************************************************************************/
+void AxiDma_Reset(XAxiDma * InstancePtr)
+{
+	u32 RegBase;
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+	int RingIndex;
+
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		/* Save the locations of current BDs both rings are working on
+		 * before the reset so later we can resume the rings smoothly.
+		 */
+		if(XAxiDma_HasSg(InstancePtr)){
+			XAxiDma_BdRingSnapShotCurrBd(TxRingPtr);
+
+			for (RingIndex = 0; RingIndex < InstancePtr->RxNumChannels;
+							RingIndex++) {
+				RxRingPtr = XAxiDma_GetRxIndexRing(InstancePtr,
+							RingIndex);
+				XAxiDma_BdRingSnapShotCurrBd(RxRingPtr);
+			}
+		}
+	}
+
+	/* Reset
+	 */
+	if (InstancePtr->HasMm2S) {
+		RegBase = InstancePtr->RegBase + XAXIDMA_TX_OFFSET;
+	}
+	else {
+		RegBase = InstancePtr->RegBase + XAXIDMA_RX_OFFSET;
+	}
+
+	XAxiDma_WriteReg(RegBase, XAXIDMA_CR_OFFSET, XAXIDMA_CR_RESET_MASK);
+
+	/* Set TX/RX Channel state */
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		TxRingPtr->RunState = AXIDMA_CHANNEL_HALTED;
+	}
+
+	if (InstancePtr->HasS2Mm) {
+		for (RingIndex = 0; RingIndex < InstancePtr->RxNumChannels;
+						RingIndex++) {
+			RxRingPtr = XAxiDma_GetRxIndexRing(InstancePtr, RingIndex);
+			if (InstancePtr->HasS2Mm) {
+				RxRingPtr->RunState = AXIDMA_CHANNEL_HALTED;
+			}
+		}
+	}
+}
+
+/*****************************************************************************/
+/**
+*
+* Check whether reset is done
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+* 		- 1 if reset is done.
+*		- 0 if reset is not done
+*
+* @note		None
+*
+******************************************************************************/
+int AxiDma_ResetIsDone(XAxiDma * InstancePtr)
+{
+	u32 RegisterValue;
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+
+	TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+	RxRingPtr = XAxiDma_GetRxRing(InstancePtr);
+
+	/* Check transmit channel
+	 */
+	if (InstancePtr->HasMm2S) {
+		RegisterValue = XAxiDma_ReadReg(TxRingPtr->ChanBase,
+			XAXIDMA_CR_OFFSET);
+
+		/* Reset is done when the reset bit is low
+		 */
+		if(RegisterValue & XAXIDMA_CR_RESET_MASK) {
+
+			return 0;
+		}
+	}
+
+	/* Check receive channel
+	 */
+	if (InstancePtr->HasS2Mm) {
+		RegisterValue = XAxiDma_ReadReg(RxRingPtr->ChanBase,
+				XAXIDMA_CR_OFFSET);
+
+		/* Reset is done when the reset bit is low
+		 */
+		if(RegisterValue & XAXIDMA_CR_RESET_MASK) {
+
+			return 0;
+		}
+	}
+
+	return 1;
+}
+/*****************************************************************************/
+/*
+* Start the DMA engine.
+*
+* Start a halted engine. Processing of BDs is not started.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+* 		- XST_SUCCESS for success
+* 		- XST_NOT_SGDMA if the driver instance has not been initialized
+* 		- XST_DMA_ERROR if starting the hardware channel fails
+*
+* @note		None
+*
+*****************************************************************************/
+static int AxiDma_Start(XAxiDma * InstancePtr)
+{
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+	int Status;
+	int RingIndex = 0;
+
+	if (!InstancePtr->Initialized) {
+
+		xdbg_printf(XDBG_DEBUG_ERROR, "Start: Driver not initialized "
+				"%d\r\n", InstancePtr->Initialized);
+
+		return XST_NOT_SGDMA;
+	}
+
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		if (TxRingPtr->RunState == AXIDMA_CHANNEL_HALTED) {
+
+			/* Start the channel
+			 */
+			if(XAxiDma_HasSg(InstancePtr)) {
+				if (Status != XST_SUCCESS) {
+					xdbg_printf(XDBG_DEBUG_ERROR,
+					"Start hw tx channel failed %d\r\n",
+								Status);
+
+					return XST_DMA_ERROR;
+				}
+			}
+			else {
+				XAxiDma_WriteReg(TxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET,
+					XAxiDma_ReadReg(TxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET)
+					| XAXIDMA_CR_RUNSTOP_MASK);
+			}
+			TxRingPtr->RunState = AXIDMA_CHANNEL_NOT_HALTED;
+		}
+	}
+
+	if (InstancePtr->HasS2Mm) {
+
+		for (RingIndex = 0; RingIndex < InstancePtr->RxNumChannels;
+						RingIndex++) {
+			RxRingPtr = XAxiDma_GetRxIndexRing(InstancePtr,
+							 RingIndex);
+
+			if (RxRingPtr->RunState != AXIDMA_CHANNEL_HALTED) {
+				return XST_SUCCESS;
+			}
+
+			/* Start the channel
+			 */
+			if(XAxiDma_HasSg(InstancePtr)) {
+				if (Status != XST_SUCCESS) {
+					xdbg_printf(XDBG_DEBUG_ERROR,
+					"Start hw tx channel failed %d\r\n",
+								Status);
+
+					return XST_DMA_ERROR;
+				}
+			}
+			else {
+				XAxiDma_WriteReg(RxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET,
+					XAxiDma_ReadReg(RxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET) |
+					XAXIDMA_CR_RUNSTOP_MASK);
+			}
+
+			RxRingPtr->RunState = AXIDMA_CHANNEL_NOT_HALTED;
+		}
+	}
+
+	return XST_SUCCESS;
+}
+/*****************************************************************************/
+/**
+* Pause DMA transactions on both channels.
+*
+* If the engine is running and doing transfers, this function does not stop
+* the DMA transactions immediately, because then hardware will throw away
+* our previously queued transfers. All submitted transfers will finish.
+* Transfers submitted after this function will not start until
+* XAxiDma_BdRingStart() or AxiDma_Resume() is called.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+* 		- XST_SUCCESS if successful
+* 		- XST_NOT_SGDMA, if the driver instance is not initialized
+*
+* @note		None
+*
+*****************************************************************************/
+int AxiDma_Pause(XAxiDma * InstancePtr)
+{
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+	int RingIndex = 0;
+
+	if (!InstancePtr->Initialized) {
+
+		xdbg_printf(XDBG_DEBUG_ERROR, "Pause: Driver not initialized"
+					" %d\r\n",InstancePtr->Initialized);
+
+		return XST_NOT_SGDMA;
+	}
+
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		/* If channel is halted, then we do not need to do anything
+		 */
+		if(!XAxiDma_HasSg(InstancePtr)) {
+			XAxiDma_WriteReg(TxRingPtr->ChanBase,
+				XAXIDMA_CR_OFFSET,
+				XAxiDma_ReadReg(TxRingPtr->ChanBase,
+				XAXIDMA_CR_OFFSET)
+				& ~XAXIDMA_CR_RUNSTOP_MASK);
+		}
+
+		TxRingPtr->RunState = AXIDMA_CHANNEL_HALTED;
+	}
+
+	if (InstancePtr->HasS2Mm) {
+		for (RingIndex = 0; RingIndex < InstancePtr->RxNumChannels;
+				RingIndex++) {
+			RxRingPtr = XAxiDma_GetRxIndexRing(InstancePtr, RingIndex);
+
+			/* If channel is halted, then we do not need to do anything
+			 */
+
+			if(!XAxiDma_HasSg(InstancePtr) && !RingIndex) {
+				XAxiDma_WriteReg(RxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET,
+					XAxiDma_ReadReg(RxRingPtr->ChanBase,
+					XAXIDMA_CR_OFFSET)
+					& ~XAXIDMA_CR_RUNSTOP_MASK);
+			}
+
+			RxRingPtr->RunState = AXIDMA_CHANNEL_HALTED;
+		}
+	}
+
+	return XST_SUCCESS;
+
+}
+
+/*****************************************************************************/
+/**
+* Resume DMA transactions on both channels.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+*		- XST_SUCCESS for success
+*		- XST_NOT_SGDMA if the driver instance has not been initialized
+*		- XST_DMA_ERROR if one of the channels fails to start
+*
+* @note		None
+*
+*****************************************************************************/
+int AxiDma_Resume(XAxiDma * InstancePtr)
+{
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+	int Status;
+	int RingIndex = 0;
+
+	if (!InstancePtr->Initialized) {
+
+		xdbg_printf(XDBG_DEBUG_ERROR, "Resume: Driver not initialized"
+		" %d\r\n",InstancePtr->Initialized);
+
+		return XST_NOT_SGDMA;
+	}
+
+	/* If the DMA engine is not running, start it. Start may fail.
+	 */
+	if (!AxiDma_Started(InstancePtr)) {
+		Status = AxiDma_Start(InstancePtr);
+
+		if (Status != XST_SUCCESS) {
+			xdbg_printf(XDBG_DEBUG_ERROR, "Resume: failed to start"
+				" engine %d\r\n", Status);
+
+			return Status;
+		}
+	}
+
+	/* Mark the state to be not halted
+	 */
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		if(XAxiDma_HasSg(InstancePtr)) {
+			if (Status != XST_SUCCESS) {
+				xdbg_printf(XDBG_DEBUG_ERROR, "Resume: failed"
+				" to start tx ring %d\r\n", Status);
+
+				return XST_DMA_ERROR;
+			}
+		}
+
+		TxRingPtr->RunState = AXIDMA_CHANNEL_NOT_HALTED;
+	}
+
+	if (InstancePtr->HasS2Mm) {
+		for (RingIndex = 0 ; RingIndex < InstancePtr->RxNumChannels;
+					RingIndex++) {
+			RxRingPtr = XAxiDma_GetRxIndexRing(InstancePtr, RingIndex);
+
+			if(XAxiDma_HasSg(InstancePtr)) {
+				if (Status != XST_SUCCESS) {
+					xdbg_printf(XDBG_DEBUG_ERROR, "Resume: failed"
+					"to start rx ring %d\r\n", Status);
+
+					return XST_DMA_ERROR;
+				}
+			}
+
+			RxRingPtr->RunState = AXIDMA_CHANNEL_NOT_HALTED;
+		}
+	}
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/*
+* Check whether the DMA engine is started.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+*		- 1 if engine is started
+*		- 0 otherwise.
+*
+* @note		None
+*
+*****************************************************************************/
+static int AxiDma_Started(XAxiDma * InstancePtr)
+{
+	XAxiDma_BdRing *TxRingPtr;
+	XAxiDma_BdRing *RxRingPtr;
+
+	if (!InstancePtr->Initialized) {
+
+		xdbg_printf(XDBG_DEBUG_ERROR, "Started: Driver not initialized"
+		" %d\r\n",InstancePtr->Initialized);
+
+		return 0;
+	}
+
+	if (InstancePtr->HasMm2S) {
+		TxRingPtr = XAxiDma_GetTxRing(InstancePtr);
+
+		if (!XAxiDma_BdRingHwIsStarted(TxRingPtr)) {
+			xdbg_printf(XDBG_DEBUG_ERROR,
+				"Started: tx ring not started\r\n");
+
+			return 0;
+		}
+	}
+
+	if (InstancePtr->HasS2Mm) {
+		RxRingPtr = XAxiDma_GetRxRing(InstancePtr);
+
+		if (!XAxiDma_BdRingHwIsStarted(RxRingPtr)) {
+			xdbg_printf(XDBG_DEBUG_ERROR,
+				"Started: rx ring not started\r\n");
+
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+/*****************************************************************************/
+/**
+ * This function checks whether specified DMA channel is busy
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ *
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ *
+ * @return	- TRUE if channel is busy
+ *		- FALSE if channel is idle
+ *
+ * @note	None.
+ *
+ *****************************************************************************/
+u32 AxiDma_Busy(XAxiDma *InstancePtr, int Direction)
+{
+
+	return ((XAxiDma_ReadReg(InstancePtr->RegBase +
+				(XAXIDMA_RX_OFFSET * Direction),
+				XAXIDMA_SR_OFFSET) &
+				XAXIDMA_IDLE_MASK) ? FALSE : TRUE);
+}
+
+
+/*****************************************************************************/
+/**
+ * This function Enable or Disable KeyHole Feature
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ *
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ * @Select	Select is the option to enable (TRUE) or disable (FALSE).
+ *
+ * @return	- XST_SUCCESS for success
+ *
+ * @note	None.
+ *
+ *****************************************************************************/
+int AxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, int Select)
+{
+	u32 Value;
+
+	Value = XAxiDma_ReadReg(InstancePtr->RegBase +
+				(XAXIDMA_RX_OFFSET * Direction),
+				XAXIDMA_CR_OFFSET);
+
+	if (Select)
+		Value |= XAXIDMA_CR_KEYHOLE_MASK;
+	else
+		Value &= ~XAXIDMA_CR_KEYHOLE_MASK;
+
+	XAxiDma_WriteReg(InstancePtr->RegBase +
+			(XAXIDMA_RX_OFFSET * Direction),
+			XAXIDMA_CR_OFFSET, Value);
+
+	return XST_SUCCESS;
+
+}
+
+/*****************************************************************************/
+/**
+ * This function Enable or Disable Cyclic Mode Feature
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ *
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ * @Select	Select is the option to enable (TRUE) or disable (FALSE).
+ *
+ * @return	- XST_SUCCESS for success
+ *
+ * @note	None.
+ *
+ *****************************************************************************/
+int AxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, int Select)
+{
+	u32 Value;
+
+	Value = XAxiDma_ReadReg(InstancePtr->RegBase +
+				(XAXIDMA_RX_OFFSET * Direction),
+				XAXIDMA_CR_OFFSET);
+
+	if (Select)
+		Value |= XAXIDMA_CR_CYCLIC_MASK;
+	else
+		Value &= ~XAXIDMA_CR_CYCLIC_MASK;
+
+	XAxiDma_WriteReg(InstancePtr->RegBase +
+			(XAXIDMA_RX_OFFSET * Direction),
+			XAXIDMA_CR_OFFSET, Value);
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function does one simple transfer submission
+ *
+ * It checks in the following sequence:
+ *	- if engine is busy, cannot submit
+ *	- if engine is in SG mode , cannot submit
+ *
+ * @param	InstancePtr is the pointer to the driver instance
+ * @param	BuffAddr is the address of the source/destination buffer
+ * @param	Length is the length of the transfer
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+
+ * @return
+ *		- XST_SUCCESS for success of submission
+ *		- XST_FAILURE for submission failure, maybe caused by:
+ *		Another simple transfer is still going
+ *		- XST_INVALID_PARAM if:Length out of valid range [1:8M]
+ *		Or, address not aligned when DRE is not built in
+ *
+ * @note	This function is used only when system is configured as
+ *		Simple mode.
+ *
+ *****************************************************************************/
+u32 AxiDma_SimpleTransfer(XAxiDma *InstancePtr, UINTPTR BuffAddr, u32 Length,
+	int Direction)
+{
+	u32 WordBits;
+	int RingIndex = 0;
+
+	/* If Scatter Gather is included then, cannot submit
+	 */
+	if (XAxiDma_HasSg(InstancePtr)) {
+		xdbg_printf(XDBG_DEBUG_ERROR, "Simple DMA mode is not"
+							" supported\r\n");
+
+		return XST_FAILURE;
+	}
+
+	if(Direction == XAXIDMA_DMA_TO_DEVICE){
+		if ((Length < 1) ||
+			(Length > InstancePtr->TxBdRing.MaxTransferLen)) {
+			return XST_INVALID_PARAM;
+		}
+
+		if (!InstancePtr->HasMm2S) {
+			xdbg_printf(XDBG_DEBUG_ERROR, "MM2S channel is not"
+							"supported\r\n");
+
+			return XST_FAILURE;
+		}
+
+		/* If the engine is doing transfer, cannot submit
+		 */
+
+		if(!(XAxiDma_ReadReg(InstancePtr->TxBdRing.ChanBase,
+				XAXIDMA_SR_OFFSET) & XAXIDMA_HALTED_MASK)) {
+			if (AxiDma_Busy(InstancePtr,Direction)) {
+				xdbg_printf(XDBG_DEBUG_ERROR,
+							"Engine is busy\r\n");
+				return XST_FAILURE;
+			}
+		}
+
+		if (!InstancePtr->MicroDmaMode) {
+			WordBits = (u32)((InstancePtr->TxBdRing.DataWidth) - 1);
+		}
+		else {
+			WordBits = XAXIDMA_MICROMODE_MIN_BUF_ALIGN;
+		}
+
+		if ((BuffAddr & WordBits)) {
+
+			if (!InstancePtr->TxBdRing.HasDRE) {
+				xdbg_printf(XDBG_DEBUG_ERROR,
+					"Unaligned transfer without"
+					" DRE %x\r\n",(unsigned int)BuffAddr);
+
+				return XST_INVALID_PARAM;
+			}
+		}
+
+
+		XAxiDma_WriteReg(InstancePtr->TxBdRing.ChanBase,
+				 XAXIDMA_SRCADDR_OFFSET, LOWER_32_BITS(BuffAddr));
+		if (InstancePtr->AddrWidth > 32)
+			XAxiDma_WriteReg(InstancePtr->TxBdRing.ChanBase,
+					 XAXIDMA_SRCADDR_MSB_OFFSET,
+					 UPPER_32_BITS(BuffAddr));
+
+		XAxiDma_WriteReg(InstancePtr->TxBdRing.ChanBase,
+				XAXIDMA_CR_OFFSET,
+				XAxiDma_ReadReg(
+				InstancePtr->TxBdRing.ChanBase,
+				XAXIDMA_CR_OFFSET)| XAXIDMA_CR_RUNSTOP_MASK);
+
+		/* Writing to the BTT register starts the transfer
+		 */
+		XAxiDma_WriteReg(InstancePtr->TxBdRing.ChanBase,
+					XAXIDMA_BUFFLEN_OFFSET, Length);
+	}
+	else if(Direction == XAXIDMA_DEVICE_TO_DMA){
+		if ((Length < 1) ||
+			(Length >
+			InstancePtr->RxBdRing[RingIndex].MaxTransferLen)) {
+			return XST_INVALID_PARAM;
+		}
+
+
+		if (!InstancePtr->HasS2Mm) {
+			xdbg_printf(XDBG_DEBUG_ERROR, "S2MM channel is not"
+							" supported\r\n");
+
+			return XST_FAILURE;
+		}
+
+		if(!(XAxiDma_ReadReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+				XAXIDMA_SR_OFFSET) & XAXIDMA_HALTED_MASK)) {
+			if (AxiDma_Busy(InstancePtr,Direction)) {
+				xdbg_printf(XDBG_DEBUG_ERROR,
+							"Engine is busy\r\n");
+				return XST_FAILURE;
+			}
+		}
+
+		if (!InstancePtr->MicroDmaMode) {
+			WordBits =
+			 (u32)((InstancePtr->RxBdRing[RingIndex].DataWidth) - 1);
+		}
+		else {
+			WordBits = XAXIDMA_MICROMODE_MIN_BUF_ALIGN;
+		}
+
+		if ((BuffAddr & WordBits)) {
+
+			if (!InstancePtr->RxBdRing[RingIndex].HasDRE) {
+				xdbg_printf(XDBG_DEBUG_ERROR,
+					"Unaligned transfer without"
+				" DRE %x\r\n", (unsigned int)BuffAddr);
+
+				return XST_INVALID_PARAM;
+			}
+		}
+
+
+		XAxiDma_WriteReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+				 XAXIDMA_DESTADDR_OFFSET, LOWER_32_BITS(BuffAddr));
+		if (InstancePtr->AddrWidth > 32)
+			XAxiDma_WriteReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+					 XAXIDMA_DESTADDR_MSB_OFFSET,
+					 UPPER_32_BITS(BuffAddr));
+
+		XAxiDma_WriteReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+				XAXIDMA_CR_OFFSET,
+			XAxiDma_ReadReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+			XAXIDMA_CR_OFFSET)| XAXIDMA_CR_RUNSTOP_MASK);
+		/* Writing to the BTT register starts the transfer
+		 */
+		XAxiDma_WriteReg(InstancePtr->RxBdRing[RingIndex].ChanBase,
+					XAXIDMA_BUFFLEN_OFFSET, Length);
+
+	}
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function disables the interrupts for all DMA transactions.
+ *
+ * @param	InstancePtr is the pointer to the DMA instance
+ *
+ * @return	None
+ *
+ * @note	This function is customized only for PYNQ.
+ *
+ *****************************************************************************/
+void AxiDma_DisableInterruptsAll(XAxiDma * InstancePtr)
+{
+	XAxiDma_IntrDisable(InstancePtr,XAXIDMA_IRQ_ALL_MASK, 
+        XAXIDMA_DMA_TO_DEVICE);
+	XAxiDma_IntrDisable(InstancePtr,XAXIDMA_IRQ_ALL_MASK, 
+        XAXIDMA_DEVICE_TO_DMA);
+}

--- a/pynq/lib/_pynq/inc/axidma.h
+++ b/pynq/lib/_pynq/inc/axidma.h
@@ -1,0 +1,335 @@
+/******************************************************************************
+ *  Copyright (c) 2018, Xilinx, Inc.
+ *  All rights reserved.
+ * 
+ *  Redistribution and use in source and binary forms, with or without 
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice, 
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright 
+ *      notice, this list of conditions and the following disclaimer in the 
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its 
+ *      contributors may be used to endorse or promote products derived from 
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************/
+/*****************************************************************************/
+/**
+*
+* @file axidma.h
+*
+* This file overwrites some of the functions in xaxidma.c, with the major
+* changes of disabling XAxiDma_BdRingStart() function. Also, it addes a ew
+* function for disabling interrupts. 
+* The data type is also modified to be consistent with Python data types.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who  Date     Changes
+* ----- ---- -------- -------------------------------------------------------
+* 1.00  yrq  01/25/2018  Refactor the function change out of the xaxidma code
+* </pre>
+*
+******************************************************************************/
+
+#ifndef _AXIDMA_H_   /* prevent circular inclusions */
+#define _AXIDMA_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************** Include Files *********************************/
+#include "xaxidma_bdring.h"
+#include <string.h>
+#include "xil_cache.h"
+
+/************************** Constant Definitions *****************************/
+
+
+/**************************** Type Definitions *******************************/
+
+/**
+ * The XAxiDma driver instance data. An instance must be allocated for each DMA
+ * engine in use.
+ */
+typedef struct XAxiDma {
+	u32 RegBase;		/* Virtual base address of DMA engine */
+
+	int HasMm2S;		/* Has transmit channel */
+	int HasS2Mm;		/* Has receive channel */
+	int Initialized;	/* Driver has been initialized */
+	int HasSg;
+
+	XAxiDma_BdRing TxBdRing;     /* BD container management for TX channel */
+	XAxiDma_BdRing RxBdRing[16]; /* BD container management for RX channel */
+	int TxNumChannels;
+	int RxNumChannels;
+	int MicroDmaMode;
+	int AddrWidth;		  /**< Address Width */
+} XAxiDma;
+
+/**
+ * The configuration structure for AXI DMA engine
+ *
+ * This structure passes the hardware building information to the driver
+ */
+typedef struct {
+	u32 DeviceId;
+	UINTPTR BaseAddr;
+
+	int HasStsCntrlStrm;
+	int HasMm2S;
+	int HasMm2SDRE;
+	int Mm2SDataWidth;
+	int HasS2Mm;
+	int HasS2MmDRE;
+	int S2MmDataWidth;
+	int HasSg;
+	int Mm2sNumChannels;
+	int S2MmNumChannels;
+	int Mm2SBurstSize;
+	int S2MmBurstSize;
+	int MicroDmaMode;
+	int AddrWidth;		  /**< Address Width */
+} XAxiDma_Config;
+
+
+/***************** Macros (Inline Functions) Definitions *********************/
+/*****************************************************************************/
+/**
+* Get Transmit (Tx) Ring ptr
+*
+* Warning: This has a different API than the LLDMA driver. It now returns
+* the pointer to the BD ring.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return	Pointer to the Tx Ring
+*
+* @note		C-style signature:
+* 		XAxiDma_BdRing * XAxiDma_GetTxRing(XAxiDma * InstancePtr)
+* 		This function is used only when system is configured as SG mode
+*
+*****************************************************************************/
+#define XAxiDma_GetTxRing(InstancePtr) \
+			(&((InstancePtr)->TxBdRing))
+
+/*****************************************************************************/
+/**
+* Get Receive (Rx) Ring ptr
+*
+* Warning: This has a different API than the LLDMA driver. It now returns
+* the pointer to the BD ring.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return	Pointer to the Rx Ring
+*
+* @note
+* 		C-style signature:
+* 		XAxiDma_BdRing * XAxiDma_GetRxRing(XAxiDma * InstancePtr)
+*		This function is used only when system is configured as SG mode
+*
+*****************************************************************************/
+#define XAxiDma_GetRxRing(InstancePtr) \
+			(&((InstancePtr)->RxBdRing[0]))
+
+/*****************************************************************************/
+/**
+* Get Receive (Rx) Ring ptr of a Index
+*
+* Warning: This has a different API than the LLDMA driver. It now returns
+* the pointer to the BD ring.
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+* @param	RingIndex is the channel Index.
+*
+* @return	Pointer to the Rx Ring
+*
+* @note
+* 		C-style signature:
+* 		XAxiDma_BdRing * XAxiDma_GetRxIndexRing(XAxiDma * InstancePtr,
+						int RingIndex)
+*		This function is used only when system is configured as SG mode
+*
+*****************************************************************************/
+#define XAxiDma_GetRxIndexRing(InstancePtr, RingIndex) \
+			(&((InstancePtr)->RxBdRing[RingIndex]))
+
+/*****************************************************************************/
+/**
+* This function checks whether system is configured as Simple or
+* Scatter Gather mode
+*
+* @param	InstancePtr is a pointer to the DMA engine instance to be
+*		worked on.
+*
+* @return
+*		- TRUE if configured as SG mode
+*		- FALSE if configured as simple mode
+*
+* @note		None
+*
+*****************************************************************************/
+#define XAxiDma_HasSg(InstancePtr)	((InstancePtr)->HasSg) ? TRUE : FALSE
+
+/*****************************************************************************/
+/**
+ * This function enables interrupts specified by the Mask in specified
+ * direction, Interrupts that are not in the mask are not affected.
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ * @param	Mask is the mask for the interrupts to be enabled
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ * @return	None
+ *
+ * @note	None
+ *
+ *****************************************************************************/
+#define  XAxiDma_IntrEnable(InstancePtr, Mask, Direction) 	\
+	XAxiDma_WriteReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_CR_OFFSET, \
+			(XAxiDma_ReadReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_CR_OFFSET)) \
+			| (Mask & XAXIDMA_IRQ_ALL_MASK))
+
+
+/*****************************************************************************/
+/**
+ * This function gets the mask for the interrupts that are currently enabled
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ *
+ * @return	The bit mask for the interrupts that are currently enabled
+ *
+ * @note	None
+ *
+ *****************************************************************************/
+#define   XAxiDma_IntrGetEnabled(InstancePtr, Direction)	\
+			XAxiDma_ReadReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_CR_OFFSET) &\
+							XAXIDMA_IRQ_ALL_MASK)
+
+
+
+/*****************************************************************************/
+/**
+ * This function disables interrupts specified by the Mask. Interrupts that
+ * are not in the mask are not affected.
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ * @param	Mask is the mask for the interrupts to be disabled
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ * @return	None
+ *
+ * @note	None
+ *
+ *****************************************************************************/
+ #define XAxiDma_IntrDisable(InstancePtr, Mask, Direction)	\
+		XAxiDma_WriteReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_CR_OFFSET, \
+			(XAxiDma_ReadReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_CR_OFFSET)) \
+			& ~(Mask & XAXIDMA_IRQ_ALL_MASK))
+
+
+/*****************************************************************************/
+/**
+ * This function gets the interrupts that are asserted.
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ *
+ * @return	The bit mask for the interrupts asserted.
+ *
+ * @note	None
+ *
+ *****************************************************************************/
+#define  XAxiDma_IntrGetIrq(InstancePtr, Direction)	\
+			(XAxiDma_ReadReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_SR_OFFSET) &\
+							XAXIDMA_IRQ_ALL_MASK)
+
+/*****************************************************************************/
+/**
+ * This function acknowledges the interrupts that are specified in Mask
+ *
+ * @param	InstancePtr is the driver instance we are working on
+ * @param	Mask is the mask for the interrupts to be acknowledge
+ * @param	Direction is DMA transfer direction, valid values are
+ *			- XAXIDMA_DMA_TO_DEVICE.
+ *			- XAXIDMA_DEVICE_TO_DMA.
+ *
+ * @return	None
+ *
+ * @note	None.
+ *
+ *****************************************************************************/
+#define  XAxiDma_IntrAckIrq(InstancePtr, Mask, Direction)	\
+			XAxiDma_WriteReg((InstancePtr)->RegBase + \
+			(XAXIDMA_RX_OFFSET * Direction), XAXIDMA_SR_OFFSET, \
+			(Mask) & XAXIDMA_IRQ_ALL_MASK)
+
+
+
+/************************** Function Prototypes ******************************/
+
+/*
+ * Initialization and control functions in axidma.c
+ */
+XAxiDma_Config *XAxiDma_LookupConfig(u32 DeviceId);
+XAxiDma_Config *XAxiDma_LookupConfigBaseAddr(u32 Baseaddr);
+/*
+ * Modified functions in axidma.c
+ */
+int AxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config);
+void AxiDma_Reset(XAxiDma * InstancePtr);
+int AxiDma_ResetIsDone(XAxiDma * InstancePtr);
+int AxiDma_Pause(XAxiDma * InstancePtr);
+int AxiDma_Resume(XAxiDma * InstancePtr);
+u32 AxiDma_Busy(XAxiDma *InstancePtr,int Direction);
+u32 AxiDma_SimpleTransfer(XAxiDma *InstancePtr, UINTPTR BuffAddr, u32 Length,
+	int Direction);
+int AxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, int Select);
+int AxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, int Select);
+int AxiDma_Selftest(XAxiDma * InstancePtr);
+/*
+ * New functions added in axidma.c
+ */
+void AxiDma_DisableInterruptsAll(XAxiDma * InstancePtr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of protection macro */

--- a/pynq/lib/dma.py
+++ b/pynq/lib/dma.py
@@ -29,7 +29,6 @@
 
 from pynq import DefaultIP
 import os
-import sys
 import cffi
 import functools
 import signal
@@ -41,6 +40,7 @@ from pynq.ps import CPU_ARCH_IS_SUPPORTED, CPU_ARCH
 __author__ = 'Peter Ogden, Anurag Dubey'
 __copyright__ = 'Copyright 2017, Xilinx'
 __email__ = 'pynq_support@xilinx.com'
+
 
 class timeout:
     """Internal timeout functions.
@@ -62,6 +62,7 @@ class timeout:
 
     def __exit__(self, type, value, traceback):
         signal.alarm(0)
+
 
 class LegacyDMA:
     """Python class which controls DMA.
@@ -105,38 +106,40 @@ class LegacyDMA:
     typedef unsigned int* XAxiDma_Bd[20];
 
     typedef struct {
-        uint32_t ChanBase;           /**< physical base address*/
-        int IsRxChannel;        /**< Is this a receive channel */
-        volatile int RunState;  /**< Whether channel is running */
-        int HasStsCntrlStrm;    /**< Whether has stscntrl stream */
+        uint32_t ChanBase;		/**< physical base address*/
+        int IsRxChannel;	/**< Is this a receive channel */
+        volatile int RunState;	/**< Whether channel is running */
+        int HasStsCntrlStrm; 	/**< Whether has stscntrl stream */
         int HasDRE;
         int DataWidth;
         int Addr_ext;
         uint32_t MaxTransferLen;
 
-        uint32_t * FirstBdPhysAddr; /**< Physical address of 1st BD in list */
-        uint32_t * FirstBdAddr;  /**< Virtual address of 1st BD in list */
-        uint32_t * LastBdAddr;  /**< Virtual address of last BD in the list */
-        uint32_t Length;         /**< Total size of ring in bytes */
-        uint32_t * Separation;  /**< Number of bytes between the starting
-                                     address of adjacent BDs */
-        XAxiDma_Bd *FreeHead;   /**< First BD in the free group */
-        XAxiDma_Bd *PreHead;    /**< First BD in the pre-work group */
-        XAxiDma_Bd *HwHead;     /**< First BD in the work group */
-        XAxiDma_Bd *HwTail;     /**< Last BD in the work group */
-        XAxiDma_Bd *PostHead;   /**< First BD in the post-work group */
-        XAxiDma_Bd *BdaRestart; /**< BD to load when channel is started */
-        int FreeCnt;            /**< Number of allocatable BDs in free group */
-        int PreCnt;             /**< Number of BDs in pre-work group */
-        int HwCnt;              /**< Number of BDs in work group */
-        int PostCnt;            /**< Number of BDs in post-work group */
-        int AllCnt;             /**< Total Number of BDs for channel */
-        int RingIndex;          /**< Ring Index */
+        uint32_t* FirstBdPhysAddr;	/**< Physical address of 1st BD in list */
+        uint32_t* FirstBdAddr;	/**< Virtual address of 1st BD in list */
+        uint32_t* LastBdAddr;	/**< Virtual address of last BD in the list */
+        uint32_t Length;		/**< Total size of ring in bytes */
+        uint32_t* Separation;		/**< Number of bytes between the starting 
+        address of adjacent BDs */
+        XAxiDma_Bd *FreeHead;	/**< First BD in the free group */
+        XAxiDma_Bd *PreHead;	/**< First BD in the pre-work group */
+        XAxiDma_Bd *HwHead;	/**< First BD in the work group */
+        XAxiDma_Bd *HwTail;	/**< Last BD in the work group */
+        XAxiDma_Bd *PostHead;	/**< First BD in the post-work group */
+        XAxiDma_Bd *BdaRestart;	/**< BD to load when channel is started */
+        XAxiDma_Bd *CyclicBd;	/**< Useful for Cyclic DMA operations */
+        int FreeCnt;		/**< Number of allocatable BDs in free group */
+        int PreCnt;		/**< Number of BDs in pre-work group */
+        int HwCnt;		/**< Number of BDs in work group */
+        int PostCnt;		/**< Number of BDs in post-work group */
+        int AllCnt;		/**< Total Number of BDs for channel */
+        int RingIndex;		/**< Ring Index */
+        int Cyclic;		/**< Check for cyclic DMA Mode */
     } XAxiDma_BdRing;
 
     typedef struct {
         uint32_t DeviceId;
-        uint32_t * BaseAddr;
+        uint32_t* BaseAddr;
 
         int HasStsCntrlStrm;
         int HasMm2S;
@@ -151,38 +154,38 @@ class LegacyDMA:
         int Mm2SBurstSize;
         int S2MmBurstSize;
         int MicroDmaMode;
-        int AddrWidth;            /**< Address Width */
+        int AddrWidth;		  /**< Address Width */
     } XAxiDma_Config;
 
     typedef struct XAxiDma {
-        uint32_t RegBase;            /* Virtual base address of DMA engine */
-        int HasMm2S;            /* Has transmit channel */
-        int HasS2Mm;            /* Has receive channel */
-        int Initialized;        /* Driver has been initialized */
+        uint32_t RegBase;		/* Virtual base address of DMA engine */
+        int HasMm2S;		/* Has transmit channel */
+        int HasS2Mm;		/* Has receive channel */
+        int Initialized;	/* Driver has been initialized */
         int HasSg;
-        XAxiDma_BdRing TxBdRing;     /* BD container management */
-        XAxiDma_BdRing RxBdRing[16]; /* BD container management */
+
+        XAxiDma_BdRing TxBdRing;
+        XAxiDma_BdRing RxBdRing[16];
         int TxNumChannels;
         int RxNumChannels;
         int MicroDmaMode;
-        int AddrWidth;            /**< Address Width */
+        int AddrWidth;		  /**< Address Width */
     } XAxiDma;
 
-    unsigned int getMemoryMap(unsigned int phyAddr, unsigned int len);
-    unsigned int getPhyAddr(void *buf);
-    void frame_free(void *buf);
-    int XAxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config);
-    void XAxiDma_Reset(XAxiDma * InstancePtr);
-    int XAxiDma_ResetIsDone(XAxiDma * InstancePtr);
-    int XAxiDma_Pause(XAxiDma * InstancePtr);
-    int XAxiDma_Resume(XAxiDma * InstancePtr);
-    uint32_t XAxiDma_Busy(XAxiDma *InstancePtr,int Direction);
-    uint32_t XAxiDma_SimpleTransfer(XAxiDma *InstancePtr,\
-    uint32_t * BuffAddr, uint32_t Length,int Direction);
-    int XAxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, int Select);
-    int XAxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, int Select);
-    int XAxiDma_Selftest(XAxiDma * InstancePtr);
-    void DisableInterruptsAll(XAxiDma * InstancePtr);
+    int AxiDma_CfgInitialize(XAxiDma * InstancePtr, XAxiDma_Config *Config);
+    void AxiDma_Reset(XAxiDma * InstancePtr);
+    int AxiDma_ResetIsDone(XAxiDma * InstancePtr);
+    int AxiDma_Pause(XAxiDma * InstancePtr);
+    int AxiDma_Resume(XAxiDma * InstancePtr);
+    uint32_t AxiDma_Busy(XAxiDma *InstancePtr,int Direction);
+    uint32_t AxiDma_SimpleTransfer(XAxiDma *InstancePtr, uint32_t* BuffPtr, 
+                                uint32_t Length, int Direction);
+    int AxiDma_SelectKeyHole(XAxiDma *InstancePtr, int Direction, 
+                                int Select);
+    int AxiDma_SelectCyclicMode(XAxiDma *InstancePtr, int Direction, 
+                                int Select);
+    int AxiDma_Selftest(XAxiDma * InstancePtr);
+    void AxiDma_DisableInterruptsAll(XAxiDma * InstancePtr);
     """)
     LIB_SEARCH_PATH = os.path.dirname(os.path.realpath(__file__))
     if CPU_ARCH_IS_SUPPORTED:
@@ -190,7 +193,7 @@ class LegacyDMA:
     else:
         warnings.warn("Pynq does not support the CPU Architecture: {}"
                       .format(CPU_ARCH), ResourceWarning)
-        
+
     DMA_TO_DEV = 0
     DMA_FROM_DEV = 1
     DMA_BIDIRECTIONAL = 3
@@ -220,12 +223,12 @@ class LegacyDMA:
 
     memapi.cdef("""
     static uint32_t xlnkBufCnt = 0;
-    uint32_t cma_mmap(uint32_t phyAddr, uint32_t len);
-    uint32_t cma_munmap(void *buf, uint32_t len);
+    unsigned long cma_mmap(unsigned long phyAddr, uint32_t len);
+    uint32_t cma_munmap(void* buf, uint32_t len);
     void *cma_alloc(uint32_t len, uint32_t cacheable);
-    uint32_t cma_get_phy_addr(void *buf);
+    unsigned long cma_get_phy_addr(void *buf);
     void cma_free(void *buf);
-    uint32_t cma_pages_available();
+    uint32_t cma_pages_available(void);
     """)
 
     if CPU_ARCH_IS_SUPPORTED:
@@ -265,19 +268,22 @@ class LegacyDMA:
 
         """
         self.buf = None
+        self._bufPtr = None
         self.direction = direction
         self.bufLength = None
         self.phyAddress = address
         self.DMAengine = self.ffi.new("XAxiDma *")
         self.DMAinstance = self.ffi.new("XAxiDma_Config *")
         self.Configuration = {}
+        self._TransferInitiated = 0
         self._gen_config(address, direction, attr_dict)
 
-        status = self.libdma.XAxiDma_CfgInitialize(self.DMAengine, self.DMAinstance)
+        status = self.libdma.AxiDma_CfgInitialize(self.DMAengine,
+                                                  self.DMAinstance)
         if status != 0:
             raise RuntimeError("Failed to initialize DMA!")
-        self.libdma.XAxiDma_Reset(self.DMAengine)
-        self.libdma.DisableInterruptsAll(self.DMAengine)
+        self.libdma.AxiDma_Reset(self.DMAengine)
+        self.libdma.AxiDma_DisableInterruptsAll(self.DMAengine)
 
     def _gen_config(self, address, direction, attr_dict):
         """Build configuration and map memory.
@@ -297,11 +303,11 @@ class LegacyDMA:
         self._bufPtr = None
         self._TransferInitiated = 0
         if attr_dict is not None:
-            if type(attr_dict) == dict:
+            if type(attr_dict) is dict:
                 for key in attr_dict.keys():
                     self.DMAinstance.__setattr__(key, attr_dict[key])
             else:
-                print("Warning: Expecting 3rd Arg to be a dict.")
+                raise ValueError("Expecting 3rd Arg to be a dict.")
 
         virt = self.libxlnk.cma_mmap(address, 0x10000)
         if virt == -1:
@@ -318,10 +324,6 @@ class LegacyDMA:
 
         Frees the internal buffer and Resets the DMA.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         None
@@ -329,7 +331,7 @@ class LegacyDMA:
         """
         if self.buf is not None and self.buf is not self.ffi.NULL:
             self.free_buf()
-        self.libdma.XAxiDma_Reset(self.DMAengine)
+        self.libdma.AxiDma_Reset(self.DMAengine)
 
     def transfer(self, num_bytes=-1, direction=-1):
         """Transfer data using DMA (Non-blocking).
@@ -375,12 +377,10 @@ class LegacyDMA:
             raise RuntimeError("Invalid direction for transfer.")
         self.direction = direction
         if self.buf is not None:
-            self.libdma.XAxiDma_SimpleTransfer(
-                self.DMAengine,
-                self._bufPtr,
-                num_bytes,
-                self.direction
-            )
+            if self.libdma.AxiDma_SimpleTransfer(
+                    self.DMAengine, self._bufPtr,
+                    num_bytes, self.direction) != 0:
+                raise RuntimeError("DMA transfer failed.")
             self._TransferInitiated = 1
         else:
             raise RuntimeError("Buffer not allocated.")
@@ -422,8 +422,8 @@ class LegacyDMA:
         else:
             self.libxlnk.cma_free(self.buf)
             self.buf = self.libxlnk.cma_alloc(num_bytes, cacheable)
-        bufPhyAddr = self.libxlnk.cma_get_phy_addr(self.buf)
-        self._bufPtr = self.ffi.cast("uint32_t *", bufPhyAddr)
+        buf_addr = self.libxlnk.cma_get_phy_addr(self.buf)
+        self._bufPtr = self.ffi.cast("uint32_t *", buf_addr)
         self.bufLength = num_bytes
 
     def free_buf(self):
@@ -431,10 +431,6 @@ class LegacyDMA:
 
         Use this to free a previously allocated memory buffer.
         This is specially useful for reallocations.
-
-        Parameters
-        ----------
-        None
 
         Returns
         -------
@@ -462,11 +458,11 @@ class LegacyDMA:
         """
         if self._TransferInitiated == 0:
             return
-        Error = "DMA wait timed out."
-        with timeout(seconds=wait_timeout, error_message=Error):
+        error = "DMA wait timed out."
+        with timeout(seconds=wait_timeout, error_message=error):
             while True:
-                if self.libdma.XAxiDma_Busy(self.DMAengine,
-                                            self.direction) == 0:
+                if self.libdma.AxiDma_Busy(self.DMAengine,
+                                           self.direction) == 0:
                     break
 
     def get_buf(self, width=32):


### PR DESCRIPTION
* remove dependency on function `XAxiDma_BdRingStart()`. Examples include:
https://github.com/Xilinx/PYNQ/blob/image_v2.1/pynq/lib/_pynq/bsp/ps7_cortexa9_0/libsrc/axidma_v9_1/src/xaxidma.c#L445
These changes should stay outside of the original BSP source code.