### PR TITLE
fix displayport refresh

### DIFF
--- a/pynq/lib/video/drm.py
+++ b/pynq/lib/video/drm.py
@@ -139,7 +139,7 @@ class DrmDriver:
         if not pixelformat.fourcc:
             raise ValueError("pixelformat does not define a FourCC")
         ret = self._videolib.pynqvideo_device_set_mode(
-            self._device, mode.width, mode.height, 60,
+            self._device, mode.width, mode.height, mode.fps,
             _fourcc_int(pixelformat.fourcc))
         if ret:
             raise OSError(ret)


### PR DESCRIPTION
Hi, It was a simple fix.  I have tested this with an Ultra96 and a NEC PA241W monitor.  I tried a handful of different resolutions and refresh rates and they now work.  Before this fix only resolutions at 60Hz would function.  This should also fix it for ZCU104.