### PR TITLE
Switch to using c++ for pynqmicroblaze

### DIFF
--- a/pynq/lib/pynqmicroblaze/bsp.py
+++ b/pynq/lib/pynqmicroblaze/bsp.py
@@ -85,10 +85,30 @@ class BSPInstance:
         self.libraries = ['xil']
 
         self.linker_script = path.join(root, 'lscript.ld')
-        self.cflags = [
-            '-Os', '-lxil', '-mlittle-endian',
-            '-mcpu=v9.6', '-mxl-soft-mul'
-        ]
+        self.mss = path.join(root, 'system.mss')
+
+        self.cflags = ['-Os', '-lxil']
+        # Some sane default
+        extracflags = ['-mlittle-endian', '-mcpu=v9.6', '-mxl-soft-mul']
+
+        try:
+            found = False
+            with open(self.mss) as fp:
+                for line in fp:
+                    words = line.strip().split()
+                    if(len(words) > 2 and
+                       words[0] == 'PARAMETER' and
+                       words[1] == 'compiler_flags'):
+                        extracflags = words[3:]
+                        found = True
+                        break;
+            if(not found):
+                print("compiler_flags not found in ", self.mss, ": using default cflags")
+        except FileNotFoundError:
+            print(self.mss, "not found: using default cflags")
+
+        self.cflags.extend(extracflags)
+
         self.ldflags = {
             '-Wl,--no-relax'
         }

--- a/pynq/lib/pynqmicroblaze/modules/pyprintf/src/pyprintf.c
+++ b/pynq/lib/pynqmicroblaze/modules/pyprintf/src/pyprintf.c
@@ -15,8 +15,8 @@ void complete_write(int fd, const char* data, unsigned int length) {
 
 void pyprintf(const char* format, ...) {
     unsigned short len = strlen(format);
-    complete_write(3, &printf_command, 1);
-    complete_write(3, &len, 2);
+    complete_write(3, (const char *)&printf_command, 1);
+    complete_write(3, (const char *)&len, 2);
     complete_write(3, format, len);
     int in_special = 0;
     va_list args;
@@ -31,7 +31,7 @@ void pyprintf(const char* format, ...) {
             case 'X':
             {
                 int val = va_arg(args, int);
-                complete_write(3, &val, sizeof(val));
+                complete_write(3, (const char *)&val, sizeof(val));
             }
                 break;
             case 'f':
@@ -42,14 +42,14 @@ void pyprintf(const char* format, ...) {
             case 'E':
             {
                 float val = (double)va_arg(args, double);
-                complete_write(3, &val, sizeof(val));
+                complete_write(3, (const char *)&val, sizeof(val));
             }
                 break;
             case 's':
             {
                 char* str = (char*)va_arg(args, char*);
                 short len = strlen(str);
-                complete_write(3, &len, sizeof(len));
+                complete_write(3, (const char *)&len, sizeof(len));
                 complete_write(3, str, len);
             }
                 break;

--- a/pynq/lib/pynqmicroblaze/rpc.py
+++ b/pynq/lib/pynqmicroblaze/rpc.py
@@ -585,8 +585,10 @@ def _build_handle_function(functions):
 def _build_main(program_text, functions):
     sections = []
     sections.append(R"""
+    extern "C" {
     #include <unistd.h>
     #include <mailbox_io.h>
+    }
     static const char return_command = 0;
     static const char void_command = 2;
 
@@ -595,7 +597,7 @@ def _build_main(program_text, functions):
         while (available < size) {
             available = mailbox_available(2);
         }
-        read(2, data, size);
+        mailbox_read(2, data, size);
     }
 
     static void _rpc_write(const void* data, int size) {
@@ -603,7 +605,7 @@ def _build_main(program_text, functions):
         while (available < size) {
             available = mailbox_available(3);
         }
-        write(3, data, size);
+        mailbox_write(3, data, size);
     }
     """)
 
@@ -793,7 +795,7 @@ class MicroblazeRPC:
             Source of the program to extract functions from
 
         """
-        preprocessed = preprocess(program_text, mb_info=iop)
+        preprocessed = preprocess(program_text, mb_info=iop, defines=["WRAP"])
         try:
             ast = _parser.parse(preprocessed, filename='program_text')
         except ParseError as e:


### PR DESCRIPTION
There are several bits to this:
1) define WRAP to make your wrapper generation work. The expectation is that user code has something like:

CODE> %%microblaze overlay.user_port.control_microblaze
CODE> // Must be valid C and C++
CODE> #include <pyprintf.h>
CODE> int foo(int x); // Generate a wrapper for foo()
CODE>
CODE> #ifndef WRAP
CODE> // Must be valid C++
CODE> extern "C" {
CODE>   #include "mb_interface.h"
CODE> }
CODE> int foo(int x) {
CODE>    return x+1;
CODE> }

2) use mb-g++ to compile, with some extra flags to ensure that we don't bring in lots of standard library functions that aren't called
3) Because we have to be careful about code size, dump the size of the largest symbols
4) fix some of the library code to be C++ safe (const correct, declaration correct)