### PR TITLE
Zero out Microblaze memory not covered by the binary

### DIFF
--- a/pynq/lib/pynqmicroblaze/pynqmicroblaze.py
+++ b/pynq/lib/pynqmicroblaze/pynqmicroblaze.py
@@ -258,7 +258,7 @@ class PynqMicroblaze:
 
         """
         self.reset()
-        PL.load_ip_data(self.ip_name, self.mb_program)
+        PL.load_ip_data(self.ip_name, self.mb_program, zero=True)
         if self.interrupt:
             self.interrupt.clear()
         self.run()

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -887,7 +887,7 @@ class PLMeta(type):
         cls._interrupt_pins.clear()
         cls._hierarchy_dict.clear()
 
-    def load_ip_data(cls, ip_name, data):
+    def load_ip_data(cls, ip_name, data, zero=False):
         """This method writes data to the addressable IP.
 
         Note
@@ -901,6 +901,8 @@ class PLMeta(type):
             The name of the addressable IP.
         data : str
             The absolute path of the data to be loaded.
+        zero : bool
+            Zero out the address of the IP not covered by data
 
         Returns
         -------
@@ -909,11 +911,15 @@ class PLMeta(type):
         """
         cls.client_request()
         with open(data, 'rb') as bin_file:
-            size = int((math.ceil(os.fstat(bin_file.fileno()).st_size /
-                                  mmap.PAGESIZE)) * mmap.PAGESIZE)
-            mmio = MMIO(cls._ip_dict[ip_name]['phys_addr'], size)
+            size = os.fstat(bin_file.fileno()).st_size
+            target_size = cls._ip_dict[ip_name]['addr_range']
+            if size > target_size:
+                raise RuntimeError("Binary file too big for IP")
+            mmio = MMIO(cls._ip_dict[ip_name]['phys_addr'], target_size)
             buf = bin_file.read(size)
             mmio.write(0, buf)
+            if zero and size < target_size:
+                mmio.write(size, b'\x00' * (target_size - size))
 
         cls._ip_dict[ip_name]['state'] = data
         cls.server_update()


### PR DESCRIPTION
This ensures that any global variables are correctly initialised
to 0 - it is assumed by GCC compiled code that memory below
the data segment is zero initialised prior to loading the text and
data sections so zero-initialised variables may not be explicitly zeroed
in the .bin file.