### PR TITLE
Use FPGA manager for Zynq-7000 designs

### DIFF
--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -1602,7 +1602,6 @@ class _BitstreamMeta:
 
         """
         self._download()
-        self._update_pl()
         if not self.partial:
             self._update_pl()
 

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -1623,53 +1623,8 @@ class _BitstreamMeta:
         PL.server_update()
 
 
-class _BitstreamZynq(_BitstreamMeta):
-    """This class instantiates a PL bitstream for Zynq.
-
-    Note
-    ----
-    This class inherits from the _BitstreamMeta class
-
-    """
-    BS_IS_PARTIAL = "/sys/devices/soc0/amba/f8007000.devcfg/" \
-                    "is_partial_bitstream"
-    BS_XDEVCFG = "/dev/xdevcfg"
-
-    def _download(self):
-        """The method to download the bitstream onto PL.
-
-        Note
-        ----
-        The class variables held by the singleton PL will also be updated.
-
-        Returns
-        -------
-        None
-
-        """
-        if not os.path.exists(self.BS_XDEVCFG):
-            raise RuntimeError("Could not find programmable device")
-
-        # Compose bitfile name, open bitfile
-        with open(self.bitfile_name, 'rb') as f:
-            buf = f.read()
-
-        # Set is_partial_bitfile device attribute to the appropriate value
-        with open(self.BS_IS_PARTIAL, 'w') as fd:
-            if self.partial:
-                fd.write('1')
-            else:
-                fd.write('0')
-
-        PL.shutdown()
-
-        # Write bitfile to xdevcfg device
-        with open(self.BS_XDEVCFG, 'wb') as f:
-            f.write(buf)
-
-
-class _BitstreamUltrascale(_BitstreamMeta):
-    """This class instantiates a PL bitstream for Zynq Ultrascale.
+class Bitstream(_BitstreamMeta):
+    """This class instantiates a PL bitstream using FPGA manager to download
 
     Note
     ----
@@ -1795,15 +1750,3 @@ class _BitstreamUltrascale(_BitstreamMeta):
                 else:
                     raise RuntimeError("Unknown field: {}".format(hex(desc)))
             return bit_dict
-
-
-if CPU_ARCH == ZU_ARCH:
-    Bitstream = _BitstreamUltrascale
-elif CPU_ARCH == ZYNQ_ARCH:
-    Bitstream = _BitstreamZynq
-else:
-    # Use the _BitstreamMeta class as the Bitstream implementation
-    # so that the docs get built correctly
-    Bitstream = _BitstreamMeta
-    warnings.warn("PYNQ does not support the CPU Architecture: {}"
-                  .format(CPU_ARCH), ResourceWarning)


### PR DESCRIPTION
Looks like xdevcfg has disappeared but luckily the ZU+ code download works