### PR TITLE
boot.py service to run user Python during boot sequence

### DIFF
--- a/sdbuild/packages/bootpy/boot.py
+++ b/sdbuild/packages/bootpy/boot.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python3.6
+
+print("bootpy running...")
+
+# example #1 - WiFi connection at boot
+# from pynq.lib import Wifi
+#
+# port = Wifi()
+# port.connect('your_ssid', 'your_password', auto=True)
+
+# example #2 - blink LEDs (PYNQ-Z1, PYNQ-Z2, ZCU104)
+# from pynq import Overlay
+# from time import sleep
+
+# ol = Overlay('base.bit')
+# leds = ol.leds
+
+# for _ in range(8):
+#     leds[0:4].off()
+#     sleep(0.2)
+#     leds[0:4].on()
+#     sleep(0.2)
+
+print("bootpy completed...")

--- a/sdbuild/packages/bootpy/boot.py
+++ b/sdbuild/packages/bootpy/boot.py
@@ -1,24 +1,25 @@
 #! /usr/bin/env python3.6
 
-print("bootpy running...")
-
 # example #1 - WiFi connection at boot
-# from pynq.lib import Wifi
+#from pynq.lib import Wifi
 #
-# port = Wifi()
-# port.connect('your_ssid', 'your_password', auto=True)
+#port = Wifi()
+#port.connect('your_ssid', 'your_password', auto=True)
 
-# example #2 - blink LEDs (PYNQ-Z1, PYNQ-Z2, ZCU104)
-# from pynq import Overlay
-# from time import sleep
+## example #2 - Change hostname
+# import subprocess
+# subprocess.call('pynq_hostname.sh aNewHostName'.split())
 
-# ol = Overlay('base.bit')
-# leds = ol.leds
+## example #3 - blink LEDs (PYNQ-Z1, PYNQ-Z2, ZCU104)
+#from pynq import Overlay
+#from time import sleep
+#
+#ol = Overlay('base.bit')
+#leds = ol.leds
+#
+#for _ in range(8):
+#    leds[0:4].off()
+#    sleep(0.2)
+#    leds[0:4].on()
+#    sleep(0.2)
 
-# for _ in range(8):
-#     leds[0:4].off()
-#     sleep(0.2)
-#     leds[0:4].on()
-#     sleep(0.2)
-
-print("bootpy completed...")

--- a/sdbuild/packages/bootpy/bootpy.service
+++ b/sdbuild/packages/bootpy/bootpy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Executing boot.py from the boot partition
+Requires=pl_server.service networking.service
+After=pl_server.service 
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/bootpy.sh
+
+[Install]
+WantedBy=basic.target

--- a/sdbuild/packages/bootpy/bootpy.service
+++ b/sdbuild/packages/bootpy/bootpy.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Executing boot.py from the boot partition
 Requires=pl_server.service jupyter.service
-After=pl_server.service jupyter.service
+After=pl_server.service jupyter.service boot.mount
 
 [Service]
 Type=oneshot

--- a/sdbuild/packages/bootpy/bootpy.service
+++ b/sdbuild/packages/bootpy/bootpy.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Executing boot.py from the boot partition
-Requires=pl_server.service networking.service
-After=pl_server.service 
+Requires=pl_server.service jupyter.service
+After=pl_server.service jupyter.service
 
 [Service]
 Type=oneshot

--- a/sdbuild/packages/bootpy/bootpy.sh
+++ b/sdbuild/packages/bootpy/bootpy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+. /etc/environment
+
+if [ -z "$PYNQ_PYTHON" ]; then
+	PYNQ_PYTHON=python3.4
+else
+	PATH=/opt/$PYNQ_PYTHON/bin:$PATH
+fi
+
+
+BOOT_MNT=/boot
+BOOT_DEV=/dev/mmcblk0p1
+
+if [[ ! -d "$BOOT_MNT" ]]
+then
+    mkdir $BOOT_MNT
+fi
+
+mount $BOOT_DEV $BOOT_MNT
+$PYNQ_PYTHON $BOOT_MNT/boot.py
+umount $BOOT_MNT
+
+

--- a/sdbuild/packages/bootpy/bootpy.sh
+++ b/sdbuild/packages/bootpy/bootpy.sh
@@ -2,23 +2,15 @@
 
 . /etc/environment
 
-if [ -z "$PYNQ_PYTHON" ]; then
-	PYNQ_PYTHON=python3.4
-else
-	PATH=/opt/$PYNQ_PYTHON/bin:$PATH
-fi
-
-
 BOOT_MNT=/boot
 BOOT_DEV=/dev/mmcblk0p1
+BOOT_PY=$BOOT_MNT/boot.py
 
-if [[ ! -d "$BOOT_MNT" ]]
-then
-    mkdir $BOOT_MNT
+if !(mount | grep -q "$BOOT_MNT") ; then
+   mount $BOOT_DEV $BOOT_MNT
 fi
 
-mount $BOOT_DEV $BOOT_MNT
-$PYNQ_PYTHON $BOOT_MNT/boot.py
-umount $BOOT_MNT
-
+if test -f "$BOOT_PY"; then
+   $PYNQ_PYTHON $BOOT_PY
+fi
 

--- a/sdbuild/packages/bootpy/pre.sh
+++ b/sdbuild/packages/bootpy/pre.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+target=$1
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+sudo cp $script_dir/bootpy.sh $target/usr/local/bin
+sudo cp $script_dir/boot.py $target/boot/
+sudo cp $script_dir/bootpy.service $target/lib/systemd/system
+

--- a/sdbuild/packages/bootpy/qemu.sh
+++ b/sdbuild/packages/bootpy/qemu.sh
@@ -1,0 +1,2 @@
+systemctl enable bootpy
+

--- a/sdbuild/packages/bootpy/qemu.sh
+++ b/sdbuild/packages/bootpy/qemu.sh
@@ -1,2 +1,3 @@
 systemctl enable bootpy
+echo "/dev/mmcblk0p1 /boot vfat defaults 0 2" >> /etc/fstab
 

--- a/sdbuild/ubuntu/bionic/aarch64/config
+++ b/sdbuild/ubuntu/bionic/aarch64/config
@@ -1,4 +1,5 @@
 STAGE2_PACKAGES_aarch64 := gcc-mb libsds python_packages_bionic jupyter
 STAGE2_PACKAGES_aarch64 += phantomjs-fix sigrok
 STAGE2_PACKAGES_aarch64 += glog pybind11 json-c googletest protobuf opencv
+STAGE2_PACKAGES_aarch64 += bootpy
 STAGE3_PACKAGES_aarch64 := pynq x11 resizefs

--- a/sdbuild/ubuntu/bionic/arm/config
+++ b/sdbuild/ubuntu/bionic/arm/config
@@ -1,4 +1,5 @@
 STAGE2_PACKAGES_arm := gcc-mb pandas python_packages_bionic libsds
 STAGE2_PACKAGES_arm += jupyter phantomjs-fix sigrok
 STAGE2_PACKAGES_arm += glog pybind11 json-c googletest protobuf opencv
+STAGE2_PACKAGES_arm += bootpy
 STAGE3_PACKAGES_arm := pynq resizefs


### PR DESCRIPTION
This will place a boot.py in the boot partition of the SD Card that will always run as part of PYNQ's boot sequence.  

That boot.py file is left empty with two commented out examples that users could run including (1) connecting to WiFi and (2) downloading a custom overlay.