### PR TITLE
Add boot_bitstream package to initialize PL server

### DIFF
--- a/sdbuild/packages/boot_bitstream/pre.sh
+++ b/sdbuild/packages/boot_bitstream/pre.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -x
+set -e
+
+target=$1
+
+xsa_path=$BUILD_ROOT/$PYNQ_BOARD/petalinux_project/project-spec/hw-description/system.xsa
+
+hwh_name=$(unzip -p $xsa_path sysdef.xml | xmllint --xpath 'string(/Project/File[@Type="HW_HANDOFF" and @BD_TYPE="DEFAULT_BD"]/@Name)' -)
+bin_name=${hwh_name%hwh}bin
+
+(cd $target/boot && sudo unzip $xsa_path $hwh_name)
+sudo touch $target/boot/$bin_name
+
+sudo tee -a $target/boot/boot.py <<EOT
+import pynq
+ol = pynq.Overlay('/boot/$bin_name', download=False)
+pynq.Device.active_device.reset(ol.parser, ol.timestamp, ol.bitfile_name)
+EOT


### PR DESCRIPTION
The boot_bitstream package will load the metadata for the petalinux project-provided bitstream into the PL server at boot and provide a dummy binary file for creating an overlay object in user code

Fixes: Xilinx/PYNQ-Dev#282