### PR TITLE
 Update main README to point to new discuss forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ for how to improve PYNQ.
 
 ## Support
 
-Please ask questions on the <a href="https://groups.google.com/forum/#!forum/pynq_project" target="_blank">PYNQ support forum</a>.
+Please ask questions on the <a href="https://discuss.pynq.io" target="_blank">PYNQ support forum</a>.
 
 ## Licenses
 


### PR DESCRIPTION
Current link in main README.md points to old google groups support forum.
This pull request updates the link to point to discuss.pynq.io