### PR TITLE
Refactor pynq.ps.Clocks

### DIFF
--- a/pynq/__init__.py
+++ b/pynq/__init__.py
@@ -27,11 +27,11 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from .registers import Register
 from .mmio import MMIO
 from .uio import UioController
 from .xlnk import Xlnk
 from .pl import PL
-from .ps import Register
 from .ps import Clocks
 from .gpio import GPIO
 from .devicetree import DeviceTreeSegment

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -27,11 +27,8 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import numpy as np
 import os
 import warnings
-from .mmio import MMIO
-from .registers import Register
 
 __author__ = "Yun Rock Qu"
 __copyright__ = "Copyright 2017, Xilinx"
@@ -43,6 +40,117 @@ CPU_ARCH = os.uname().machine
 CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH, ZU_ARCH]
 
 DEFAULT_PL_CLK_MHZ = 100.0
+
+ZYNQ_PLL_FIELDS = {
+    'PLL_FDIV': {'access': 'read-write', 'bit_offset': 12, 'bit_width': 7,
+                 'description': 'Provide the feedback divisor for the PLL'},
+}
+
+ZYNQ_ARM_FIELDS = {
+    'DIVISOR': {'access': 'read-write', 'bit_offset': 8, 'bit_width': 6,
+                'description': 'Frequency divisor for the CPU clock'},
+    'SRCSEL': {'access': 'read-write', 'bit_offset': 4, 'bit_width': 2,
+               'description': 'Source for the CPU clock'}
+}
+
+ZYNQ_CLK_FIELDS = {
+    'DIVISOR1': {'access': 'read-write', 'bit_offset': 20, 'bit_width': 6,
+                 'description': 'Second divisor of the clock source'},
+    'DIVISOR0': {'access': 'read-write', 'bit_offset': 8, 'bit_width': 6,
+                 'description': 'First divisor of the clock source'},
+    'SRCSEL': {'access': 'read-write', 'bit_offset': 4, 'bit_width': 2,
+               'description': 'Select the source for the clock'},
+}
+
+ZYNQ_SLCR_REGISTERS = {
+    'ARM_PLL_CTRL': {'address_offset': 0x100, 'access': 'read-write',
+                     'size': 32, 'description': 'ARM PLL Control',
+                     'fields': ZYNQ_PLL_FIELDS},
+    'DDR_PLL_CTRL': {'address_offset': 0x104, 'access': 'read-write',
+                     'size': 32, 'description': 'DDR PLL Control',
+                     'fields': ZYNQ_PLL_FIELDS},
+    'IO_PLL_CTRL': {'address_offset': 0x108, 'access': 'read-write',
+                    'size': 32, 'description': 'IO PLL Control',
+                    'fields': ZYNQ_PLL_FIELDS},
+    'ARM_CLK_CTRL': {'address_offset': 0x120, 'access': 'read-write',
+                     'size': 32, 'description': 'CPU Clock Control',
+                     'fields': ZYNQ_ARM_FIELDS},
+    'FPGA0_CLK_CTRL': {'address_offset': 0x170, 'access': 'read-write',
+                       'size': 32, 'description': 'PL Clock 0 Control',
+                       'fields': ZYNQ_CLK_FIELDS},
+    'FPGA1_CLK_CTRL': {'address_offset': 0x180, 'access': 'read-write',
+                       'size': 32, 'description': 'PL Clock 1 Control',
+                       'fields': ZYNQ_CLK_FIELDS},
+    'FPGA2_CLK_CTRL': {'address_offset': 0x190, 'access': 'read-write',
+                       'size': 32, 'description': 'PL Clock 2 Control',
+                       'fields': ZYNQ_CLK_FIELDS},
+    'FPGA3_CLK_CTRL': {'address_offset': 0x1a0, 'access': 'read-write',
+                       'size': 32, 'description': 'PL Clock 3 Control',
+                       'fields': ZYNQ_CLK_FIELDS},
+}
+
+ZU_PLL_FIELDS = {
+    'PRE_SRC': {'access': 'read-write', 'bit_offset': 20, 'bit_width': 3,
+                'description': 'Select the clock source for the PLL input'},
+    'DIV2': {'access': 'read-write', 'bit_offset': 16, 'bit_width': 1,
+             'description': 'Divide output frequency by 2'},
+    'FBDIV': {'access': 'read-write', 'bit_offset': 8, 'bit_width': 7,
+              'description': 'Feedback divisor for the PLL'}
+}
+
+ZU_CLK_FIELDS = {
+    'CLKACT': {'access': 'read-write', 'bit_offset': 24, 'bit_width': 1,
+               'description': 'Enable the clock output'},
+    'DIVISOR1': {'access': 'read-write', 'bit_offset': 16, 'bit_width': 6,
+                 'description': 'Second divisor of the clock source'},
+    'DIVISOR0': {'access': 'read-write', 'bit_offset': 8, 'bit_width': 6,
+                 'description': 'First divisor of the clock sourcer'},
+    'SRCSEL': {'access': 'read-write', 'bit_offset': 0, 'bit_width': 3,
+               'description': 'Clock generator input source'}
+}
+
+ZU_ARM_FIELDS = {
+    'DIVISOR0': {'access': 'read-write', 'bit_offset': 8, 'bit_width': 6,
+                 'description': 'First divisor of the clock sourcer'},
+    'SRCSEL': {'access': 'read-write', 'bit_offset': 0, 'bit_width': 3,
+               'description': 'Clock generator input source'}
+}
+
+ZU_CRL_REGISTERS = {
+    'IOPLL_CTRL': {'address_offset': 0x20, 'access': 'read-write',
+                   'size': 32, 'description': 'IOPLL Clock Unit Control',
+                   'fields': ZU_PLL_FIELDS},
+    'RPLL_CTRL': {'address_offset': 0x30, 'access': 'read-write',
+                  'size': 32, 'description': 'RPLL Clock Unit Control',
+                  'fields': ZU_PLL_FIELDS},
+    'PL0_REF_CTRL': {'address_offset': 0xc0, 'access': 'read-write',
+                     'size': 32, 'description': 'PL Clock 0 Control',
+                     'fields': ZU_CLK_FIELDS},
+    'PL1_REF_CTRL': {'address_offset': 0xc4, 'access': 'read-write',
+                     'size': 32, 'description': 'PL Clock 1 Control',
+                     'fields': ZU_CLK_FIELDS},
+    'PL2_REF_CTRL': {'address_offset': 0xc8, 'access': 'read-write',
+                     'size': 32, 'description': 'PL Clock 2 Control',
+                     'fields': ZU_CLK_FIELDS},
+    'PL3_REF_CTRL': {'address_offset': 0xcc, 'access': 'read-write',
+                     'size': 32, 'description': 'PL Clock 3 Control',
+                     'fields': ZU_CLK_FIELDS}
+}
+
+ZU_CRF_REGISTERS = {
+    'APLL_CTRL': {'address_offset': 0x20, 'access': 'read-write',
+                  'size': 32, 'description': 'APLL Clock Unit Control',
+                  'fields': ZU_PLL_FIELDS},
+    'DPLL_CTRL': {'address_offset': 0x2C, 'access': 'read-write',
+                  'size': 32, 'description': 'DPLL Clock Unit Control',
+                  'fields': ZU_PLL_FIELDS},
+    'VPLL_CTRL': {'address_offset': 0x38, 'access': 'read-write',
+                  'size': 32, 'description': 'VPLL Clock Unit Control',
+                  'fields': ZU_PLL_FIELDS},
+    'ACPU_CTRL': {'address_offset': 0x60, 'access': 'read-write',
+                  'size': 32, 'description': 'CPU Clock Control',
+                  'fields': ZU_ARM_FIELDS}
+}
 
 
 class _ClocksMeta(type):
@@ -65,17 +173,7 @@ class _ClocksMeta(type):
         The returned clock rate is measured in MHz.
 
         """
-        return cls.get_cpu_mhz()
-
-    @cpu_mhz.setter
-    def cpu_mhz(cls, clk_mhz):
-        """The setter method for CPU clock.
-
-        Since the CPU clock should not be changed, setting it will raise
-        an exception.
-
-        """
-        raise RuntimeError("Not allowed to change CPU clock.")
+        return cls._instance.get_cpu_mhz()
 
     @property
     def fclk0_mhz(cls):
@@ -90,7 +188,7 @@ class _ClocksMeta(type):
             The returned clock rate measured in MHz.
 
         """
-        return cls.get_pl_clk(0)
+        return cls._instance.get_pl_clk(0)
 
     @fclk0_mhz.setter
     def fclk0_mhz(cls, clk_mhz):
@@ -102,7 +200,7 @@ class _ClocksMeta(type):
             The clock rate in MHz.
 
         """
-        cls.set_pl_clk(0, clk_mhz=clk_mhz)
+        cls._instance.set_pl_clk(0, clk_mhz=clk_mhz)
 
     @property
     def fclk1_mhz(cls):
@@ -117,7 +215,7 @@ class _ClocksMeta(type):
             The returned clock rate measured in MHz.
 
         """
-        return cls.get_pl_clk(1)
+        return cls._instance.get_pl_clk(1)
 
     @fclk1_mhz.setter
     def fclk1_mhz(cls, clk_mhz):
@@ -129,7 +227,7 @@ class _ClocksMeta(type):
             The clock rate in MHz.
 
         """
-        cls.set_pl_clk(1, clk_mhz=clk_mhz)
+        cls._instance.set_pl_clk(1, clk_mhz=clk_mhz)
 
     @property
     def fclk2_mhz(cls):
@@ -144,7 +242,7 @@ class _ClocksMeta(type):
             The returned clock rate measured in MHz.
 
         """
-        return cls.get_pl_clk(2)
+        return cls._instance.get_pl_clk(2)
 
     @fclk2_mhz.setter
     def fclk2_mhz(cls, clk_mhz):
@@ -156,7 +254,7 @@ class _ClocksMeta(type):
             The clock rate in MHz.
 
         """
-        cls.set_pl_clk(2, clk_mhz=clk_mhz)
+        cls._instance.set_pl_clk(2, clk_mhz=clk_mhz)
 
     @property
     def fclk3_mhz(cls):
@@ -171,7 +269,7 @@ class _ClocksMeta(type):
             The returned clock rate measured in MHz.
 
         """
-        return cls.get_pl_clk(3)
+        return cls._instance.get_pl_clk(3)
 
     @fclk3_mhz.setter
     def fclk3_mhz(cls, clk_mhz):
@@ -183,10 +281,70 @@ class _ClocksMeta(type):
             The clock rate in MHz.
 
         """
-        cls.set_pl_clk(3, clk_mhz=clk_mhz)
+        cls._instance.set_pl_clk(3, clk_mhz=clk_mhz)
 
-    @classmethod
-    def get_pl_clk(mcs, clk_idx):
+    def get_pl_clk(cls, clk_idx):
+        """This method will return the clock frequency.
+
+        This method is not exposed to users.
+
+        Parameters
+        ----------
+        clk_idx : int
+            The index of the PL clock to be changed, from 0 to 3.
+
+        """
+        cls._instance.get_pl_clk(clk_idx)
+
+    def set_pl_clk(cls, clk_idx, div0=None, div1=None,
+                   clk_mhz=DEFAULT_PL_CLK_MHZ):
+        """This method sets a PL clock frequency.
+
+        Users have to specify the index of the PL clock to be changed.
+        For example, for fclk1 (Zynq) or pl_clk_1 (ZynqUltrascale),
+        `clk_idx` is 1.
+
+        The CPU, and other source clocks, by default, should not get changed.
+
+        Users have two options:
+        1. specify the two frequency divider values directly (div0, div1), or
+        2. specify the clock rate, in which case the divider values will be
+        calculated.
+
+        Note
+        ----
+        In case `div0` and `div1` are both specified, the parameter `clk_mhz`
+        will be ignored.
+
+        Parameters
+        ----------
+        clk_idx : int
+            The index of the PL clock to be changed, from 0 to 3.
+        div0 : int
+            The first frequency divider value.
+        div1 : int
+            The second frequency divider value.
+        clk_mhz : float
+            The clock rate in MHz.
+
+        """
+        cls._instance.set_pl_clk(clk_idx, div0, div1, clk_mhz)
+
+    @property
+    def _instance(cls):
+        if not hasattr(cls, '_real_instance'):
+            if CPU_ARCH == ZYNQ_ARCH:
+                cls._real_instance = _ClocksZynq()
+            elif CPU_ARCH == ZU_ARCH:
+                cls._real_instance = _ClocksUltrascale()
+            else:
+                raise RuntimeError('Architecture not supported for Clocks')
+        return cls._real_instance
+
+
+class _ClocksBase:
+
+    def get_pl_clk(self, clk_idx):
         """This method will return the clock frequency.
 
         This method is not exposed to users.
@@ -200,16 +358,15 @@ class _ClocksMeta(type):
         if clk_idx not in range(4):
             raise ValueError("Valid PL clock index is 0 - 3.")
 
-        pl_clk_reg = mcs.PL_CLK_CTRLS[clk_idx]
-        src_clk_idx = pl_clk_reg[mcs.PL_CLK_SRC_FIELD]
-        src_clk_mhz = mcs._get_src_clk_mhz(src_clk_idx)
-        pl_clk_odiv0 = pl_clk_reg[mcs.PL_CLK_ODIV0_FIELD]
-        pl_clk_odiv1 = pl_clk_reg[mcs.PL_CLK_ODIV1_FIELD]
+        pl_clk_reg = self.PL_CLK_CTRLS[clk_idx]
+        src_clk_idx = pl_clk_reg.SRCSEL
+        src_clk_mhz = self._get_src_clk_mhz(src_clk_idx)
+        pl_clk_odiv0 = pl_clk_reg.DIVISOR0
+        pl_clk_odiv1 = pl_clk_reg.DIVISOR1
 
         return round(src_clk_mhz / (pl_clk_odiv0 * pl_clk_odiv1), 6)
 
-    @classmethod
-    def set_pl_clk(mcs, clk_idx, div0=None, div1=None,
+    def set_pl_clk(self, clk_idx, div0=None, div1=None,
                    clk_mhz=DEFAULT_PL_CLK_MHZ):
         """This method sets a PL clock frequency.
 
@@ -244,15 +401,15 @@ class _ClocksMeta(type):
         if clk_idx not in range(4):
             raise ValueError("Valid PL clock index is 0 - 3.")
 
-        pl_clk_reg = mcs.PL_CLK_CTRLS[clk_idx]
-        div0_width = Register.count(mcs.PL_CLK_ODIV0_FIELD)
-        div1_width = Register.count(mcs.PL_CLK_ODIV1_FIELD)
-        src_clk_idx = pl_clk_reg[mcs.PL_CLK_SRC_FIELD]
-        src_clk_mhz = mcs._get_src_clk_mhz(src_clk_idx)
+        pl_clk_reg = self.PL_CLK_CTRLS[clk_idx]
+        div0_width = 6
+        div1_width = 6
+        src_clk_idx = pl_clk_reg.SRCSEL
+        src_clk_mhz = self._get_src_clk_mhz(src_clk_idx)
 
         if div0 is None and div1 is None:
-            div0, div1 = mcs._get_2_divisors(src_clk_mhz, clk_mhz,
-                                             div0_width, div1_width)
+            div0, div1 = self._get_2_divisors(src_clk_mhz, clk_mhz,
+                                              div0_width, div1_width)
         elif div0 is not None and div1 is None:
             div1 = round(src_clk_mhz / clk_mhz / div0)
         elif div1 is not None and div0 is None:
@@ -263,24 +420,19 @@ class _ClocksMeta(type):
         if div1 <= 0 or div1 > ((1 << div1_width) - 1):
             raise ValueError("Frequency divider 1 value out of range.")
 
-        pl_clk_reg[mcs.PL_CLK_ODIV0_FIELD] = div0
-        pl_clk_reg[mcs.PL_CLK_ODIV1_FIELD] = div1
+        pl_clk_reg.DIVISOR0 = div0
+        pl_clk_reg.DIVISOR1 = div1
 
-    @classmethod
-    def _get_src_clk_mhz(mcs, clk_idx):
+    def _get_src_clk_mhz(self, clk_idx):
         """The getter method for PL clock (pl_clk) sources.
 
         The returned clock rate is measured in MHz.
 
         """
-        if clk_idx not in range(4):
-            raise ValueError("Valid PL clock index is 0 - 3.")
+        src_pll_reg = self.PL_SRC_PLL_CTRLS[clk_idx]
+        return round(self.get_pll_mhz(src_pll_reg), 6)
 
-        src_pll_reg = mcs.PL_SRC_PLL_CTRLS[clk_idx]
-        return round(mcs.get_pll_mhz(src_pll_reg), 6)
-
-    @classmethod
-    def _get_2_divisors(mcs, freq_high, freq_desired, reg0_width, reg1_width):
+    def _get_2_divisors(self, freq_high, freq_desired, reg0_width, reg1_width):
         """Return 2 divisors of the specified width for frequency divider.
 
         Warning will be raised if the closest clock rate achievable
@@ -304,22 +456,16 @@ class _ClocksMeta(type):
 
         """
         div_product_desired = round(freq_high / freq_desired, 6)
-        _, q0 = min(enumerate(mcs.VALID_CLOCK_DIV_PRODUCTS),
+        _, q0 = min(enumerate(self.VALID_CLOCK_DIV_PRODUCTS.keys()),
                     key=lambda x: abs(x[1] - div_product_desired))
         if abs(freq_desired - freq_high / q0) > 0.01 * freq_desired:
             warnings.warn(
                 "Setting frequency to the closet possible value {}MHz.".format(
                     round(freq_high / q0, 5)))
-
-        max_val0 = 1 << reg0_width
-        max_val1 = 1 << reg1_width
-        for i in range(1, max_val0):
-            for j in range(1, max_val1):
-                if i * j == q0:
-                    return i, j
+        return self.VALID_CLOCK_DIV_PRODUCTS[q0]
 
 
-class _ClocksUltrascale(_ClocksMeta):
+class _ClocksUltrascale(_ClocksBase):
     """Implementation class for all Zynq Ultrascale PS and PL clocks
     not exposed to users.
 
@@ -329,76 +475,45 @@ class _ClocksUltrascale(_ClocksMeta):
 
     """
     DEFAULT_SRC_CLK_MHZ = 33.333
-
-    # Registers in the CRL "Namespace"
     CRL_APB_ADDRESS = 0xFF5E0000
-    IOPLL_CTRL_OFFSET = 0x20
-    RPLL_CTRL_OFFSET = 0x30
-
-    PL0_CTRL_OFFSET = 0xC0
-    PL1_CTRL_OFFSET = 0xC4
-    PL2_CTRL_OFFSET = 0xC8
-    PL3_CTRL_OFFSET = 0xCC
-    PLX_CTRL_CLKACT_FIELD = 24
-    PLX_CTRL_ODIV1_FIELD = slice(21, 16)
-    PLX_CTRL_ODIV0_FIELD = slice(13, 8)
-    PLX_CTRL_SRC_FIELD = slice(2, 0)
-
+    CRF_APB_ADDRESS = 0xFD1A0000
+    CRX_APB_SRC_DEFAULT = 0
     PLX_CTRL_SRC_DEFAULT = 0
 
-    PL_CLK_SRC_FIELD = PLX_CTRL_SRC_FIELD
-    PL_CLK_ODIV0_FIELD = PLX_CTRL_ODIV0_FIELD
-    PL_CLK_ODIV1_FIELD = PLX_CTRL_ODIV1_FIELD
+    VALID_CLOCK_DIV_PRODUCTS = {i*j: (i, j)
+                                for i in range(1 << 6)
+                                for j in range(1 << 6)}
 
-    # Registers in the CRF "Namespace"
-    CRF_APB_ADDRESS = 0xFD1A0000
-    APLL_CTRL_OFFSET = 0x20
-    DPLL_CTRL_OFFSET = 0x2C
-    VPLL_CTRL_OFFSET = 0x38
+    def __init__(self, src_clk_mhz=33.333):
+        self._ref_clk_mhz = src_clk_mhz
 
-    ACPU_CTRL_OFFSET = 0x60
-    ACPU_CTRL_CLKHALF_FIELD = 25
-    ACPU_CTRL_CLKFULL_FIELD = 24
-    ACPU_CTRL_ODIV_FIELD = slice(13, 8)
-    ACPU_CTRL_SRC_FIELD = slice(2, 0)
+        from .mmio import MMIO
+        self._crf_mmio = MMIO(self.CRF_APB_ADDRESS, 0x100)
+        self._crl_mmio = MMIO(self.CRL_APB_ADDRESS, 0x100)
 
-    # Fields shared between CRF and CRL "Namespaces"
-    CRX_APB_SRC_DEFAULT = 0
-    CRX_APB_SRC_FIELD = slice(22, 20)
-    CRX_APB_ODIVBY2_FIELD = 16
-    CRX_APB_FBDIV_FIELD = slice(14, 8)
+        from .registers import RegisterMap
+        CrfRegisterMap = RegisterMap.create_subclass('CRF', ZU_CRF_REGISTERS)
+        CrlRegisterMap = RegisterMap.create_subclass('CRL', ZU_CRL_REGISTERS)
 
-    PLX_CTRL_ODIV1_WIDTH = (PLX_CTRL_ODIV1_FIELD.start -
-                            PLX_CTRL_ODIV1_FIELD.stop + 1)
-    PLX_CTRL_ODIV0_WIDTH = (PLX_CTRL_ODIV0_FIELD.start -
-                            PLX_CTRL_ODIV0_FIELD.stop + 1)
-    VALID_CLOCK_DIV_PRODUCTS = sorted(list(set(
-        (np.multiply(
-            np.arange(1 << PLX_CTRL_ODIV1_WIDTH).reshape(
-                1 << PLX_CTRL_ODIV1_WIDTH, 1),
-            np.arange(1 << PLX_CTRL_ODIV0_WIDTH))).reshape(-1))))
+        self._crf_registers = CrfRegisterMap(self._crf_mmio.array)
+        self._crl_registers = CrlRegisterMap(self._crl_mmio.array)
 
-    if CPU_ARCH_IS_SUPPORTED:
-        IOPLL_CTRL = Register(CRL_APB_ADDRESS + IOPLL_CTRL_OFFSET)
-        RPLL_CTRL = Register(CRL_APB_ADDRESS + RPLL_CTRL_OFFSET)
+        self.PL_CLK_CTRLS = [
+            self._crl_registers.PL0_REF_CTRL, self._crl_registers.PL1_REF_CTRL,
+            self._crl_registers.PL2_REF_CTRL, self._crl_registers.PL3_REF_CTRL
+        ]
 
-        PL_CLK_CTRLS = [Register(CRL_APB_ADDRESS + PL0_CTRL_OFFSET),
-                        Register(CRL_APB_ADDRESS + PL1_CTRL_OFFSET),
-                        Register(CRL_APB_ADDRESS + PL2_CTRL_OFFSET),
-                        Register(CRL_APB_ADDRESS + PL3_CTRL_OFFSET)]
+        self.PL_SRC_PLL_CTRLS = [
+            self._crl_registers.IOPLL_CTRL, None,
+            self._crl_registers.RPLL_CTRL, self._crf_registers.DPLL_CTRL
+        ]
 
-        ACPU_CTRL = Register(CRF_APB_ADDRESS + ACPU_CTRL_OFFSET)
+        self.ACPU_SRC_PLL_CTRLS = [
+            self._crf_registers.APLL_CTRL, None,
+            self._crf_registers.DPLL_CTRL, self._crf_registers.VPLL_CTRL
+        ]
 
-        APLL_CTRL = Register(CRF_APB_ADDRESS + APLL_CTRL_OFFSET)
-        DPLL_CTRL = Register(CRF_APB_ADDRESS + DPLL_CTRL_OFFSET)
-        VPLL_CTRL = Register(CRF_APB_ADDRESS + VPLL_CTRL_OFFSET)
-
-        PL_SRC_PLL_CTRLS = [IOPLL_CTRL, IOPLL_CTRL, RPLL_CTRL, DPLL_CTRL]
-        ACPU_SRC_PLL_CTRLS = [APLL_CTRL, APLL_CTRL, DPLL_CTRL, VPLL_CTRL]
-
-
-    @classmethod
-    def set_pl_clk(mcs, clk_idx, div0=None, div1=None,
+    def set_pl_clk(self, clk_idx, div0=None, div1=None,
                    clk_mhz=DEFAULT_PL_CLK_MHZ):
         """This method sets a PL clock frequency.
 
@@ -428,13 +543,12 @@ class _ClocksUltrascale(_ClocksMeta):
             The clock rate in MHz.
 
         """
-        pl_clk_reg = mcs.PL_CLK_CTRLS[clk_idx]
-        pl_clk_reg[mcs.PLX_CTRL_CLKACT_FIELD] = 1
-        pl_clk_reg[mcs.PLX_CTRL_SRC_FIELD] = mcs.PLX_CTRL_SRC_DEFAULT
+        pl_clk_reg = self.PL_CLK_CTRLS[clk_idx]
+        pl_clk_reg.CLKACT = 1
+        pl_clk_reg.SRC_FIELD = self.PLX_CTRL_SRC_DEFAULT
         super().set_pl_clk(clk_idx, div0, div1, clk_mhz)
 
-    @classmethod
-    def get_pll_mhz(mcs, pll_reg):
+    def get_pll_mhz(self, pll_reg):
         """The getter method for PLL output clocks.
 
         Parameters
@@ -448,31 +562,31 @@ class _ClocksUltrascale(_ClocksMeta):
             The PLL output clock rate measured in MHz.
 
         """
-        if pll_reg[mcs.CRX_APB_SRC_FIELD] != mcs.CRX_APB_SRC_DEFAULT:
+        if pll_reg.PRE_SRC != self.CRX_APB_SRC_DEFAULT:
             raise ValueError("Invalid PLL Source")
 
-        pll_fbdiv = pll_reg[mcs.CRX_APB_FBDIV_FIELD]
-        if pll_reg[mcs.CRX_APB_ODIVBY2_FIELD] == 1:
+        pll_fbdiv = pll_reg.FBDIV
+        if pll_reg.DIV2:
             pll_odiv2 = 2
         else:
             pll_odiv2 = 1
 
-        return mcs.DEFAULT_SRC_CLK_MHZ * pll_fbdiv / pll_odiv2
+        return self._ref_clk_mhz * pll_fbdiv / pll_odiv2
 
-    @classmethod
-    def get_cpu_mhz(mcs):
+    def get_cpu_mhz(self):
         """The getter method for CPU clock.
 
         The returned clock rate is measured in MHz.
 
         """
-        arm_src_pll_idx = mcs.ACPU_CTRL[mcs.ACPU_CTRL_SRC_FIELD]
-        arm_clk_odiv = mcs.ACPU_CTRL[mcs.ACPU_CTRL_ODIV_FIELD]
-        src_pll_reg = mcs.ACPU_SRC_PLL_CTRLS[arm_src_pll_idx]
-        return round(mcs.get_pll_mhz(src_pll_reg) / arm_clk_odiv, 6)
+        acpu_reg = self._crf_registers.ACPU_CTRL
+        arm_src_pll_idx = acpu_reg.SRCSEL
+        arm_clk_odiv = acpu_reg.DIVISOR0
+        src_pll_reg = self.ACPU_SRC_PLL_CTRLS[arm_src_pll_idx]
+        return round(self.get_pll_mhz(src_pll_reg) / arm_clk_odiv, 6)
 
 
-class _ClocksZynq(_ClocksMeta):
+class _ClocksZynq(_ClocksBase):
     """Implementation class for all Zynq 7-Series PS and PL clocks
     not exposed to users.
 
@@ -482,60 +596,44 @@ class _ClocksZynq(_ClocksMeta):
 
     """
     DEFAULT_SRC_CLK_MHZ = 50.0
-
     SLCR_BASE_ADDRESS = 0xF8000000
-    ARM_PLL_CTRL_OFFSET = 0x100
-    DDR_PLL_CTRL_OFFSET = 0x104
-    IO_PLL_CTRL_OFFSET = 0x108
-    SRC_PLL_FBDIV_FIELD = slice(18, 12)
 
-    FCLK0_CTRL_OFFSET = 0x170
-    FCLK1_CTRL_OFFSET = 0x180
-    FCLK2_CTRL_OFFSET = 0x190
-    FCLK3_CTRL_OFFSET = 0x1A0
-    FCLKX_CTRL_ODIV1_FIELD = slice(25, 20)
-    FCLKX_CTRL_ODIV0_FIELD = slice(13, 8)
-    FCLKX_CTRL_SRC_FIELD = slice(5, 4)
+    VALID_CLOCK_DIV_PRODUCTS = {i*j: (i, j)
+                                for i in range(1 << 6)
+                                for j in range(1 << 6)}
 
-    PL_CLK_SRC_FIELD = FCLKX_CTRL_SRC_FIELD
-    PL_CLK_ODIV0_FIELD = FCLKX_CTRL_ODIV0_FIELD
-    PL_CLK_ODIV1_FIELD = FCLKX_CTRL_ODIV1_FIELD
+    def __init__(self, ref_clk_mhz=50.0):
+        self._ref_clk_mhz = ref_clk_mhz
 
-    ARM_CLK_CTRL_OFFSET = 0x120
-    ARM_CLK_ODIV_FIELD = slice(13, 8)
-    ARM_CLK_SRC_FIELD = slice(5, 4)
+        from .mmio import MMIO
+        self._slcr_mmio = MMIO(self.SLCR_BASE_ADDRESS, 0x200)
 
-    FCLKX_CTRL_ODIV1_WIDTH = (FCLKX_CTRL_ODIV1_FIELD.start -
-                              FCLKX_CTRL_ODIV1_FIELD.stop + 1)
-    FCLKX_CTRL_ODIV0_WIDTH = (FCLKX_CTRL_ODIV0_FIELD.start -
-                              FCLKX_CTRL_ODIV0_FIELD.stop + 1)
-    VALID_CLOCK_DIV_PRODUCTS = sorted(list(set(
-        (np.multiply(
-            np.arange(1 << FCLKX_CTRL_ODIV1_WIDTH).reshape(
-                1 << FCLKX_CTRL_ODIV1_WIDTH, 1),
-            np.arange(1 << FCLKX_CTRL_ODIV0_WIDTH))).reshape(-1))))
+        from .registers import RegisterMap
+        SlcrRegisters = RegisterMap.create_subclass('SL', ZYNQ_SLCR_REGISTERS)
+        self._slcr_registers = SlcrRegisters(self._slcr_mmio.array)
 
-    if CPU_ARCH_IS_SUPPORTED:
-        ARM_PLL_CTRL = Register(SLCR_BASE_ADDRESS + ARM_PLL_CTRL_OFFSET)
-        DDR_PLL_CTRL = Register(SLCR_BASE_ADDRESS + DDR_PLL_CTRL_OFFSET)
-        IO_PLL_CTRL = Register(SLCR_BASE_ADDRESS + IO_PLL_CTRL_OFFSET)
+        self.PL_CLK_CTRLS = [
+            self._slcr_registers.FPGA0_CLK_CTRL,
+            self._slcr_registers.FPGA1_CLK_CTRL,
+            self._slcr_registers.FPGA2_CLK_CTRL,
+            self._slcr_registers.FPGA3_CLK_CTRL
+        ]
 
-        PL_SRC_PLL_CTRLS = [IO_PLL_CTRL, IO_PLL_CTRL,
-                            ARM_PLL_CTRL, DDR_PLL_CTRL]
+        self.PL_SRC_PLL_CTRLS = [
+            self._slcr_registers.IO_PLL_CTRL,
+            self._slcr_registers.IO_PLL_CTRL,
+            self._slcr_registers.ARM_PLL_CTRL,
+            self._slcr_registers.DDR_PLL_CTRL,
+        ]
 
-        PL_CLK_CTRLS = [Register(SLCR_BASE_ADDRESS + FCLK0_CTRL_OFFSET),
-                        Register(SLCR_BASE_ADDRESS + FCLK1_CTRL_OFFSET),
-                        Register(SLCR_BASE_ADDRESS + FCLK2_CTRL_OFFSET),
-                        Register(SLCR_BASE_ADDRESS + FCLK3_CTRL_OFFSET)]
+        self.ARM_SRC_PLL_CTRLS = [
+            self._slcr_registers.ARM_PLL_CTRL,
+            self._slcr_registers.ARM_PLL_CTRL,
+            self._slcr_registers.DDR_PLL_CTRL,
+            self._slcr_registers.IO_PLL_CTRL,
+        ]
 
-        ARM_CLK_CTRL = Register(SLCR_BASE_ADDRESS + ARM_CLK_CTRL_OFFSET)
-
-        ARM_SRC_PLL_CTRLS = [ARM_PLL_CTRL, ARM_PLL_CTRL,
-                             DDR_PLL_CTRL, IO_PLL_CTRL]
-
-
-    @classmethod
-    def set_pl_clk(mcs, clk_idx, div0=None, div1=None,
+    def set_pl_clk(self, clk_idx, div0=None, div1=None,
                    clk_mhz=DEFAULT_PL_CLK_MHZ):
         """This method sets a PL clock frequency.
 
@@ -567,8 +665,7 @@ class _ClocksZynq(_ClocksMeta):
         """
         super().set_pl_clk(clk_idx, div0, div1, clk_mhz)
 
-    @classmethod
-    def get_pll_mhz(mcs, pll_reg):
+    def get_pll_mhz(self, pll_reg):
         """The getter method for PLL output clocks.
 
         Parameters
@@ -582,13 +679,12 @@ class _ClocksZynq(_ClocksMeta):
             The PLL output clock rate measured in MHz.
 
         """
-        pll_fbdiv = pll_reg[mcs.SRC_PLL_FBDIV_FIELD]
-        clk_mhz = mcs.DEFAULT_SRC_CLK_MHZ * pll_fbdiv
+        pll_fbdiv = pll_reg.PLL_FDIV
+        clk_mhz = self._ref_clk_mhz * pll_fbdiv
 
         return round(clk_mhz, 6)
 
-    @classmethod
-    def get_cpu_mhz(mcs):
+    def get_cpu_mhz(self):
         """The getter method for the CPU clock.
 
         Returns
@@ -597,21 +693,14 @@ class _ClocksZynq(_ClocksMeta):
             The CPU clock rate measured in MHz.
 
         """
-        arm_src_pll_idx = mcs.ARM_CLK_CTRL[mcs.ARM_CLK_SRC_FIELD]
-        arm_clk_odiv = mcs.ARM_CLK_CTRL[mcs.ARM_CLK_ODIV_FIELD]
-        src_pll_reg = mcs.ARM_SRC_PLL_CTRLS[arm_src_pll_idx]
-        return round(mcs.get_pll_mhz(src_pll_reg) / arm_clk_odiv, 6)
+        cpu_ctrl_reg = self._slcr_registers.ARM_CLK_CTRL
+        arm_src_pll_idx = cpu_ctrl_reg.SRCSEL
+        arm_clk_odiv = cpu_ctrl_reg.DIVISOR
+        src_pll_reg = self.ARM_SRC_PLL_CTRLS[arm_src_pll_idx]
+        return round(self.get_pll_mhz(src_pll_reg) / arm_clk_odiv, 6)
 
 
-if CPU_ARCH == ZU_ARCH:
-    _ClockParent = _ClocksUltrascale
-elif CPU_ARCH == ZYNQ_ARCH:
-    _ClockParent = _ClocksZynq
-else:
-    _ClockParent = object
-
-
-class Clocks(_ClockParent, metaclass=_ClocksMeta):
+class Clocks(metaclass=_ClocksMeta):
     """Class for all the PS and PL clocks exposed to users.
 
     With this class, users can get the CPU clock and all the PL clocks. Users

--- a/pynq/registers.py
+++ b/pynq/registers.py
@@ -204,7 +204,7 @@ class Register:
                 raise ValueError("Value to be set should be either 0 or 1.")
             self._debug("Setting bit {} at address {} to {}"
                         .format(lower, hex(self.address), value))
-            mask = 1 << index
+            mask = 1 << lower
             curr_val = int(self._buffer[0])
             self._buffer[0] = (curr_val & ~mask) | (value << lower)
         else:

--- a/tests/test_clocks.py
+++ b/tests/test_clocks.py
@@ -1,0 +1,299 @@
+import math
+import pynq
+import pytest
+import importlib
+import os
+import numpy as np
+from .mock_devices import MockMemoryMappedDevice
+
+
+ZYNQ_SLCR_OFFSET = 0xF8000000
+ZU_LPD_OFFSET = 0xFF5E0000
+ZU_FPD_OFFSET = 0xFD1A0000
+
+
+class FakeUname:
+    def __init__(self, machine):
+        self.machine = machine
+
+
+def be_zynq():
+    return FakeUname(pynq.ps.ZYNQ_ARCH)
+
+
+def be_zu():
+    return FakeUname(pynq.ps.ZU_ARCH)
+
+
+# Entries of the form PLL_OFFSET, CLK_REG
+ZYNQ_READ_PLLS = {
+    'arm_pll': [0x100, 0x0030_0520],
+    'ddr_pll': [0x104, 0x0030_0530],
+    'io0_pll': [0x108, 0x0030_0500],
+    'io1_pll': [0x108, 0x0030_0510],
+}
+
+ZYNQ_READ_CLKS = {
+    'fclk0_mhz': 0x170,
+    'fclk1_mhz': 0x180,
+    'fclk2_mhz': 0x190,
+    'fclk3_mhz': 0x1A0,
+}
+
+ZYNQ_CPU_PLLS = {
+    'arm0_pll': [0x100, 0x0200],
+    'arm1_pll': [0x100, 0x0210],
+    'ddr_pll': [0x104, 0x0220],
+    'io_pll': [0x108, 0x0230],
+}
+
+ZU_READ_PLLS = {
+    'iopll': (1, 0x20, 0x0050300),
+    'rpll': (1, 0x30, 0x0050302),
+    'dpll': (0, 0x2C, 0x0050303),
+}
+
+ZU_READ_CLKS = {
+    'fclk0_mhz': 0xc0,
+    'fclk1_mhz': 0xc4,
+    'fclk2_mhz': 0xc8,
+    'fclk3_mhz': 0xcC,
+}
+
+ZU_CPU_PLLS = {
+    'apll': (0x20, 0x200),
+    'dpll': (0x2C, 0x202),
+    'vpll': (0x38, 0x203),
+}
+
+
+@pytest.fixture
+def setup_zynq(monkeypatch):
+    old_arch = pynq.ps.CPU_ARCH
+    monkeypatch.setattr(os, 'uname', be_zynq)
+    device = MockMemoryMappedDevice('zynq_clocks')
+    pynq.Device.active_device = device
+    slcr_buffer = device.mmap(ZYNQ_SLCR_OFFSET, 0x200)
+    slcr_array = np.frombuffer(slcr_buffer, dtype='u4')
+    new_ps = importlib.reload(pynq.ps)
+    Clocks = new_ps.Clocks
+
+    yield Clocks, slcr_array
+
+    pynq.Device.active_device = None
+    pynq.ps.CPU_ARCH = old_arch
+
+
+@pytest.fixture
+def setup_zu(monkeypatch):
+    old_arch = pynq.ps.CPU_ARCH
+    monkeypatch.setattr(os, 'uname', be_zu)
+    device = MockMemoryMappedDevice('zu_clocks')
+    pynq.Device.active_device = device
+    lpd_buffer = device.mmap(ZU_LPD_OFFSET, 0x100)
+    lpd_array = np.frombuffer(lpd_buffer, dtype='u4')
+
+    fpd_buffer = device.mmap(ZU_FPD_OFFSET, 0x100)
+    fpd_array = np.frombuffer(fpd_buffer, dtype='u4')
+
+    new_ps = importlib.reload(pynq.ps)
+    Clocks = new_ps.Clocks
+
+    yield Clocks, lpd_array, fpd_array
+
+    pynq.Device.active_device = None
+    pynq.ps.CPU_ARCH = old_arch
+
+
+def split_clk_reg(reg_val):
+    source = (reg_val >> 4) & 0x3
+    div0 = (reg_val >> 8) & 0x3F
+    div1 = (reg_val >> 20) & 0x3F
+    return source, div0, div1
+
+
+def split_zu_reg(reg_val):
+    source = (reg_val) & 0x07
+    div0 = (reg_val >> 8) & 0x3F
+    div1 = (reg_val >> 16) & 0x3F
+    return source, div0, div1
+
+
+@pytest.mark.parametrize('pll_name', ZYNQ_READ_PLLS.keys())
+@pytest.mark.parametrize('clk_name', ZYNQ_READ_CLKS.keys())
+def test_zynq_pl(setup_zynq, pll_name, clk_name):
+    pll_reg, clk_val = ZYNQ_READ_PLLS[pll_name]
+    clk_reg = ZYNQ_READ_CLKS[clk_name]
+    Clocks, slcr_array = setup_zynq
+
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    assert getattr(Clocks, clk_name) == 100
+
+    setattr(Clocks, clk_name, 50)
+    source, div0, div1 = split_clk_reg(slcr_array[clk_reg >> 2])
+    assert div0 * div1 == 30
+    expected_source, _, _ = split_clk_reg(clk_val)
+    assert expected_source == source
+
+
+@pytest.mark.parametrize('pll_name', ZU_READ_PLLS.keys())
+@pytest.mark.parametrize('clk_name', ZU_READ_CLKS.keys())
+def test_zu_pl(setup_zu, pll_name, clk_name):
+    pll_region, pll_reg, clk_val = ZU_READ_PLLS[pll_name]
+    clk_reg = ZU_READ_CLKS[clk_name]
+    Clocks, lpd_array, fpd_array = setup_zu
+
+    if pll_region:
+        lpd_array[pll_reg >> 2] = 45 << 8  # FBDIV of 45 (1500 MHz)
+    else:
+        fpd_array[pll_reg >> 2] = 45 << 8
+
+    lpd_array[clk_reg >> 2] = clk_val
+
+    assert math.isclose(getattr(Clocks, clk_name), 99.999)
+
+    if pll_name == 'iopll':
+        setattr(Clocks, clk_name, 50)
+        source, div0, div1 = split_zu_reg(lpd_array[clk_reg >> 2])
+        assert div0 * div1 == 30
+        assert source == 0
+
+
+@pytest.mark.parametrize('pll_name', ZU_READ_PLLS.keys())
+@pytest.mark.parametrize('clk_name', ZU_READ_CLKS.keys())
+def test_zu_pl_div2(setup_zu, pll_name, clk_name):
+    pll_region, pll_reg, clk_val = ZU_READ_PLLS[pll_name]
+    clk_reg = ZU_READ_CLKS[clk_name]
+    Clocks, lpd_array, fpd_array = setup_zu
+
+    if pll_region:
+        lpd_array[pll_reg >> 2] = 0x10000 | (45 << 8)  # FBDIV of 45 (1500 MHz)
+    else:
+        fpd_array[pll_reg >> 2] = 0x10000 | (45 << 8)
+
+    lpd_array[clk_reg >> 2] = clk_val
+
+    assert math.isclose(getattr(Clocks, clk_name), 49.9995)
+
+    if pll_name == 'iopll':
+        setattr(Clocks, clk_name, 25)
+        source, div0, div1 = split_zu_reg(lpd_array[clk_reg >> 2])
+        assert div0 * div1 == 30
+        assert source == 0
+
+
+def test_invalid_clkidx(setup_zynq):
+    Clocks, slcr_array = setup_zynq
+    with pytest.raises(ValueError):
+        Clocks.get_pl_clk(-1)
+    with pytest.raises(ValueError):
+        Clocks.get_pl_clk(4)
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(-1)
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(4)
+
+
+def test_zynq_nearest(setup_zynq):
+    pll_reg, clk_val = ZYNQ_READ_PLLS['arm_pll']
+    clk_reg = ZYNQ_READ_CLKS['fclk0_mhz']
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    with pytest.warns(UserWarning):
+        Clocks.fclk0_mhz = 440
+
+    source, div0, div1 = split_clk_reg(slcr_array[clk_reg >> 2])
+    assert div0 * div1 == 3
+
+
+def test_divider0(setup_zynq):
+    pll_reg, clk_val = ZYNQ_READ_PLLS['arm_pll']
+    clk_reg = ZYNQ_READ_CLKS['fclk0_mhz']
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    Clocks.set_pl_clk(0, div0=5, clk_mhz=50)
+
+    source, div0, div1 = split_clk_reg(slcr_array[clk_reg >> 2])
+    assert div0 == 5
+    assert div1 == 6
+
+
+def test_divider1(setup_zynq):
+    pll_reg, clk_val = ZYNQ_READ_PLLS['arm_pll']
+    clk_reg = ZYNQ_READ_CLKS['fclk0_mhz']
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    Clocks.set_pl_clk(0, div1=5, clk_mhz=50)
+
+    source, div0, div1 = split_clk_reg(slcr_array[clk_reg >> 2])
+    assert div0 == 6
+    assert div1 == 5
+
+
+def test_divider01(setup_zynq):
+    pll_reg, clk_val = ZYNQ_READ_PLLS['arm_pll']
+    clk_reg = ZYNQ_READ_CLKS['fclk0_mhz']
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    Clocks.set_pl_clk(0, div0=3, div1=5, clk_mhz=50)
+
+    source, div0, div1 = split_clk_reg(slcr_array[clk_reg >> 2])
+    assert div0 == 3
+    assert div1 == 5
+
+
+def test_div_underflow(setup_zynq):
+    pll_reg, clk_val = ZYNQ_READ_PLLS['arm_pll']
+    clk_reg = ZYNQ_READ_CLKS['fclk0_mhz']
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[clk_reg >> 2] = clk_val
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(0, div0=-1, div1=10)
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(0, div0=10, div1=0)
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(0, div0=64, div1=10)
+    with pytest.raises(ValueError):
+        Clocks.set_pl_clk(0, div0=10, div1=64)
+
+
+@pytest.mark.parametrize('pll_name', ZU_READ_PLLS.keys())
+def test_zu_invalid_source(setup_zu, pll_name):
+    pll_region, pll_reg, clk_val = ZU_READ_PLLS[pll_name]
+    clk_reg = ZU_READ_CLKS['fclk0_mhz']
+    Clocks, lpd_array, fpd_array = setup_zu
+    if pll_region:
+        lpd_array[pll_reg >> 2] = 0x10000 | (45 << 8) | (4 << 20)
+    else:
+        fpd_array[pll_reg >> 2] = 0x10000 | (45 << 8) | (4 << 20)
+
+    lpd_array[clk_reg >> 2] = clk_val
+    with pytest.raises(ValueError):
+        Clocks.fclk0_mhz
+
+
+@pytest.mark.parametrize('pll_name', ZU_CPU_PLLS.keys())
+def test_zu_cpu(setup_zu, pll_name):
+    pll_reg, clk_val = ZU_CPU_PLLS[pll_name]
+    Clocks, lpd_array, fpd_array = setup_zu
+
+    fpd_array[pll_reg >> 2] = 45 << 8
+    fpd_array[0x60 >> 2] = clk_val
+
+    assert Clocks.cpu_mhz == 749.9925
+
+
+@pytest.mark.parametrize('pll_name', ZYNQ_CPU_PLLS.keys())
+def test_zynq_cpu(setup_zynq, pll_name):
+    pll_reg, clk_val = ZYNQ_CPU_PLLS[pll_name]
+    Clocks, slcr_array = setup_zynq
+    slcr_array[pll_reg >> 2] = 30 << 12  # FBDIV of 30 (1500 MHz)
+    slcr_array[0x120 >> 2] = clk_val
+
+    assert Clocks.cpu_mhz == 750

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -17,6 +17,10 @@ TEST_VECTORS = {
         (32, 0x0000_0000, 4, 1, 0, 0x0000_0010, 1),
     "single-bit-clear-32":
         (32, 0x0000_0010, 4, 0, 1, 0x0000_0000, 1),
+    "single-bit-range-set-32":
+        (32, 0x0000_0000, slice(4, 4), 1, 0, 0x0000_0010, 1),
+    "single-bit-range-clear-32":
+        (32, 0x0000_0010, slice(4, 4), 0, 1, 0x0000_0000, 1),
     "multi-bit-set-32":
         (32, 0x0000_0000, slice(7, 4), 0xF, 0, 0x0000_00F0, 4),
     "multi-bit-clear-32":
@@ -56,6 +60,10 @@ TEST_VECTORS = {
         (64, 0x0000_0000, 4, 1, 0, 0x0000_0010, 1),
     "single-bit-clear-64":
         (64, 0x0000_0010, 4, 0, 1, 0x0000_0000, 1),
+    "single-bit-range-set-64":
+        (64, 0x0000_0000, slice(4, 4), 1, 0, 0x0000_0010, 1),
+    "single-bit-range-clear-64":
+        (64, 0x0000_0010, slice(4, 4), 0, 1, 0x0000_0000, 1),
     "multi-bit-set-64":
         (64, 0x0000_0000, slice(7, 4), 0xF, 0, 0x0000_00F0, 4),
     "multi-bit-clear-64":


### PR DESCRIPTION
 * Add tests for `ps.Clocks` class
 * Use the RegisterMap to only open a single MMIO per range
 * Only open registers when accessed
 * Change __init__ to pull the Register class from the correct module
    
Fixes: Xilinx/PYNQ-Dev#253 Xilinx/PYNQ-Dev#240
