### PR TITLE
Add package to display IP address via Grove OLED

### DIFF
--- a/sdbuild/packages/show_ip/README.md
+++ b/sdbuild/packages/show_ip/README.md
@@ -1,0 +1,13 @@
+# Show IP package
+
+This package runs a script on boot, allowing the user to get the board's IP address via a Grove OLED display.
+This is especially useful for hackathons, etc., where many PYNQ boards are connected to the same network.
+
+## How to use
+
+  * After boot, wait until the LEDs flash and then turn off
+  * Insert the Grove OLED module in PMODB via connector G3
+  * Press BTN0
+  * Read IP from OLED display
+
+Note that there is a timeout of 5 minutes while waiting for the button press. This is to minimise any danger of having this script running in the background on subsequent boots.

--- a/sdbuild/packages/show_ip/pre.sh
+++ b/sdbuild/packages/show_ip/pre.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+target=$1
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+sudo cp $script_dir/show_ip.py $target/usr/local/bin
+sudo cp $script_dir/show_ip.service $target/lib/systemd/system
+

--- a/sdbuild/packages/show_ip/qemu.sh
+++ b/sdbuild/packages/show_ip/qemu.sh
@@ -1,0 +1,1 @@
+systemctl enable show_ip

--- a/sdbuild/packages/show_ip/show_ip.py
+++ b/sdbuild/packages/show_ip/show_ip.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3.6
+
+from pynq.overlays.base import BaseOverlay
+from pynq import PL
+from pynq.lib.pmod import PMOD_GROVE_G3
+from pynq.lib.pmod import Grove_OLED
+import subprocess as sp
+import signal
+from sys import exit
+
+
+def show_ip(ol, interface, ip_addr):
+    """Displays the given IP address on a GROVE OLED screen"""
+    PL.reset()
+    oled = Grove_OLED(ol.PMODB,PMOD_GROVE_G3)
+    oled.clear()
+    if interface:
+        msg = f"IP for {interface:<5} is:{' '*16}{ip_addr}"
+    else:
+        f"Can't find interface with an IP"
+    oled.write(msg)
+    del oled
+
+    
+def parse_ip(interface):
+    """Returns the IP address of a given network interface.
+    
+    Will return an empty string on error.
+    """
+    cmd = "ifconfig "+interface+" | grep 'inet ' | cut -f1 | awk '{ print $2}'"
+    ip_output = sp.getoutput(cmd)
+    if ip_output.endswith('Device not found'):
+        return ''
+    return ip_output
+
+
+def get_first_ip(interfaces):
+    """Search through the given interfaces for the first with an IP.
+    
+    Use the order of names in interfaces for setting priority.
+    Returns a tuple of the interface name and its IP address.
+    """
+    for interface in interfaces:
+        ip = parse_ip(interface)
+        if ip:
+            return interface, ip
+    return '', ''
+
+
+def timeout_handler(sig_num, stack_frame):
+    """A simple handler for timeout signals"""
+    raise Exception('Timeout!')
+
+    
+# Load base overlay
+ol = BaseOverlay("base.bit")
+timeout_secs = 5*60
+
+# Setup signal for button timeout
+signal.signal(signal.SIGALRM, timeout_handler)
+signal.alarm(timeout_secs)
+
+print("Ready for button press...")
+print(f"Timing out in {timeout_secs} seconds")
+
+# Try to wait for button press
+try:
+    ol.buttons[0].wait_for_value(1)
+except Exception:
+    print("Timed out. Exiting...")
+    exit(0)
+
+# Clear timeout
+signal.alarm(0)
+
+# Print IP
+print("Button pressed. Continuing...")
+interface, ip = get_first_ip(['wlan0', 'eth0'])
+show_ip(ol, interface, ip)

--- a/sdbuild/packages/show_ip/show_ip.service
+++ b/sdbuild/packages/show_ip/show_ip.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Show IP on Grove OLED when BTN0 is pressed
+After=boot_leds.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3.6 /usr/local/bin/show_ip.py
+
+[Install]
+WantedBy=boot_leds.service


### PR DESCRIPTION
This package should help simplify board discovery during workshops/hackathons when OLED displays are available.

Starts a python script on boot to print the IP address (`wlan0` or the `eth0` fallback) to an OLED display after BTN0 is pressed.