### PR TITLE
formalize the process to ignore large files and hardware project

### DIFF
--- a/sdbuild/packages/pynq/pre.sh
+++ b/sdbuild/packages/pynq/pre.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 
-set -x
+set +x
 set -e
 
 target=$1
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ignore=( "*.bsp" "*.dsa" "*.hdf" )
+array_contains () {
+	local seeking=$1; shift
+	local in=1
+	for element; do
+	if [[ $seeking == $element* ]]; then
+		in=0
+		break
+	fi
+	done
+	return $in
+}
 
 sudo cp -r $BUILD_ROOT/PYNQ $target/home/xilinx/pynq_git
 if [ ${PYNQ_BOARD} != "Unknown" ]; then
@@ -12,14 +24,23 @@ if [ ${PYNQ_BOARD} != "Unknown" ]; then
 	if [ -d .git ]; then
 		sudo cp -rf .git $target/home/xilinx/pynq_git/boards
 	fi
+
 	cd ${PYNQ_BOARDDIR}
-	for f in `find . ! -name "*.bsp"`
+	for f in `find . -type d`
 	do
-		if [ -d "$f" ]; then
+		if [ -e $f/*.xpr ]; then
+			ignore+=( $f/ )
+		fi
+	done
+	for f in `find .`
+	do
+	if ! array_contains "$f" "${ignore[@]}" ; then
+		if [ -d $f ]; then
 			sudo mkdir -p $target/home/xilinx/pynq_git/boards/${PYNQ_BOARD}/$f
 		else
 			sudo cp -rf $f $target/home/xilinx/pynq_git/boards/${PYNQ_BOARD}/$f
 		fi
+	fi
 	done
 fi
 sudo cp $script_dir/pl_server.sh $target/usr/local/bin


### PR DESCRIPTION
This pull request makes sure no vivado project and dsa files are copied to the board image - otherwise build process fails with out-of-space errors.