### PR TITLE
Logictools fixes

### DIFF
--- a/boards/Pynq-Z1/logictools/logictools.tcl
+++ b/boards/Pynq-Z1/logictools/logictools.tcl
@@ -3200,7 +3200,7 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0xC0000000 -range 0x00008000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/FSM_generator/fsm_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/pattern_generator/pattern_data_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30040000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/pattern_generator/pattern_tri_bram_ctrl/S_AXI/Mem0] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP0/HP0_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP0/HP0_DDR_LOWOCM] -force
   assign_bd_address -offset 0x44A10000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/axi_cdma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x41E00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/trace_analyzer/axi_dma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x44A00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/boolean_generator/boolean_generator/S_AXI/S_AXI_reg] -force
@@ -3214,7 +3214,7 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0x00000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Instruction] [get_bd_addr_segs lcp_ar/lmb/lmb_bram_if_cntlr/SLMB/Mem] -force
   assign_bd_address -offset 0x40010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/pattern_generator/pattern_nsamples/S_AXI/Reg] -force
   assign_bd_address -offset 0x44A20000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/trace_analyzer/trace_cntrl_64_0/s_axi_trace_cntrl/Reg] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_ar/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP2/HP2_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_ar/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP2/HP2_DDR_LOWOCM] -force
 
 
   # Restore current instance

--- a/boards/Pynq-Z2/logictools/logictools.tcl
+++ b/boards/Pynq-Z2/logictools/logictools.tcl
@@ -4175,7 +4175,7 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0xC0000000 -range 0x00008000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/FSM_generator/fsm_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/pattern_generator/pattern_data_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30040000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs lcp_ar/pattern_generator/pattern_tri_bram_ctrl/S_AXI/Mem0] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP0/HP0_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_ar/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP0/HP0_DDR_LOWOCM] -force
   assign_bd_address -offset 0x44A10000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/axi_cdma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x41E00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/trace_analyzer/axi_dma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x44A00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_ar/mb/Data] [get_bd_addr_segs lcp_ar/boolean_generator/boolean_generator/S_AXI/S_AXI_reg] -force
@@ -4192,7 +4192,7 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0xC0000000 -range 0x00008000 -target_address_space [get_bd_addr_spaces lcp_rp/axi_cdma_0/Data] [get_bd_addr_segs lcp_rp/FSM_generator/fsm_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/axi_cdma_0/Data] [get_bd_addr_segs lcp_rp/pattern_generator/pattern_data_bram_ctrl/S_AXI/Mem0] -force
   assign_bd_address -offset 0x30040000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/axi_cdma_0/Data] [get_bd_addr_segs lcp_rp/pattern_generator/pattern_tri_bram_ctrl/S_AXI/Mem0] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_rp/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP1/HP1_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_rp/axi_cdma_0/Data] [get_bd_addr_segs ps7_0/S_AXI_HP1/HP1_DDR_LOWOCM] -force
   assign_bd_address -offset 0x44A10000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Data] [get_bd_addr_segs lcp_rp/axi_cdma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x41E00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Data] [get_bd_addr_segs lcp_rp/trace_analyzer/axi_dma_0/S_AXI_LITE/Reg] -force
   assign_bd_address -offset 0x44A00000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Data] [get_bd_addr_segs lcp_rp/boolean_generator/boolean_generator/S_AXI/S_AXI_reg] -force
@@ -4206,8 +4206,8 @@ proc create_root_design { parentCell } {
   assign_bd_address -offset 0x00000000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Instruction] [get_bd_addr_segs lcp_rp/lmb/lmb_bram_if_cntlr/SLMB/Mem] -force
   assign_bd_address -offset 0x40010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Data] [get_bd_addr_segs lcp_rp/pattern_generator/pattern_nsamples/S_AXI/Reg] -force
   assign_bd_address -offset 0x44A20000 -range 0x00010000 -target_address_space [get_bd_addr_spaces lcp_rp/mb/Data] [get_bd_addr_segs lcp_rp/trace_analyzer/trace_cntrl_64_0/s_axi_trace_cntrl/Reg] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_ar/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP2/HP2_DDR_LOWOCM] -force
-  assign_bd_address -offset 0x10000000 -range 0x10000000 -target_address_space [get_bd_addr_spaces lcp_rp/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP3/HP3_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_ar/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP2/HP2_DDR_LOWOCM] -force
+  assign_bd_address -offset 0x00000000 -range 0x20000000 -target_address_space [get_bd_addr_spaces lcp_rp/trace_analyzer/axi_dma_0/Data_S2MM] [get_bd_addr_segs ps7_0/S_AXI_HP3/HP3_DDR_LOWOCM] -force
 
 
   # Restore current instance

--- a/pynq/lib/logictools/logictools_arduino/src/logictools_arduino.c
+++ b/pynq/lib/logictools/logictools_arduino/src/logictools_arduino.c
@@ -88,9 +88,9 @@
 
 #define XPAR_FSM_BRAM_RST_ADDR_BASEADDR \
     XPAR_LCP_AR_FSM_GENERATOR_FSM_BRAM_RST_ADDR_BASEADDR
-#define PATTERN_CDMA_BRAM_MEMORY 0x10000000 // CDMA access to PATTERN BRAM
+#define PATTERN_CDMA_BRAM_MEMORY 0x30000000 // CDMA access to PATTERN BRAM
 // BRAM Port B mapped through 2nd BRAM Controller accessed by CDMA
-#define PATTERN_TRI_CDMA_BRAM_MEMORY 0x10040000 // CDMA access to PATTERN TRI
+#define PATTERN_TRI_CDMA_BRAM_MEMORY 0x30040000 // CDMA access to PATTERN TRI
 // BRAM Port B mapped through 2nd BRAM Controller accessed by CDMA
 #define FSM_CDMA_BRAM_MEMORY 0xC0000000
 #define FSM_CDMA_BRAM_MEMORY_SIZE 0x8000    // size in bytes
@@ -208,7 +208,7 @@ u32 boolean_status = RESET_STATE;
 int pattern_generator_config(void) {
     pattern_multiple = 0;
     pattern_data_source = (u8 *)MAILBOX_DATA(0); // DDR address for the pattern
-    pattern_data_source = (u8 *) ((u32) pattern_data_source | 0x20000000);
+    pattern_data_source = (u8 *) ((u32) pattern_data_source);
     pattern_numofsamples = MAILBOX_DATA(1); // number of words in the pattern
 
     // move pattern data from DDR memory to BlockRAM
@@ -235,7 +235,7 @@ int pattern_generator_config(void) {
         pattern_multiple = 1;
     }
 	pattern_tri_source = (u8 *)MAILBOX_DATA(3);	// Tri control BRAM address
-	pattern_tri_source = (u8 *) ((u32) pattern_tri_source | 0x20000000);
+	pattern_tri_source = (u8 *) ((u32) pattern_tri_source);
 	// move pattern data from DDR memory to BlockRAM
 	destination = (u8 *)PATTERN_TRI_CDMA_BRAM_MEMORY;
 	XAxiCdma_IntrDisable(&xcdma, XAXICDMA_XR_IRQ_ALL_MASK);
@@ -416,7 +416,7 @@ int main (void) {
             reg6 = MAILBOX_DATA(6);     // output select for pins 16,17,18,19
             fsm_direction = MAILBOX_DATA(7);    // I/O direction
             fsm_source = (u8 *)MAILBOX_DATA(8); // DDR address for pattern
-            fsm_source = (u8 *) ((u32) fsm_source | 0x20000000);
+            fsm_source = (u8 *) ((u32) fsm_source);
             // move pattern data from DDR memory to BlockRAM
             destination = (u8 *)FSM_CDMA_BRAM_MEMORY;
             XAxiCdma_IntrDisable(&xcdma, XAXICDMA_XR_IRQ_ALL_MASK);
@@ -470,7 +470,7 @@ int main (void) {
         case CONFIG_TRACE:
             traceptr = (u8 *)MAILBOX_DATA(0);   // DDR address of the trace
             if(traceptr) {
-                traceptr = (u8 *) ((u32) traceptr | 0x20000000);
+                traceptr = (u8 *) ((u32) traceptr);
                 tracing = 1;
             }
             trace_numofsamples = MAILBOX_DATA(1);

--- a/pynq/lib/logictools/logictools_controller.py
+++ b/pynq/lib/logictools/logictools_controller.py
@@ -413,7 +413,12 @@ class LogicToolsController(PynqMicroblaze):
             The address of the source or destination buffer.
 
         """
-        buf = allocate(num_samples, dtype=data_type)
+        dtype = data_type
+        for k, v in BYTE_WIDTH_TO_CTYPE.items():
+            if v == data_type:
+                dtype = BYTE_WIDTH_TO_NPTYPE[k]
+                break
+        buf = allocate(num_samples, dtype=dtype)
         self.buffers[name] = buf
         return buf.physical_address
 


### PR DESCRIPTION
Fix issues that arose with the update to 2020.1 and the more restrictive addressing scheme.

The decision was made to move the DDR addresses to offset 0 rather than add remap IPs due to the lack of AXI3 support in the existing remapper and the logictools IOP not being designed for user programability.