### PR TITLE
Interrupt Improvements

### DIFF
--- a/pynq/interrupt.py
+++ b/pynq/interrupt.py
@@ -91,11 +91,10 @@ class Interrupt(object):
         """
         if pinname not in PL.interrupt_pins:
             raise ValueError("No Pin of name {} found".format(pinname))
+        parent, self.number = _InterruptController.get_parent(
+            PL.interrupt_pins[pinname])
 
-        parentname = PL.interrupt_pins[pinname]['controller']
-        self.number = PL.interrupt_pins[pinname]['index']
-        self.parent = weakref.ref(
-            _InterruptController.get_controller(parentname))
+        self.parent = weakref.ref(parent)
         self.event = asyncio.Event()
         self.waiting = False
 
@@ -126,6 +125,7 @@ class _InterruptController(object):
 
     """
     _controllers = []
+    _uio_devices = {}
     _last_timestamp = None
 
     @staticmethod
@@ -153,6 +153,34 @@ class _InterruptController(object):
         _InterruptController._controllers.append(ret)
         return ret
 
+    @staticmethod
+    def get_parent(entry):
+        """Return the parent and index of an interrupt.
+
+        This can either be an interrupt controller or a UIO interface
+
+        Parameters
+        ----------
+        entry : dict
+            The entry in the interrupt_pins dict for the pin
+
+        """
+        parent = entry['parent'] if 'parent' in entry else entry['controller']
+        number = entry['index']
+        if parent == "":
+            raw_irq = entry['raw_irq']
+            if raw_irq in _InterruptController._uio_devices:
+                return _InterruptController._uio_devices[raw_irq], 0
+            uiodev = get_uio_irq(raw_irq)
+            if uiodev is None:
+                raise ValueError('Could not find UIO device for interrupt pin '
+                                 'for IRQ number {}'.format(raw_irq))
+            dev = UioController(uiodev)
+            _InterruptController._uio_devices[raw_irq] = dev
+            return dev, 0
+        else:
+            return _InterruptController.get_controller(parent), number
+
     def __init__(self, name):
         """Return a new _InterruptController
 
@@ -175,19 +203,8 @@ class _InterruptController(object):
         # Disable Interrupt lines
         self.mmio.write(0x08, 0)
 
-        parent = PL.interrupt_controllers[name]['parent']
-        number = PL.interrupt_controllers[name]['index']
-        if parent == "":
-            raw_irq = PL.interrupt_controllers[name]['raw_irq']
-            uiodev = get_uio_irq(raw_irq)
-            if uiodev is None:
-                raise ValueError('Could not find UIO device for interrupt pin '
-                                 'for IRQ number {}'.format(raw_irq))
-            self.parent = UioController(uiodev)
-            self.number = 0
-        else:
-            self.parent = _InterruptController.get_controller(parent)
-            self.number = number
+        self.parent, self.number = _InterruptController.get_parent(
+            PL.interrupt_controllers[name])
 
     def set(self):
         """Mimics the set function of an event. Should not be called by

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -821,7 +821,12 @@ class DefaultIP(metaclass=RegisterIP):
         else:
             self._gpio = {}
         for interrupt, details in self._interrupts.items():
-            setattr(self, interrupt, Interrupt(details['fullpath']))
+            try:
+                setattr(self, interrupt, Interrupt(details['fullpath']))
+            except ValueError as e:
+                warnings.warn('Interrupt {} not created: {}'.format(
+                    interrupt, str(e)))
+                setattr(self, interrupt, None)
         for gpio, entry in self._gpio.items():
             gpio_number = GPIO.get_gpio_pin(entry['index'])
             setattr(self, gpio, GPIO(gpio_number, 'out'))

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -415,6 +415,30 @@ async def test_simul_wait(interrupt, ipdevice, setup):
     endpoints['interrupt2'](False)
 
 
+@pytest.mark.asyncio
+async def test_direct_interrupt(interrupt, ipdevice):
+    endpoints = _setup_device(ipdevice, DIRECT_SETUP, interrupt)
+    pin = interrupt.Interrupt('direct_interrupt')
+    wait = asyncio.ensure_future(pin.wait())    
+    endpoints['direct_interrupt'](True)
+    await wait
+    endpoints['direct_interrupt'](False)
+
+
+@pytest.mark.asyncio
+async def test_direct_duplicate_interrupt(interrupt, ipdevice):
+    endpoints = _setup_device(ipdevice, DIRECT_SETUP, interrupt)
+    pin = interrupt.Interrupt('direct_interrupt')
+    pin2 = interrupt.Interrupt('direct_interrupt')
+    assert pin.parent == pin2.parent
+    wait1 = asyncio.ensure_future(pin.wait())
+    wait2 = asyncio.ensure_future(pin2.wait())
+    await(asyncio.sleep(0))
+    endpoints['direct_interrupt'](True)
+    await wait1
+    await wait2
+
+
 def test_invalid_interrupt(interrupt, ipdevice):
     endpoints = _setup_device(ipdevice, STANDARD_SETUP, interrupt)  # NOQA
     with pytest.raises(ValueError):


### PR DESCRIPTION
 * Allow for directly connected interrupts
 * Use a warning rather than an exception when a DefaultIP instance contains an incorrectly connected interrupt.