### PR TITLE
More bug-fixes and features for 2.5.1

### DIFF
--- a/pynq/buffer.py
+++ b/pynq/buffer.py
@@ -67,7 +67,7 @@ class PynqBuffer(np.ndarray):
     def __array_finalize__(self, obj):
         if isinstance(obj, PynqBuffer) and obj.coherent is not None:
             self.coherent = obj.coherent
-            offset = self.ctypes.data - obj.ctypes.data
+            offset = self.virtual_address - obj.virtual_address
             self.device_address = obj.device_address + offset
             self.offset = obj.offset + offset
         else:
@@ -98,6 +98,10 @@ class PynqBuffer(np.ndarray):
     def physical_address(self):
         return self.device_address
 
+    @property
+    def virtual_address(self):
+        return self.__array_interface__['data'][0]
+
     def close(self):
         """Unused - for backwards compatibility only
 
@@ -110,7 +114,7 @@ class PynqBuffer(np.ndarray):
         """
         if not self.coherent:
             self.device.flush(self.bo, self.offset,
-                              self.ctypes.data, self.nbytes)
+                              self.virtual_address, self.nbytes)
 
     def invalidate(self):
         """Invalidate the underlying memory if necessary
@@ -118,7 +122,7 @@ class PynqBuffer(np.ndarray):
         """
         if not self.coherent:
             self.device.invalidate(self.bo, self.offset,
-                                   self.ctypes.data, self.nbytes)
+                                   self.virtual_address, self.nbytes)
 
     def __enter__(self):
         return self

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -358,6 +358,10 @@ class Overlay(Bitstream):
         self.hierarchy_dict = deepcopy(source.hierarchy_dict)
         self.mem_dict = deepcopy(source.mem_dict)
 
+    def free(self):
+        if hasattr(self.device, 'free_bitstream'):
+            self.device.free_bitstream()
+
     def download(self, dtbo=None):
         """The method to download a full bitstream onto PL.
 

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -360,6 +360,11 @@ class XrtDevice(Device):
         xrt.xclWrite(self.handle, xrt.xclAddressSpace.XCL_ADDR_KERNEL_CTRL,
                      address, cdata, len(data)) 
 
+    def free_bitstream(self):
+        for c in self.contexts:
+            xrt.xclCloseContext(self.handle, c[0], c[1])
+        self.contexts = []
+
     def download(self, bitstream, parser=None):
         # Close existing contexts
         for c in self.contexts:


### PR DESCRIPTION
 * Work around circular references in numpy.ctypes
 * Add `free` function to Overlay class to release accelerator context
 * Add deallocation to DDR and Exec buffer objects