### PR TITLE
Always load libgomp.so on Python start for aarch64

### DIFF
--- a/sdbuild/ubuntu/bionic/aarch64/patch/etc/python3.6/sitecustomize.py.diff
+++ b/sdbuild/ubuntu/bionic/aarch64/patch/etc/python3.6/sitecustomize.py.diff
@@ -1,0 +1,10 @@
+--- a/sitecustomize.py	2018-09-06 14:10:15.383777593 +0000
++++ b/sitecustomize.py	2018-09-06 14:10:00.939777851 +0000
+@@ -5,3 +5,7 @@
+     pass
+ else:
+     apport_python_hook.install()
++
++# Import libgomp to work around OpenCV load order issues
++import ctypes
++ctypes.cdll.LoadLibrary("libgomp.so.1")


### PR DESCRIPTION
Loading the opencv library after PYNQ inside a Jupyter environment
causes a failure due to lack of TLS space. This patch uses a hook
to always load libgomp at the startup of Python 3.6 to ensure
that opencv loads cleanly regardless of where it appears in the list
of imports