### PR TITLE
New Vagrant created vm needs apt database initialized before setup_host.sh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,10 @@ Vagrant.configure("2") do |config|
 	chmod 777 -R /sdbuild
   SHELL
 
+  # Initialize the apt database in the brand new Ubuntu VM
+  config.vm.provision "shell",
+    inline: "apt-get update"
+
   # Install prerequisites
   config.vm.provision "shell", 
 	inline: "/bin/bash /pynq/sdbuild/scripts/setup_host.sh"


### PR DESCRIPTION
Hi PYNQ team,  when I tried out using Vagrant to create a VM for building PYNQ it did not work for me.  Initializing the apt database fixed the issue.  I was using updated Ubuntu 16.04 LTS as host and latest VirtualBox 6.0.4 and latest Vagrant.  Please apply suggested fix as you deem appropriate.