### PR TITLE
Refactor XRT Environment Checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@ branch = True
 [report]
 omit =
     pynq/lib/*
-    pynq/xrt.py
     pynq/ert.py
     pynq/xclbin.py
     pynq/tinynumpy.py

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -44,15 +44,7 @@ from .registers import RegisterMap
 from .registers import Register
 from .utils import ReprDict
 
-if "XILINX_XRT" in os.environ:
-    try:
-        import ert_binding as ert
-    except ImportError:
-        from pynq import ert
-
-    # Monkey patch typo in some versions on XRT Python binding
-    if not hasattr(ert, 'ert_cmd_type'):
-        ert.ert_cmd_type = ert.ert_cmdype
+from pynq import ert
 
 
 __author__ = "Yun Rock Qu"

--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -58,7 +58,8 @@ class DeviceMeta(type):
     def __init__(cls, name, bases, attrs):
         if '_probe_' in attrs:
             priority = attrs['_probe_priority_']
-            if priority in DeviceMeta._subclasses:
+            if (priority in DeviceMeta._subclasses and
+                DeviceMeta._subclasses[priority].__name__ != name):
                 raise RuntimeError(
                     "Multiple Device subclasses with same priority")
             DeviceMeta._subclasses[priority] = cls

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -35,10 +35,7 @@ __email__ = "pynq_support@xilinx.com"
 import ctypes
 from copy import deepcopy
 from xml.etree import ElementTree
-try:
-    import xclbin_binding as xclbin
-except ImportError:
-    from pynq import xclbin
+from pynq import xclbin
 
 _mem_types = [
     "DDR3",

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -39,33 +39,13 @@ import numpy as np
 from pynq.buffer import PynqBuffer
 from .device import Device
 
-try:
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=SyntaxWarning)
-        import xrt_binding as xrt
-        import ert_binding as ert
-except ImportError:
-    from pynq import xrt
-    from pynq import ert
+from pynq import xrt
+from pynq import ert
 
 __author__ = "Peter Ogden"
 __copyright__ = "Copyright 2019, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
-
-if "XCL_EMULATION_MODE" in os.environ:
-    emulation_mode = os.environ["XCL_EMULATION_MODE"]
-    if emulation_mode == "hw_emu":
-        xrt_lib = os.path.join(
-            os.environ['XILINX_XRT'], 'lib', 'libxrt_hwemu.so')
-    elif emulation_mode == "sw_emu":
-        raise RuntimeError("PYNQ doesn't support software emulation: either "
-                           "unset XCL_EMULATION_MODE or set it hw_emu")
-    else:
-        warnings.warn("Unknown emulation mode: " + emulation_mode)
-        xrt_lib = os.path.join(
-            os.environ['XILINX_XRT'], 'lib', 'libxrt_core.so')
-    xrt.libc = ctypes.CDLL(xrt_lib)
 
 DRM_XOCL_BO_EXECBUF = 1 << 31
 REQUIRED_VERSION_ERT = (2, 3, 0)
@@ -88,6 +68,7 @@ class xclDeviceUsage (ctypes.Structure):
         ("memSize", ctypes.c_ulonglong*8)
     ]
 
+
 _xrt_errors = {
     -95: "Shell does not match",
     -16: "Bitstream in use by another program",
@@ -108,7 +89,10 @@ def _get_xrt_version():
         return (0, 0, 0)
 
 
-_xrt_version = _get_xrt_version()
+if xrt.XRT_SUPPORTED:
+    _xrt_version = _get_xrt_version()
+else:
+    _xrt_version = (0, 0, 0)
 
 
 def _format_xrt_error(err):
@@ -315,6 +299,8 @@ class XrtStream:
 class XrtDevice(Device):
     @classmethod
     def _probe_(cls):
+        if not xrt.XRT_SUPPORTED:
+            return []
         num = xrt.xclProbe()
         devices = [XrtDevice(i) for i in range(num)]
         return devices

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -1,0 +1,109 @@
+import importlib
+import pynq.xrt
+import ctypes
+import os
+
+class FakeXrt:
+    def __init__(self, path):
+        self.path = path
+
+    def xclProbe(self):
+        return 0
+
+    def __getattr__(self, key):
+        return FakeXrt(self.path + '.' + key)
+
+
+def test_xrt_none(monkeypatch, recwarn):
+    monkeypatch.delenv('XILINX_XRT', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    xrt = importlib.reload(pynq.xrt)
+    assert xrt.XRT_SUPPORTED == False
+    assert len(recwarn) == 0
+
+
+def test_xrt_hw_emu(monkeypatch, recwarn):
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.setenv('XCL_EMULATION_MODE', 'hw_emu')
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    xrt = importlib.reload(pynq.xrt)
+    assert xrt.XRT_SUPPORTED == True
+    assert xrt.XRT_EMULATION == True
+    assert xrt.libc.path == '/path/to/xrt/lib/libxrt_hwemu.so'
+    assert len(recwarn) == 0
+
+
+def test_xrt_sw_emu(monkeypatch, recwarn):
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.setenv('XCL_EMULATION_MODE', 'sw_emu')
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    xrt = importlib.reload(pynq.xrt)
+    assert xrt.XRT_SUPPORTED == False
+    assert len(recwarn) == 1
+
+
+def test_xrt_wrong_emu(monkeypatch, recwarn):
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.setenv('XCL_EMULATION_MODE', 'wrong_emu')
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    xrt = importlib.reload(pynq.xrt)
+    assert xrt.XRT_SUPPORTED == False
+    assert len(recwarn) == 1
+
+
+def test_xrt_normal(monkeypatch, recwarn):
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    xrt = importlib.reload(pynq.xrt)
+    assert xrt.XRT_SUPPORTED == True
+    assert xrt.XRT_EMULATION == False
+    assert xrt.libc.path == '/path/to/xrt/lib/libxrt_core.so'
+    assert len(recwarn) == 0
+
+
+def test_xrt_version(monkeypatch, tmp_path):
+    with open(tmp_path / 'xbutil', 'w') as f:
+        f.write("""#!/bin/bash
+echo '{"runtime": {"build": {"version": "2.5.3"}}}'
+""")
+    os.chmod(tmp_path / 'xbutil', 0o777)
+    monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    import pynq.pl_server.xrt_device
+    xrt = importlib.reload(pynq.xrt)
+    xrt_device = importlib.reload(pynq.pl_server.xrt_device)
+    assert xrt_device._xrt_version == (2, 5, 3)
+
+
+def test_xrt_version_fail(monkeypatch, tmp_path):
+    with open(tmp_path / 'xbutil', 'w') as f:
+        f.write("""#!/bin/bash
+exit 1
+""")
+    os.chmod(tmp_path / 'xbutil', 0o777)
+    monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    import pynq.pl_server.xrt_device
+    xrt = importlib.reload(pynq.xrt)
+    xrt_device = importlib.reload(pynq.pl_server.xrt_device)
+    assert xrt_device._xrt_version == (0, 0, 0)
+
+
+def test_xrt_version_unsupported(monkeypatch, tmp_path):
+    with open(tmp_path / 'xbutil', 'w') as f:
+        f.write("""#!/bin/bash
+echo '{"runtime": {"build": {"version": "2.5.3"}}}'
+""")
+    os.chmod(tmp_path / 'xbutil', 0o777)
+    monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
+    monkeypatch.delenv('XILINX_XRT', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    import pynq.pl_server.xrt_device
+    xrt = importlib.reload(pynq.xrt)
+    xrt_device = importlib.reload(pynq.pl_server.xrt_device)
+    assert xrt_device._xrt_version == (0, 0, 0)


### PR DESCRIPTION
Move XRT environment checks into pynq.xrt and use local version
unconditionally. New versions of XRT broke how we were handling hardware
emulation and this is a workaround until we get some level of stability.

All exceptions for an invalid environment are now warnings and an empty device
list will arise if using an unsupported configuration

Fixes Xilinx/PYNQ-Dev#249