### PR TITLE
Fix typo in UART Arduino IOP

### DIFF
--- a/boards/sw_repo/pynqmb/src/uart.c
+++ b/boards/sw_repo/pynqmb/src/uart.c
@@ -51,22 +51,22 @@
 #include <xparameters.h>
 #include "uart.h"
 
-#ifdef XPAR_XUART_NUM_INSTANCES
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
 #include "xuartlite.h"
 #include "xuartlite_i.h"
-static XUartLite xuart[XPAR_XUART_NUM_INSTANCES];
+static XUartLite xuart[XPAR_XUARTLITE_NUM_INSTANCES];
 XUartLite* xuart_ptr = &xuart[0];
-extern XUartLite_Config XUartLite_ConfigTable[XPAR_XUART_NUM_INSTANCES];
+extern XUartLite_Config XUartLite_ConfigTable[XPAR_XUARTLITE_NUM_INSTANCES];
 
 /************************** Function Definitions ***************************/
 uart uart_open_device(unsigned int device){
     int status;
     u16 dev_id;
-    if (device < XPAR_XUART_NUM_INSTANCES) {
+    if (device < XPAR_XUARTLITE_NUM_INSTANCES) {
         dev_id = (u16)device;
     } else {
         int found = 0;
-        for (u16 i = 0; i < XPAR_XUART_NUM_INSTANCES; ++i) {
+        for (u16 i = 0; i < XPAR_XUARTLITE_NUM_INSTANCES; ++i) {
             if (XUartLite_ConfigTable[i].RegBaseAddr == device) {
                 found = 1;
                 dev_id = i;
@@ -89,7 +89,7 @@ uart uart_open_device(unsigned int device){
 static int last_tx = -1;
 static int last_rx = -1;
 
-uart uart_open(unsigned int tx, unsigned int int rx){
+uart uart_open(unsigned int tx, unsigned int rx){
     if (last_tx != -1) set_pin(last_tx, GPIO);
     if (last_rx != -1) set_pin(last_rx, GPIO);
     last_tx = tx;
@@ -118,7 +118,7 @@ void uart_close(uart dev_id){
 
 
 unsigned int uart_get_num_devices(void){
-    return XPAR_XUART_NUM_INSTANCES;
+    return XPAR_XUARTLITE_NUM_INSTANCES;
 }
 
 #endif

--- a/boards/sw_repo/pynqmb/src/uart.h
+++ b/boards/sw_repo/pynqmb/src/uart.h
@@ -53,7 +53,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_XUART_NUM_INSTANCES
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
 
 /* 
  * UART API
@@ -61,7 +61,7 @@
 typedef int uart;
 
 uart uart_open_device(unsigned int device);
-uart uart_open(unsigned int tx, unsigned int int rx);
+uart uart_open(unsigned int tx, unsigned int rx);
 void uart_read(uart dev_id, char* read_data, unsigned int length);
 void uart_write(uart dev_id, char* write_data, unsigned int length);
 void uart_close(uart dev_id);


### PR DESCRIPTION
Fixed bug and created PR for the issue discussed here: 
URGENT: UART Arduino IOP - Typos & help fixing it
https://groups.google.com/forum/#!topic/pynq_project/rgXq6egbmuI