### PR TITLE
PYNQ:  Allow fetching BSP from a URL instead of only local files.

### DIFF
--- a/sdbuild/scripts/create_bsp.sh
+++ b/sdbuild/scripts/create_bsp.sh
@@ -6,7 +6,13 @@ set -e
 board=$1
 template=$2
 
-if [ ! -z "$BSP" ]; then
+if [ -n "$BSP" ]; then
+	# If $BSP is a URL, fetch it!
+	if [[ "$BSP" == *"://"* ]] ; then
+		BSP_ABS="${BSP_BUILD}/../downloaded-${BSP_PROJECT}.bsp"
+		curl -o "${BSP_ABS}" "${BSP}"
+		BSP=$(basename "${BSP_ABS}")
+	fi
 	cp -f $BSP_ABS $BSP_BUILD
 	cd $BSP_BUILD
 	old_project=$(echo $(tar -xvf $BSP) | cut -f1 -d" ")
@@ -36,4 +42,3 @@ else
 	petalinux-package --force --bsp -p $BSP_PROJECT \
 		--output $BSP_PROJECT.bsp
 fi
-

--- a/sdbuild/scripts/setup_host.sh
+++ b/sdbuild/scripts/setup_host.sh
@@ -39,6 +39,7 @@ nfs-common
 zerofree
 u-boot-tools
 rpm2cpio
+curl
 docker-ce
 docker-ce-cli
 containerd.io


### PR DESCRIPTION
This means one can keep the (usually pretty large) BSP separate from the
repository, and has the added benefit of making some CI flows a lot
simpler