### PR TITLE
remove server_type override in XlnkDevice init

### DIFF
--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -562,7 +562,7 @@ class XlnkDevice(Device):
     _probe_priority_ = 100
 
     def __init__(self):
-        super().__init__("xlnk", server_type="global")
+        super().__init__("xlnk")
         from pynq import Xlnk
         self.default_memory = Xlnk()
         self.capabilities = {


### PR DESCRIPTION
Fixes error when starting PL server on Zynq