### PR TITLE
Add DeprecationWarning to pynq.Xlnk

### DIFF
--- a/pynq/xlnk.py
+++ b/pynq/xlnk.py
@@ -129,6 +129,10 @@ class Xlnk:
         None
 
         """
+        warnings.warn("pynq.Xlnk is deprecated and will be removed in 2.7 - " +
+                      "use pynq.allocate instead", DeprecationWarning,
+                      stacklevel=2)
+
         if os.getuid() != 0:
             raise RuntimeError("Root permission needed by the library.")
 

--- a/tests/test_xlnk.py
+++ b/tests/test_xlnk.py
@@ -1,0 +1,48 @@
+import inspect
+import pynq
+import pytest
+import sys
+import warnings
+
+
+class DummyXlnkLib:
+    pass
+
+
+def fake_root():
+    return 0
+
+
+def linenumber():
+    cf = inspect.currentframe()
+    return cf.f_back.f_lineno
+
+
+def test_deprecation_level(monkeypatch, recwarn):
+    monkeypatch.setattr(pynq.xlnk.os, 'getuid', fake_root)
+    pynq.Xlnk.libxlnk = DummyXlnkLib
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("default", category=DeprecationWarning,
+                            module=__name__,
+                            lineno=linenumber()+1)
+    xlnk = pynq.Xlnk()
+    pynq.Xlnk.libxlnk = None
+    if len(recwarn) == 0:
+        pytest.fail("Xlnk deprecation should be seen at top-level")
+
+
+def indirect_xlnk():
+    xlnk = pynq.Xlnk()
+
+
+def test_deprecation_level_indirect(monkeypatch, recwarn):
+    monkeypatch.setattr(pynq.xlnk.os, 'getuid', fake_root)
+    pynq.Xlnk.libxlnk = DummyXlnkLib
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("default", category=DeprecationWarning,
+                            module=__name__,
+                            lineno=linenumber()+1)
+    indirect_xlnk()
+    pynq.Xlnk.libxlnk = None
+    if len(recwarn) != 0:
+        pytest.fail("Xlnk deprecation should not be seen at below top-level")


### PR DESCRIPTION
With the default warning control the warning will only appear when Xlnk is used
in a notebook directly. This means that allocate or Overlay will not trigger the
warning even though they are still implemented in terms of Xlnk.

Fixes Xilinx/PYNQ-Dev#218