### PR TITLE
Update wifi_connect package

### DIFF
--- a/sdbuild/packages/wifi_connect/README.md
+++ b/sdbuild/packages/wifi_connect/README.md
@@ -1,0 +1,44 @@
+# WiFi Connect package
+
+This package connects to a wifi network at boot, using `wpa_supplicant`.
+
+## How to use
+
+The wifi connection will be made automatically at boot, but there are a few
+configuration options picked up from files in the boot partition. Change these
+files to describe your own set of wifi networks and your wifi adapter.
+
+  * `wpa_supplicant.conf`: is a standard `wpa_supplicant` configuration file,
+    listing all of the networks that the board should connect to.
+    See below for an example config file.
+
+  * `wifi.ko`: is an optional driver file. This lets you easily inject wifi
+    drivers that are not in the mainline kernel.
+
+## Example `wpa_supplicant.conf` file
+
+Here is an example config file that describes two different networks:
+
+```
+network={
+    # Network name
+    ssid="MyHomeNetwork"
+
+    # Password in plain text using quotes
+    psk="AndItsPlaintextPassword"
+
+    # A unique ID for this entry
+    id_str="home"
+}
+
+network={
+    # Second network name
+    ssid="ConferenceWiFi"
+    
+    # Password obfuscated with wpa_passphrase command
+    psk=d1d140ae3d73f946bfb117479b8967a5a5b541f712c0f40ba8049f34ce43e89c
+    
+    # A unique ID
+    id_str="demonight"
+}
+```

--- a/sdbuild/packages/wifi_connect/pre.sh
+++ b/sdbuild/packages/wifi_connect/pre.sh
@@ -5,4 +5,5 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 sudo cp $script_dir/wifi_connect.sh $target/usr/local/bin
 sudo cp $script_dir/wifi_connect.service $target/lib/systemd/system
+sudo cp $script_dir/wlan0_interface $target/etc/network/interfaces.d/wlan0
 

--- a/sdbuild/packages/wifi_connect/wifi_connect.sh
+++ b/sdbuild/packages/wifi_connect/wifi_connect.sh
@@ -21,10 +21,4 @@ if [ -f "$mount"/"$config_name" ]; then
         insmod "$mount"/"$driver_name"
     fi
 
-    #find name of wifi interface (assuming first one listed is the one we want)
-    wint="$(iw dev | grep 'Interface' | cut -d ' ' -f2 | head -n1)"
-
-    #connect to wifi
-    wpa_supplicant -i "$wint" -B -c "$mount"/"$config_name"
-    dhclient "$wint"
 fi

--- a/sdbuild/packages/wifi_connect/wifi_connect.sh
+++ b/sdbuild/packages/wifi_connect/wifi_connect.sh
@@ -4,6 +4,7 @@ set -e
 
 mount="/boot"
 config_name="wpa_supplicant.conf"
+driver_name="wifi.ko"
 
 #use the 1st partition of sdcard
 boot_part="/dev/mmcblk0p1"
@@ -13,6 +14,13 @@ mount -o rw "$boot_part" "$mount"
 
 #make sure config file is present
 if [ -f "$mount"/"$config_name" ]; then
+
+    #look for custom wifi driver
+    if [ -f "$mount"/"$driver_name" ]; then
+        rmmod "$mount"/"$driver_name" | true
+        insmod "$mount"/"$driver_name"
+    fi
+
     #find name of wifi interface (assuming first one listed is the one we want)
     wint="$(iw dev | grep 'Interface' | cut -d ' ' -f2 | head -n1)"
 

--- a/sdbuild/packages/wifi_connect/wlan0_interface
+++ b/sdbuild/packages/wifi_connect/wlan0_interface
@@ -1,0 +1,4 @@
+auto wlan0
+allow-hotplug wlan0
+iface wlan0 inet dhcp
+wpa-conf /boot/wpa_supplicant.conf


### PR DESCRIPTION
Updated the wifi_connect package to work with the current image by:

  * Add a wlan0 entry in `/etc/network/interfaces.d/`
  * Accommodate custom wifi drivers via an optional `.ko` file in the boot partition
  * Avoid starting redundant `wpa_supplicant` daemons
  * Documentation