### PR TITLE
pynqmicroblaze: Perform unsigned conversion correctly and handle hierarchies

### DIFF
--- a/boards/sw_repo/build_xsdk.tcl
+++ b/boards/sw_repo/build_xsdk.tcl
@@ -67,7 +67,7 @@ foreach mb $processors {
         setlib -bsp $bsp -lib pynqmb
         set ips [hsi::get_cells [hsi::get_property SLAVES $mb]]
         set interrupt [find_interrupt_gpio $ips]
-        set bram [find_ip $ips lmb_bram_if_cntlr]
+        set brams [find_ip $ips lmb_bram_if_cntlr]
         set gpios [find_ip $ips axi_gpio]
         foreach gpio $gpios {
             if {[string equal $gpio $interrupt]} {
@@ -76,9 +76,15 @@ foreach mb $processors {
                 setdriver -bsp $bsp -ip $gpio -driver "gpio"
             }
         }
-        setdriver -bsp $bsp -ip $bram -driver "mailbox_bram"
-        configbsp -bsp $bsp stdin $bram
-        configbsp -bsp $bsp stdout $bram
+        foreach bram $brams {
+          setdriver -bsp $bsp -ip $bram -driver "mailbox_bram"
+        }
+        # HACK: Assume that the first BRAM is the one we are
+        # using to communicate
+        # with the ARM.
+        set firstbram [lindex $brams 0]
+        configbsp -bsp $bsp stdin $firstbram
+        configbsp -bsp $bsp stdout $firstbram
         regenbsp -bsp $bsp
         file copy "[pwd]/lscript.ld" $bsp
     } else {

--- a/pynq/lib/pynqmicroblaze/compile.py
+++ b/pynq/lib/pynqmicroblaze/compile.py
@@ -67,7 +67,7 @@ def dependencies(source, bsp):
 
 
 def _find_bsp(cell_name):
-    target_bsp = "bsp_" + cell_name
+    target_bsp = "bsp_" + cell_name.replace('/','_')
     matches = [bsp for bsp in BSPs.keys()
                if target_bsp.startswith(bsp)]
     if matches:

--- a/pynq/lib/pynqmicroblaze/pynqmicroblaze.py
+++ b/pynq/lib/pynqmicroblaze/pynqmicroblaze.py
@@ -320,11 +320,17 @@ class MicroblazeHierarchy(DefaultHierarchy):
     def __init__(self, description, mbtype="Unknown"):
         super().__init__(description)
         hier = description['fullpath']
+        if hier.count('/') > 0:
+            parent, _, ip = hier.rpartition('/')
+            container = "{}/".format(parent)
+        else:
+            container = ""
+            ip = hier
         self.mb_info = {'ip_name': '{}/mb_bram_ctrl'.format(hier),
-                        'rst_name': 'mb_{}_reset'.format(hier),
+                        'rst_name': '{}mb_{}_reset'.format(container,ip),
                         'intr_pin_name': '{}/dff_en_reset_vector_0/q'.format(
                             hier),
-                        'intr_ack_name': 'mb_{}_intr_ack'.format(hier),
+                        'intr_ack_name': '{}mb_{}_intr_ack'.format(container,ip),
                         'mbtype': mbtype,
                         'name' : hier}
 

--- a/pynq/lib/pynqmicroblaze/rpc.py
+++ b/pynq/lib/pynqmicroblaze/rpc.py
@@ -627,8 +627,11 @@ def _pyprintf(stream):
     args = []
     for i in range(len(format_string)):
         if in_special:
-            if format_string[i:i+1] in [b'd', b'x', b'X', b'o', b'u']:
+            if format_string[i:i+1] in [b'd']:
                 args.append(stream.read_int32())
+            elif format_string[i:i+1] in [b'x', b'X', b'o', b'u']:
+                # perform unsigned conversion
+                args.append(stream.read_uint32())
             elif format_string[i:i+1] in [b'f', b'F', b'g', b'G', b'e', b'E']:
                 args.append(stream.read_float())
             elif format_string[i:i+1] == b's':

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -1357,9 +1357,15 @@ class PLMeta(type):
                 mmio = MMIO(details['phys_addr'])
                 # Request shutdown
                 mmio.write(0x0, 0x1)
-                while mmio.read(0x0) != 0x0F:
+                i = 0
+                while mmio.read(0x0) != 0x0F and i < 16000:
                     # wait for the shutdown to be acknowledged
+                    i = i + 1
                     pass
+                if i >= 16000:
+                    print("Timeout waiting for Shutdown Manager.")
+                    print("It's likely that the currently configured bitstream doesn't match the metadata.")
+                    print("Continuing on and hoping for the best...")
 
     def reset(cls, parser=None):
         """Reset all the dictionaries.
@@ -1671,7 +1677,7 @@ class Bitstream(_BitstreamMeta):
 
         Note
         ----
-        Imlemented based on: https://blog.aeste.my/?p=2892
+        Implemented based on: https://blog.aeste.my/?p=2892
 
         Returns
         -------

--- a/pynq/pl.py
+++ b/pynq/pl.py
@@ -291,7 +291,11 @@ class _TCLABC(metaclass=abc.ABCMeta):
                                       re.IGNORECASE)
                         if m and gpio_idx is not None:
                             name = m.group("instance_name")
-                            gpio_dict[name] = gpio_idx
+                            if(current_hier == ""):
+                                hier_name = name
+                            else:
+                                hier_name = "{}/{}".format(current_hier,name)
+                            gpio_dict[hier_name] = gpio_idx
                             gpio_idx = None
                         in_prop = False
 
@@ -501,8 +505,14 @@ class _TCLABC(metaclass=abc.ABCMeta):
                     self.hierarchy_dict[ip]['gpio'][pin] = gpio
 
     def _build_hierarchy_dict(self):
+        lasthierarchies = {}
         hierarchies = {k.rpartition('/')[0] for k in self.ip_dict.keys()
                        if k.count('/') > 0}
+        while (lasthierarchies != hierarchies):
+            parents = {k.rpartition('/')[0] for k in hierarchies if k.count('/') > 0}
+            lasthierarchies = hierarchies
+            hierarchies.update(parents)
+
         self.hierarchy_dict = dict()
         for hier in hierarchies:
             self.hierarchy_dict[hier] = {
@@ -916,8 +926,14 @@ class _HWHABC(metaclass=abc.ABCMeta):
         """Initialize the hierachical dictionary.
 
         """
+        lasthierarchies = {}
         hierarchies = {k.rpartition('/')[0] for k in self.ip_dict.keys()
                        if k.count('/') > 0}
+        while (lasthierarchies != hierarchies):
+            parents = {k.rpartition('/')[0] for k in hierarchies if k.count('/') > 0}
+            lasthierarchies = hierarchies
+            hierarchies.update(parents)
+
         for hier in hierarchies:
             self.hierarchy_dict[hier] = {
                 'ip': dict(),


### PR DESCRIPTION
This commit performs the following fixes
 * pyprintf correctly handles unsigned numbers
 * Correctly handle microblaze hierarchies not at top level
 * Timeout waiting for AXI shutdown managers to close the connection.