### PR TITLE
Ensure delay timer is initialised

### DIFF
--- a/boards/sw_repo/pynqmb/src/timer.c
+++ b/boards/sw_repo/pynqmb/src/timer.c
@@ -109,21 +109,27 @@ void timer_delay(timer dev_id, unsigned int cycles){
     XTmrCtr_Stop(&xtimer[dev_id], 1);
 }
 
+__attribute__((constructor))
+static void init_delay_timer() {
+    static int initialized = 0;
+    if (initialized == 0) {
+        timer_open_device(0);
+        initialized = 1;
+    }
+}
 
 void delay_us(unsigned int us){
     unsigned int cycles_per_us = XPAR_MICROBLAZE_CORE_CLOCK_FREQ_HZ / 1000000;
+    init_delay_timer();
     timer_delay(0, cycles_per_us * us);
 }
 
 void delay_ms(unsigned int ms){
     unsigned int cycles_per_ms = XPAR_MICROBLAZE_CORE_CLOCK_FREQ_HZ / 1000;
+    init_delay_timer();
     timer_delay(0, cycles_per_ms * ms);
 }
 
-__attribute__((constructor))
-static void init_delay_timer() {
-    timer_open_device(0);
-}
 
 void timer_close(timer dev_id){
     XTmrCtr_Stop(&xtimer[dev_id], 0);


### PR DESCRIPTION
Work around an issue in 2020.1 where constructor functions aren't being called.

Fixes: Xilinx/PYNQ-Dev#281