### PR TITLE
Replace kpartx with losetup for loop detection and detach

### DIFF
--- a/sdbuild/scripts/check_mounts.sh
+++ b/sdbuild/scripts/check_mounts.sh
@@ -10,6 +10,6 @@ fi
 
 if sudo losetup -a | grep rootfs
 then
-  echo "Loopback device still mounted please use losetup and kpartx to unmount"
+  echo "Loopback device still mounted please use losetup to unmount"
   exit 1
 fi

--- a/sdbuild/scripts/resize_umount.sh
+++ b/sdbuild/scripts/resize_umount.sh
@@ -8,10 +8,11 @@ export PATH=/sbin:$PATH
 
 image_dir=$2
 image_file=$1
+used_loop=$(sudo losetup -j $image_file | grep -o 'loop[0-9]*')
 
-boot_dev=/dev/mapper/$(sudo kpartx -v $image_file | grep -o 'loop[0-9]*p1')
-root_dev=/dev/mapper/$(sudo kpartx -v $image_file | grep -o 'loop[0-9]*p2')
-root_offset=$(sudo kpartx -v $image_file | grep 'loop[0-9]*p2' | cut -d ' ' -f 6)
+boot_dev=/dev/mapper/${used_loop}p1
+root_dev=/dev/mapper/${used_loop}p2
+root_offset=$(sudo kpartx -v /dev/${used_loop} | grep 'loop[0-9]*p2' | cut -d ' ' -f 6)
 sleep 5
 
 sudo umount $image_dir/boot
@@ -31,7 +32,9 @@ sudo chroot / zerofree $root_dev
 
 sleep 5
 
-sudo kpartx -d $image_file
+sudo dmsetup remove /dev/mapper/${used_loop}p1
+sudo dmsetup remove /dev/mapper/${used_loop}p2
+sudo losetup -d /dev/${used_loop}
 
 sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk $1
   d # delete partition

--- a/sdbuild/scripts/unmount_image.sh
+++ b/sdbuild/scripts/unmount_image.sh
@@ -4,8 +4,11 @@ set -e
 
 target=$1
 image_file=$2
+used_loop=$(sudo losetup -j $image_file | grep -o 'loop[0-9]*')
 
 sudo umount $target/boot
 sudo umount $target
 sleep 5
-sudo kpartx -d $image_file
+sudo dmsetup remove /dev/mapper/${used_loop}p1
+sudo dmsetup remove /dev/mapper/${used_loop}p2
+sudo losetup -d /dev/${used_loop}


### PR DESCRIPTION
kpartx on 18.04 (> version 0.6.1 ) is not able to correctly detect the attached loop if the image path lenght is greater than 64 bytes, causing sdbuild to fail when trying to detach. This is due to this commit https://github.com/openSUSE/multipath-tools/commit/0d83956858a946817cd09b818d70de010f7bdd76
I replaced kpartx with losetup for this job. 

Tested and working on both 16.04 and 18.04