### PR TITLE
Add delay before kpartx command in resize_umount.sh

### DIFF
--- a/sdbuild/scripts/resize_umount.sh
+++ b/sdbuild/scripts/resize_umount.sh
@@ -29,6 +29,8 @@ sudo chroot / e2fsck -y -f $root_dev
 sudo chroot / resize2fs $root_dev ${new_size}K
 sudo chroot / zerofree $root_dev
 
+sleep 5
+
 sudo kpartx -d $image_file
 
 sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk $1


### PR DESCRIPTION
Withouth the delay, it could randomly give `device-mapper: remove ioctl on loop0p2 failed: Device or resource busy` in jenkins (and I assume also in other build systems)