### PR TITLE
Bug fix, the head of the circular buffer did not overflow

### DIFF
--- a/boards/sw_repo/pynqmb/src/circular_buffer.c
+++ b/boards/sw_repo/pynqmb/src/circular_buffer.c
@@ -44,7 +44,8 @@
  * Ver   Who  Date     Changes
  * ----- --- ------- -----------------------------------------------
  * 1.00  yrq 01/09/18 release
- * 1.00  mrn 28/09/20 Bug fix, the head af the circular buffer did not overflow
+ * 1.01  mrn 09/28/20 Bug fix, the head of the circular 
+ *                    buffer did not overflow
  *
  * </pre>
  *

--- a/boards/sw_repo/pynqmb/src/circular_buffer.c
+++ b/boards/sw_repo/pynqmb/src/circular_buffer.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- *  Copyright (c) 2018, Xilinx, Inc.
+ *  Copyright (c) 2018-2020, Xilinx, Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@
  * Ver   Who  Date     Changes
  * ----- --- ------- -----------------------------------------------
  * 1.00  yrq 01/09/18 release
+ * 1.00  mrn 28/09/20 Bug fix, the head af the circular buffer did not overflow
  *
  * </pre>
  *
@@ -105,6 +106,8 @@ void cb_push_incr_ptrs(circular_buffer *cb){
 
     if (cb->tail == cb->head) {
         cb->head  = (char*)cb->head + cb->sz;
+        if (cb->head >= cb->buffer_end)
+            cb->head = cb->buffer;
     }
 
     // update mailbox head and tail

--- a/pynq/lib/arduino/arduino_analog.py
+++ b/pynq/lib/arduino/arduino_analog.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2016, Xilinx, Inc.
+#   Copyright (c) 2016-2020, Xilinx, Inc.
 #   All rights reserved.
 # 
 #   Redistribution and use in source and binary forms, with or without 
@@ -177,6 +177,9 @@ class Arduino_Analog(object):
         if log_interval_ms < 0:
             raise ValueError("Time between samples should be no less than 0.")
         
+        if isinstance(log_interval_ms, int):
+            raise ValueError("Time between samples should be integer.")
+
         self.log_interval_ms = log_interval_ms
         self.microblaze.write_mailbox(4, log_interval_ms)
 


### PR DESCRIPTION
- Bug fix, the head of the circular buffer did not overflow. The function `cb_push_incr_ptrs` did not check if the head reached the end of the buffer.
- Check if the log interval set by the user is integer in `arduino_analog.py`