### PR TITLE
Fix random MAC addresses for Z1 and Z2

### DIFF
--- a/boards/Pynq-Z1/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0002-allow-to-read-mac-address-from-SPI-flash.patch
+++ b/boards/Pynq-Z1/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0002-allow-to-read-mac-address-from-SPI-flash.patch
@@ -1,17 +1,17 @@
-From bba34edd239ad5b4878f3bfc7da1e57205705599 Mon Sep 17 00:00:00 2001
+From 752d054484a52b548e8ef46c759fe13a62d5f3d5 Mon Sep 17 00:00:00 2001
 From: Rock Qu <yunq@xilinx.com>
 Date: Mon, 22 Jun 2020 18:29:59 -0700
 Subject: [PATCH 2/4] allow to read mac address from SPI flash
 
 ---
- board/xilinx/common/board.c | 25 +++++++++++++++++++++++++
- 1 file changed, 25 insertions(+)
+ board/xilinx/common/board.c | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
 
 diff --git a/board/xilinx/common/board.c b/board/xilinx/common/board.c
-index 5fdd994..f78b68e 100644
+index 5fdd994..d43c338 100644
 --- a/board/xilinx/common/board.c
 +++ b/board/xilinx/common/board.c
-@@ -8,6 +8,8 @@
+@@ -8,13 +8,15 @@
  #include <asm/sections.h>
  #include <dm/uclass.h>
  #include <i2c.h>
@@ -20,7 +20,15 @@ index 5fdd994..f78b68e 100644
  #include "board.h"
  
  int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
-@@ -36,6 +38,29 @@ int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
+ {
+ 	int ret = -EINVAL;
+ 
+-#if defined(CONFIG_ZYNQ_GEM_I2C_MAC_OFFSET)
++#if 0
+ 	struct udevice *dev;
+ 	ofnode eeprom;
+ 
+@@ -36,6 +38,30 @@ int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
  		debug("%s: I2C EEPROM MAC %pM\n", __func__, ethaddr);
  #endif
  
@@ -37,6 +45,7 @@ index 5fdd994..f78b68e 100644
 +			CONFIG_SF_DEFAULT_CS);
 +		return -ENODEV;
 +	}
++	flash->read_opcode = CMD_OTPREAD_ARRAY_FAST;
 +	ret = spi_flash_read(flash, CONFIG_ZYNQ_GEM_SPI_MAC_OFFSET, 6, ethaddr);
 +	if (ret)
 +		debug("%s: SPI EEPROM MAC address read failed\n", __func__);
@@ -51,5 +60,5 @@ index 5fdd994..f78b68e 100644
  }
  
 -- 
-1.8.3.1
+2.7.4
 

--- a/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0002-allow-to-read-mac-address-from-SPI-flash.patch
+++ b/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0002-allow-to-read-mac-address-from-SPI-flash.patch
@@ -1,17 +1,17 @@
-From bba34edd239ad5b4878f3bfc7da1e57205705599 Mon Sep 17 00:00:00 2001
+From 752d054484a52b548e8ef46c759fe13a62d5f3d5 Mon Sep 17 00:00:00 2001
 From: Rock Qu <yunq@xilinx.com>
 Date: Mon, 22 Jun 2020 18:29:59 -0700
 Subject: [PATCH 2/4] allow to read mac address from SPI flash
 
 ---
- board/xilinx/common/board.c | 25 +++++++++++++++++++++++++
- 1 file changed, 25 insertions(+)
+ board/xilinx/common/board.c | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
 
 diff --git a/board/xilinx/common/board.c b/board/xilinx/common/board.c
-index 5fdd994..f78b68e 100644
+index 5fdd994..d43c338 100644
 --- a/board/xilinx/common/board.c
 +++ b/board/xilinx/common/board.c
-@@ -8,6 +8,8 @@
+@@ -8,13 +8,15 @@
  #include <asm/sections.h>
  #include <dm/uclass.h>
  #include <i2c.h>
@@ -20,7 +20,15 @@ index 5fdd994..f78b68e 100644
  #include "board.h"
  
  int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
-@@ -36,6 +38,29 @@ int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
+ {
+ 	int ret = -EINVAL;
+ 
+-#if defined(CONFIG_ZYNQ_GEM_I2C_MAC_OFFSET)
++#if 0
+ 	struct udevice *dev;
+ 	ofnode eeprom;
+ 
+@@ -36,6 +38,30 @@ int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
  		debug("%s: I2C EEPROM MAC %pM\n", __func__, ethaddr);
  #endif
  
@@ -37,6 +45,7 @@ index 5fdd994..f78b68e 100644
 +			CONFIG_SF_DEFAULT_CS);
 +		return -ENODEV;
 +	}
++	flash->read_opcode = CMD_OTPREAD_ARRAY_FAST;
 +	ret = spi_flash_read(flash, CONFIG_ZYNQ_GEM_SPI_MAC_OFFSET, 6, ethaddr);
 +	if (ret)
 +		debug("%s: SPI EEPROM MAC address read failed\n", __func__);
@@ -51,5 +60,5 @@ index 5fdd994..f78b68e 100644
  }
  
 -- 
-1.8.3.1
+2.7.4
 


### PR DESCRIPTION
The new version of u-boot added a mechanism which loads the MAC address from an I2C eeprom which conflicts with the QSPI loading functionality we patch in.

This patch disables the I2C eeprom code and re-adds the correct opcode for reading from SPI