### PR TITLE
Fix for LateX documentation generation

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -2,9 +2,6 @@
 Glossary
 ********
 
-.. glossary::
-
-
 A-G
 ===
 


### PR DESCRIPTION
The HTML generation already works fine.
However, `make latexpdf` generates an error in the glossary section.
```
See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                                                                             
l.28949 \end{description}
?
```
With this PR, the glossary looks OK
