### PR TITLE
Fix Base Overlay Dict in axigpio.rst

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,5 +33,7 @@
 *.a binary -crlf
 *.bsp binary
 
-# Populate git commit ID into __init__.py
+# Populate git blob ID into __init__.py
+# This ID will always be tied to a specific release tag
+# since the file will be modified to edit the version
 pynq/__init__.py ident

--- a/pynq/__init__.py
+++ b/pynq/__init__.py
@@ -52,5 +52,5 @@ __copyright__ = "Copyright 2016, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 __all__ = ['lib', 'tests']
-__version__ = '2.5.1'
+__version__ = '2.5.2'
 __git_commit__ = "$Id$"

--- a/pynq/__init__.py
+++ b/pynq/__init__.py
@@ -52,7 +52,7 @@ __copyright__ = "Copyright 2016, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 __all__ = ['lib', 'tests']
-__version__ = '2.5.2'
+__version__ = '2.5.3'
 # This ID will always be tied to a specific release tag
 # since the file will be modified to edit the version
 __git_id__ = "$Id$"

--- a/pynq/__init__.py
+++ b/pynq/__init__.py
@@ -53,4 +53,6 @@ __email__ = "pynq_support@xilinx.com"
 
 __all__ = ['lib', 'tests']
 __version__ = '2.5.2'
-__git_commit__ = "$Id$"
+# This ID will always be tied to a specific release tag
+# since the file will be modified to edit the version
+__git_id__ = "$Id$"

--- a/pynq/_cli/cmd.py
+++ b/pynq/_cli/cmd.py
@@ -134,10 +134,9 @@ def main():
         if args.version:
             mod = __import__("pynq")
             version = mod.__version__
-            git_commit = mod.__git_commit__.replace("$", "").replace("Id: ",
-                                                                     "")
+            git_id = mod.__git_id__.replace("$", "")
             print("PYNQ version {}".format(version))
-            print("Git commit: {}".format(git_commit))
+            print("Git {}".format(git_id))
             return
     if not subcommand:
         parser.print_usage(file=sys.stderr)

--- a/pynq/lib/_pynq/_displayport/Makefile
+++ b/pynq/lib/_pynq/_displayport/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 CXX ?= g++
 
 OBJSC = displayport.o 
-INC = -I${PYNQ_BUILD_ROOT}/usr/include/libdrm
+INC = -I=${PYNQ_BUILD_ROOT}/usr/include/libdrm
 
 all:	
 	$(CXX) -fPIC $(INC) -c -g -std=c++11 displayport.cpp $(CFLAGS)

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -63,6 +63,8 @@ def _xclxml_to_ip_dict(raw_xml, xclbin_uuid):
         else:
             control_protocol = 's_axilite'
         slaves = {n.attrib['name']: n for n in kernel.findall('port[@mode="slave"]')}
+        if not slaves:
+            continue
         masters = {n.attrib['name']: n for n in kernel.findall('port[@mode="master"]')}
         readonly = {n.attrib['name']: n for n in kernel.findall('port[@mode="read_only"]')}
         writeonly = {n.attrib['name']: n for n in kernel.findall('port[@mode="write_only"]')}

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -511,7 +511,7 @@ class XrtDevice(Device):
             uuid = None
             for k, v in ip_dict.items():
                 if 'index' in v:
-                    index = v['index']
+                    index = v['adjusted_index']
                     uuid = bytes.fromhex(v['xclbin_uuid'])
                     uuid_ctypes = \
                         XrtUUID((ctypes.c_char * 16).from_buffer_copy(uuid))

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -348,6 +348,13 @@ class XrtDevice(Device):
             if slot == self._info.mPciSlot:
                 self.sysfs_path = os.path.realpath(d)
 
+
+    @property
+    def device_info(self):
+        info = xrt.xclDeviceInfo2()
+        xrt.xclGetDeviceInfo2(self.handle, info)
+        return info
+
     @property
     def name(self):
         return self._info.mName.decode()

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -129,7 +129,8 @@ def _xrt_allocate(shape, dtype, device, memidx):
     dtype = np.dtype(dtype)
     size = elements * dtype.itemsize
     bo = device.allocate_bo(size, memidx)
-    buf = device.map_bo(bo)
+    raw_buf = device.map_bo(bo)
+    buf = ctypes.cast(raw_buf, ctypes.POINTER(ctypes.c_char * size))[0] 
     device_address = device.get_device_address(bo)
     ar = PynqBuffer(shape, dtype, bo=bo, device=device, buffer=buf,
                     device_address=device_address, coherent=False)

--- a/pynq/pmbus.py
+++ b/pynq/pmbus.py
@@ -351,26 +351,72 @@ class Rail:
             args.append("power=" + repr(self.power))
         return "Rail {{{}}}".format(', '.join(args))
 
-class XrtRail:
-    def __init__(self, name, base_file):
-       self.power = None
-       self.name = name
-       if os.path.isfile(base_file):
-          self.voltage = SysFSSensor(base_file, "V", name, 0.001)
-          self.current = None
-       else:
-          if os.path.isfile(base_file + "_vol"):
-             self.voltage = SysFSSensor(base_file + "_vol", "V", name + "_vol", 0.001)
-          else:
-             self.voltage = None
-          if os.path.isfile(base_file + "_curr"):
-             self.current = SysFSSensor(base_file + "_curr", "A", name + "_curr", 0.001)
-          else:
-             self.current = None
 
-          if self.voltage and self.current:
-             self.power = DerivedPowerSensor(name + "_power",
-                 self.voltage, self.current)
+class XrtInfoDump:
+    def __init__(self, device):
+        self._device = device
+        self.parents = tuple()
+
+    def get_value(self, parents=None):
+        info = self._device.device_info
+        return {
+            "0v85_v": info.m0v85,
+            "12v_aux_v": info.m12VAux,
+            "12v_aux_i": info.mAuxCurr,
+            "12v_pex_v": info.m12VPex,
+            "12v_pex_i": info.mPexCurr,
+            "12v_sw_v": info.m12vSW,
+            "1v8_v": info.m1v8Top,
+            "3v3_aux_v": info.m3v3Aux,
+            "3v3_pex_v": info.m3v3Pex,
+            "mgt0v9avcc_v": info.mMgt0v9,
+            "mgtavtt_v": info.mMgtVtt,
+            "sys_5v5_v": info.mSys5v5,
+            "vccint_v": info.mVccIntVol,
+            "vccint_i": info.mCurrent
+        }
+
+class XrtSensor:
+    def __init__(self, unit, name, scale, parent, field):
+        self.parents = (parent,)
+        self._unit = unit
+        self.name = name
+        self._scale = scale
+        self._field = field
+
+    def get_value(self, parents=None):
+        if parents is None:
+            parents = (self.parents[0].get_value(),)
+        return parents[0][self._field] * self._scale
+
+    @property
+    def value(self):
+        return self.get_value()
+
+    def __repr__(self):
+        return "Sensor {{name={}, value={}{}}}".format(
+            self.name, self.value, self._unit)
+
+
+class XrtRail:
+    def __init__(self, name, sample_dict, parent):
+       self.name = name
+       if name + "_v" in sample_dict:
+           self.voltage = XrtSensor("V", name + "_vol", 0.001, parent, name + "_v")
+       else:
+           self.voltage = None
+
+       if name + "_i" in sample_dict:
+           self.current = XrtSensor("A", name + "_curr", 0.001, parent, name + "_i")
+       else:
+           self.current = None
+
+       if self.voltage and self.current:
+           self.power = DerivedPowerSensor(name + "_power",
+               self.voltage, self.current)
+       else:
+           self.power = None
+
 
     def __repr__(self):
         args = ["name=" + self.name]
@@ -387,18 +433,16 @@ def get_xrt_sysfs_rails(device=None):
     if device is None:
         from pynq.pl_server import Device
         device = Device.active_device
-    if hasattr(device, "sysfs_path") and device.sysfs_path:
-        base_dir = device.sysfs_path
-    else:
-        return {}
 
     rail_names = ["0v85", "12v_aux", "12v_pex", "12v_sw", "1v8", "3v3_aux",
                   "3v3_pex", "mgt0v9avcc", "mgtavtt", "sys_5v5", "vccint" ]
 
+    infodump = XrtInfoDump(device)
+    sample_dict = infodump.get_value()
+
     rails = {}
-    mgmt_dir = glob.glob(base_dir + "/xmc*")[0]
     for n in rail_names:
-        rails[n] = XrtRail(n, mgmt_dir + "/xmc_" + n)
+        rails[n] = XrtRail(n, sample_dict, infodump)
 
     return rails
 
@@ -468,6 +512,25 @@ def get_rails(config_file=None):
     """
     return _enumerate_sensors(config_file)
 
+
+class MultiSensor:
+    """Class for efficiently collecting the readings from multiple sensors
+
+    """
+    def __init__(self, sensors):
+        self._sensors = sensors
+
+    def get_values(self):
+        stored = {}
+        return tuple((self._get_value(s, stored) for s in self._sensors))
+
+    def _get_value(self, sensor, stored):
+        if sensor in stored:
+            return stored[sensor]
+        value = sensor.get_value([self._get_value(p, stored) for p in sensor.parents])
+        stored[sensor] = value
+        return value
+
 class DataRecorder:
     """Class to record sensors during an execution
     The DataRecorder provides a way of recording sensor data using a
@@ -480,6 +543,7 @@ class DataRecorder:
 
         self._record_index = -1
         self._sensors = sensors
+        self._getter = MultiSensor(sensors)
         self._columns = ['Mark']
         self._times = []
         self._columns.extend([s.name for s in sensors])
@@ -539,7 +603,7 @@ class DataRecorder:
 
         while not self._done:
             row = [self._record_index]
-            row.extend([s.value for s in self._sensors])
+            row.extend(self._getter.get_values())
             self._frame.loc[pd.Timestamp.now()] = row
             time.sleep(self._interval)
 

--- a/pynq/pmbus.py
+++ b/pynq/pmbus.py
@@ -236,6 +236,7 @@ class SysFSSensor:
         self._unit = unit
         self.name = name
         self._scale = scale
+        self.parents = tuple()
 
     @property
     def value(self):
@@ -243,19 +244,30 @@ class SysFSSensor:
             raw_value = float(f.read())
         return raw_value * self._scale
 
+    def get_value(self, parents=None):
+        return self.value
+
     def __repr__(self):
         return "Sensor {{name={}, value={}{}}}".format(
             self.name, self.value, self._unit)
 
 class DerivedPowerSensor:
     def __init__(self, name, voltage, current):
+        parents = (voltage, current)
         self.voltage_sensor = voltage
         self.current_sensor = current
         self.name = name
+        self.parents = (voltage, current)
+
+    def get_value(self, parents=None):
+        if parents is None:
+            return self.voltage_sensor.value * self.current_sensor.value
+        else:
+            return parents[0] * parents[1]
 
     @property
     def value(self):
-        return self.voltage_sensor.value * self.current_sensor.value
+        return self.get_value()
 
     def __repr__(self):
         return "Sensor {{name={}, value={}W}}".format(
@@ -297,6 +309,7 @@ class Sensor:
         self._value = _ffi.new("double [1]")
         self._unit = unit
         self.name = name
+        self.parents = tuple()
 
     @property
     def value(self):
@@ -308,6 +321,9 @@ class Sensor:
             return self._value[0]
         else:
             return 0
+
+    def get_value(self, parents=None):
+        return self.value
 
     def __repr__(self):
         return "Sensor {{name={}, value={}{}}}".format(

--- a/pynq/pmbus.py
+++ b/pynq/pmbus.py
@@ -227,7 +227,6 @@ try:
     _ffi.cdef(_c_header)
     _lib = _ffi.dlopen("libsensors.so.4")
 except Exception as e:
-    warnings.warn("Could not initialise libsensors library")
     _lib = None
 
 
@@ -449,6 +448,7 @@ def get_xrt_sysfs_rails(device=None):
 
 def _enumerate_sensors(config_file=None):
     if _lib is None:
+        warnings.warn("Could not initialise libsensors library")
         return {}
 
     if config_file:

--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -423,7 +423,7 @@ class Xlnk:
             for l in f.readlines():
                 m = re.match('CmaTotal:[\\s]+([0-9]+) kB', l)
                 if m:
-                    return int(m[1]) * 1024
+                    return int(m.group(1)) * 1024
         return 0
 
     def flush(self, bo, offset, vaddr, nbytes):

--- a/sdbuild/boot/meta-pynq/recipes-bsp/device-tree/device-tree.bbappend
+++ b/sdbuild/boot/meta-pynq/recipes-bsp/device-tree/device-tree.bbappend
@@ -15,7 +15,7 @@ do_configure_append_zynq () {
     PYNQ_BOARDNAME="${@d.getVar('BB_ORIGENV', False).getVar('PYNQ_BOARDNAME', True)}"
     echo '/include/ "pynq_zynq.dtsi"' >> ${DT_FILES_PATH}/system-top.dts
     if [ -n "${PYNQ_BOARDNAME}" ]; then
-        echo '/ { chosen { pynq_board = "${PYNQ_BOARDNAME}"; }; };' >> ${DT_FILES_PATH}/system-top.dts
+        echo "/ { chosen { pynq_board = \"${PYNQ_BOARDNAME}\"; }; };" >> ${DT_FILES_PATH}/system-top.dts
     else
         echo "No board set"
         exit 1
@@ -25,7 +25,7 @@ do_configure_append_zynqmp () {
     PYNQ_BOARDNAME="${@d.getVar('BB_ORIGENV', False).getVar('PYNQ_BOARDNAME', True)}"
     echo '/include/ "pynq_zynqmp.dtsi"' >> ${DT_FILES_PATH}/system-top.dts
     if [ -n "${PYNQ_BOARDNAME}" ]; then
-        echo '/ { chosen { pynq_board = "${PYNQ_BOARDNAME}"; }; };' >> ${DT_FILES_PATH}/system-top.dts
+        echo "/ { chosen { pynq_board = \"${PYNQ_BOARDNAME}\"; }; };" >> ${DT_FILES_PATH}/system-top.dts
     else
         echo "No board set"
         exit 1

--- a/sdbuild/scripts/create_bsp.sh
+++ b/sdbuild/scripts/create_bsp.sh
@@ -6,7 +6,13 @@ set -e
 board=$1
 template=$2
 
-if [ ! -z "$BSP" ]; then
+if [ -n "$BSP" ]; then
+	# If $BSP is a URL, fetch it!
+	if [[ "$BSP" == *"://"* ]] ; then
+		BSP_ABS="${BSP_BUILD}/../downloaded-${BSP_PROJECT}.bsp"
+		curl -o "${BSP_ABS}" "${BSP}"
+		BSP=$(basename "${BSP_ABS}")
+	fi
 	cp -f $BSP_ABS $BSP_BUILD
 	cd $BSP_BUILD
 	old_project=$(echo $(tar -xvf $BSP) | cut -f1 -d" ")
@@ -36,4 +42,3 @@ else
 	petalinux-package --force --bsp -p $BSP_PROJECT \
 		--output $BSP_PROJECT.bsp
 fi
-

--- a/sdbuild/scripts/setup_host.sh
+++ b/sdbuild/scripts/setup_host.sh
@@ -39,6 +39,7 @@ nfs-common
 zerofree
 u-boot-tools
 rpm2cpio
+curl
 docker-ce
 docker-ce-cli
 containerd.io

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ from setuptools.command.build_ext import build_ext
 from distutils.dir_util import copy_tree
 from distutils.file_util import copy_file, move_file
 from shutil import rmtree
+import shutil
 import glob
 import re
 import subprocess
@@ -322,8 +323,8 @@ class BuildExtension(build_ext):
             for ol in overlay_dirs:
                 src = os.path.join(board_folder, ol)
                 dst = os.path.join(self.build_lib, "pynq/overlays", ol)
-                exclude_file_or_folder('notebooks', src)
-                copy_tree(src, dst)
+                if not os.path.isdir(dst):
+                    shutil.copytree(src, dst, ignore=shutil.ignore_patterns('notebooks'))
 
     def run(self):
         if CPU_ARCH == ZYNQ_ARCH:


### PR DESCRIPTION
The names of the AXI GPIO controller in the first example @ [https://github.com/Xilinx/PYNQ/blob/master/docs/source/pynq_libraries/axigpio.rst](url)

`led_ip = ol.ip_dict['gpio_leds']`
`switches_ip = ol.ip_dict['gpio_switches']`

are not correct. They should be

`led_ip = ol.ip_dict['leds_gpio']`
`switches_ip = ol.ip_dict['switches_gpio']`