### PR TITLE
pynqmb: SPI transfer supports read w/o write (and visa versa)

### DIFF
--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -174,13 +174,20 @@ void spi_transfer(spi dev_id, const char *write_data, char *read_data,
     unsigned volatile char j;
     unsigned int base_address = xspi[dev_id].BaseAddr;
 
+    XSpi_WriteReg(base_address, XSP_SSR_OFFSET, 0xfe);
     if (write_data) {
-        XSpi_WriteReg(base_address, XSP_SSR_OFFSET, 0xfe);
         for (i = 0; i < length; i++) {
             XSpi_WriteReg(base_address, XSP_DTR_OFFSET, write_data[i]);
         }
-        while (((XSpi_ReadReg(base_address, XSP_SR_OFFSET) & 0x04)) != 0x04);
     }
+    else {
+        /* Behavior for no data to write while reading is to write
+         * zeroes */
+        for (i = 0; i < length; i++) {
+            XSpi_WriteReg(base_address, XSP_DRR_OFFSET, 0);
+        }
+    }
+    while (((XSpi_ReadReg(base_address, XSP_SR_OFFSET) & 0x04)) != 0x04);
 
     // delay for 10 clock cycles
     j = 10;

--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -174,13 +174,13 @@ void spi_transfer(spi dev_id, const char *write_data, char *read_data,
     unsigned volatile char j;
     unsigned int base_address = xspi[dev_id].BaseAddr;
 
-    XSpi_WriteReg(base_address, XSP_SSR_OFFSET, 0xfe);
     if (write_data) {
+        XSpi_WriteReg(base_address, XSP_SSR_OFFSET, 0xfe);
         for (i = 0; i < length; i++) {
             XSpi_WriteReg(base_address, XSP_DTR_OFFSET, write_data[i]);
         }
+        while (((XSpi_ReadReg(base_address, XSP_SR_OFFSET) & 0x04)) != 0x04);
     }
-    while (((XSpi_ReadReg(base_address, XSP_SR_OFFSET) & 0x04)) != 0x04);
 
     // delay for 10 clock cycles
     j = 10;

--- a/boards/sw_repo/pynqmb/src/spi.h
+++ b/boards/sw_repo/pynqmb/src/spi.h
@@ -62,14 +62,14 @@
 typedef int spi;
 
 spi spi_open_device(unsigned int device);
-spi spi_open(unsigned int spiclk, unsigned int miso, 
+spi spi_open(unsigned int spiclk, unsigned int miso,
              unsigned int mosi, unsigned int ss);
-spi spi_configure(spi dev_id, unsigned int clk_phase, 
-                   unsigned int clk_polarity);
-void spi_transfer(spi dev_id, const char* write_data, char* read_data, 
+spi spi_configure(spi dev_id, unsigned int clk_phase,
+                  unsigned int clk_polarity);
+void spi_transfer(spi dev_id, const char *write_data, char *read_data,
                   unsigned int length);
 void spi_close(spi dev_id);
 unsigned int spi_get_num_devices(void);
 
 #endif
-#endif  // _SPI_H_
+#endif                          // _SPI_H_


### PR DESCRIPTION
This is changes that we made to use pynqmb with PyBlaze, the SPI transfer function should support the ability to write without reading, and the ability to read without writing. The simple format to do this was to simply pass ``NULL`` for either ``read_data`` or ``write_data``.

We also cleaned up some sloppy/inconsistent coding style in this module. 