### PR TITLE
Initialised ZCU104 Video when downloading overlay

### DIFF
--- a/boards/ZCU104/base/base.py
+++ b/boards/ZCU104/base/base.py
@@ -8,25 +8,30 @@ class BaseOverlay(pynq.Overlay):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.is_loaded():
-            # Make sure this is set until we can do this automatically
-            axi_config = MMIO(0xFF419000, 0x4)
-            axi_config.write(0,0)
-            # Wait for AXI reset to de-assert
-            time.sleep(0.2)
-            # Deassert HDMI clock reset
-            self.reset_control.channel1[0].write(1)
-            # Wait 200 ms for the clock to come out of reset
-            time.sleep(0.2)
             self.iop_pmod0.mbtype = "Pmod"
             self.iop_pmod1.mbtype = "Pmod"
-            self.video.hdmi_in.frontend.set_phy(
-                    self.video.phy.vid_phy_controller)
-            self.video.hdmi_out.frontend.set_phy(
-                    self.video.phy.vid_phy_controller)
-            dp159 = DP159(self.fmch_axi_iic, 0x5C)
-            idt = IDT_8T49N24(self.fmch_axi_iic, 0x6C)
-            self.video.hdmi_out.frontend.clocks.extend([dp159, idt])
             self.PMOD0 = self.iop_pmod0.mb_info
             self.PMOD1 = self.iop_pmod1.mb_info
             self.PMODA = self.PMOD0
             self.PMODB = self.PMOD1
+
+    def download(self):
+        super().download()
+        self._init_clocks()
+
+    def _init_clocks(self):
+        # Wait for AXI reset to de-assert
+        time.sleep(0.2)
+        # Deassert HDMI clock reset
+        self.reset_control.channel1[0].write(1)
+        # Wait 200 ms for the clock to come out of reset
+        time.sleep(0.2)
+
+        self.video.phy.vid_phy_controller.initialize()
+        self.video.hdmi_in.frontend.set_phy(
+                self.video.phy.vid_phy_controller)
+        self.video.hdmi_out.frontend.set_phy(
+                self.video.phy.vid_phy_controller)
+        dp159 = DP159(self.fmch_axi_iic, 0x5C)
+        idt = IDT_8T49N24(self.fmch_axi_iic, 0x6C)
+        self.video.hdmi_out.frontend.clocks = [dp159, idt]

--- a/boards/ZCU104/base/base.py
+++ b/boards/ZCU104/base/base.py
@@ -14,6 +14,15 @@ class BaseOverlay(pynq.Overlay):
             self.PMOD1 = self.iop_pmod1.mb_info
             self.PMODA = self.PMOD0
             self.PMODB = self.PMOD1
+            self.leds = self.gpio_leds.channel1
+            self.leds.setdirection('out')
+            self.leds.setlength(4)
+            self.buttons = self.gpio_btns.channel1
+            self.buttons.setdirection('in')
+            self.buttons.setlength(4)
+            self.switches = self.gpio_sws.channel1
+            self.switches.setdirection('in')
+            self.switches.setlength(4)
 
     def download(self):
         super().download()

--- a/pynq/lib/video/xilinx_hdmi.py
+++ b/pynq/lib/video/xilinx_hdmi.py
@@ -101,6 +101,8 @@ class Vphy(DefaultIP):
         if _hdmi_lib is None:
             raise RuntimeError("No Xilinx HDMI Library")
         super().__init__(description)
+
+    def initialize(self):
         self._virtaddr = self.mmio.array.ctypes.data
         self.handle = _hdmi_lib.HdmiPhy_new(self._virtaddr)
 


### PR DESCRIPTION
This commit allows for base.download() to correctly initialise
the clocks and reset and means that BaseOverlay(download=false)
doesn't cause the video output to reset.