### PR TITLE
Remove .configure() call in audio.py AudioADAU1761

### DIFF
--- a/boards/Pynq-Z2/base/base.py
+++ b/boards/Pynq-Z2/base/base.py
@@ -98,6 +98,7 @@ class BaseOverlay(pynq.Overlay):
             self.pin_select = GPIO(GPIO.get_gpio_pin(
                 self.gpio_dict['pmoda_rp_pin_sel']['index']), "out")
             self.audio = self.audio_codec_ctrl_0
+            self.audio.configure()
 
             self.leds = self.leds_gpio.channel1
             self.switches = self.switches_gpio.channel1

--- a/pynq/lib/audio.py
+++ b/pynq/lib/audio.py
@@ -356,7 +356,6 @@ class AudioADAU1761(DefaultIP):
         self.sample_len = len(self.buffer)
         self.iic_index = None
         self.uio_index = None
-        self.configure()
 
     bindto = ['xilinx.com:user:audio_codec_ctrl:1.0']
 


### PR DESCRIPTION
and add .configure() call to Pynq-Z2 base.py