### PR TITLE
Fixes arising from Alveo testing

### DIFF
--- a/pynq/_3rdparty/ert.py
+++ b/pynq/_3rdparty/ert.py
@@ -20,11 +20,7 @@
 
 import ctypes
 import os
-
-if 'XILINX_XRT' in os.environ:
-    libc = ctypes.CDLL(os.environ['XILINX_XRT'] + "/lib/libxrt_core.so")
-else:
-    libc = None
+from .xrt import libc
 
 ##  START OF ENUMS  ##
 

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -53,111 +53,6 @@ __copyright__ = "Copyright 2016, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 
-ZU_FPD_SLCR_REG = {
-    'C_MAXIGP0_DATA_WIDTH': {
-        'FPD_SLCR.AXI_FS.DW_SS0_SEL': {
-            'addr': 0xFD615000,
-            'field': [9, 8]
-        }
-    },
-    'C_MAXIGP1_DATA_WIDTH': {
-        'FPD_SLCR.AXI_FS.DW_SS1_SEL': {
-            'addr': 0xFD615000,
-            'field': [11, 10]
-        }
-    },
-    'C_MAXIGP2_DATA_WIDTH': {
-        'LPD_SLCR.AXI_FS.DW_SS2_SEL': {
-            'addr': 0xFF419000,
-            'field': [9, 8]
-        }
-    }
-}
-
-ZU_FPD_SLCR_VALUE = {
-    '32': 0,
-    '64': 1,
-    '128': 2
-}
-
-ZU_AXIFM_REG = {
-    'C_SAXIGP0_DATA_WIDTH': {
-        'AFIFM0.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD360000,
-            'field': [1, 0]
-        },
-        'AFIFM0.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD360014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP1_DATA_WIDTH': {
-        'AFIFM1.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD370000,
-            'field': [1, 0]
-        },
-        'AFIFM1.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD370014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP2_DATA_WIDTH': {
-        'AFIFM2.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD380000,
-            'field': [1, 0]
-        },
-        'AFIFM2.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD380014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP3_DATA_WIDTH': {
-        'AFIFM3.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD390000,
-            'field': [1, 0]
-        },
-        'AFIFM3.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD390014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP4_DATA_WIDTH': {
-        'AFIFM4.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD3A0000,
-            'field': [1, 0]
-        },
-        'AFIFM4.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD3A0014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP5_DATA_WIDTH': {
-        'AFIFM5.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD3B0000,
-            'field': [1, 0]
-        },
-        'AFIFM5.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFD3B0014,
-            'field': [1, 0]
-        }
-    },
-    'C_SAXIGP6_DATA_WIDTH': {
-        'AFIFM6.AFIFM_RDCTRL.FABRIC_WIDTH': {
-            'addr': 0xFF9B0000,
-            'field': [1, 0]
-        },
-        'AFIFM6.AFIFM_WRCTRL.FABRIC_WIDTH': {
-            'addr': 0xFF9B0014,
-            'field': [1, 0]
-        }
-    }
-}
-
-ZU_AXIFM_VALUE = {
-    '32': 2,
-    '64': 1,
-    '128': 0
-}
 
 DRIVERS_GROUP = "pynq.lib"
 
@@ -521,43 +416,11 @@ class Overlay(Bitstream):
                 else:
                     Clocks.set_pl_clk(i)
 
-        self.set_axi_port_width()
-
         super().download(self.parser)
         if dtbo:
             super().insert_dtbo(dtbo)
         elif self.dtbo:
             super().insert_dtbo()
-
-    def set_axi_port_width(self):
-        """This method will set the AXI port width.
-
-        This is useful to resolve discrepancy between the PS configurations
-        during boot and the PS configurations required by the bitstream. It
-        is usually to be resolved for full bitstream reconfiguration.
-
-        Check https://www.xilinx.com/support/answers/66295.html for more
-        information on the meaning of register values.
-
-        Currently only zynq ultrascale devices support data width changes.
-
-        """
-        parameter_dict = self.parser.ip_dict[self.parser.ps_name]['parameters']
-        if self.parser.family_ps == 'zynq_ultra_ps_e':
-            for para in ZU_FPD_SLCR_REG:
-                if para in parameter_dict:
-                    width = parameter_dict[para]
-                    for reg_name in ZU_FPD_SLCR_REG[para]:
-                        addr = ZU_FPD_SLCR_REG[para][reg_name]['addr']
-                        f = ZU_FPD_SLCR_REG[para][reg_name]['field']
-                        Register(addr)[f[0]:f[1]] = ZU_FPD_SLCR_VALUE[width]
-            for para in ZU_AXIFM_REG:
-                if para in parameter_dict:
-                    width = parameter_dict[para]
-                    for reg_name in ZU_AXIFM_REG[para]:
-                        addr = ZU_AXIFM_REG[para][reg_name]['addr']
-                        f = ZU_AXIFM_REG[para][reg_name]['field']
-                        Register(addr)[f[0]:f[1]] = ZU_AXIFM_VALUE[width]
 
     def pr_download(self, partial_region, partial_bit, dtbo=None):
         """The method to download a partial bitstream onto PL.

--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -557,6 +557,113 @@ def _preload_binfile(bitstream):
         bin_buffer.tofile(bitstream.firmware_path, "")
 
 
+ZU_FPD_SLCR_REG = {
+    'C_MAXIGP0_DATA_WIDTH': {
+        'FPD_SLCR.AXI_FS.DW_SS0_SEL': {
+            'addr': 0xFD615000,
+            'field': [9, 8]
+        }
+    },
+    'C_MAXIGP1_DATA_WIDTH': {
+        'FPD_SLCR.AXI_FS.DW_SS1_SEL': {
+            'addr': 0xFD615000,
+            'field': [11, 10]
+        }
+    },
+    'C_MAXIGP2_DATA_WIDTH': {
+        'LPD_SLCR.AXI_FS.DW_SS2_SEL': {
+            'addr': 0xFF419000,
+            'field': [9, 8]
+        }
+    }
+}
+
+ZU_FPD_SLCR_VALUE = {
+    '32': 0,
+    '64': 1,
+    '128': 2
+}
+
+ZU_AXIFM_REG = {
+    'C_SAXIGP0_DATA_WIDTH': {
+        'AFIFM0.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD360000,
+            'field': [1, 0]
+        },
+        'AFIFM0.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD360014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP1_DATA_WIDTH': {
+        'AFIFM1.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD370000,
+            'field': [1, 0]
+        },
+        'AFIFM1.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD370014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP2_DATA_WIDTH': {
+        'AFIFM2.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD380000,
+            'field': [1, 0]
+        },
+        'AFIFM2.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD380014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP3_DATA_WIDTH': {
+        'AFIFM3.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD390000,
+            'field': [1, 0]
+        },
+        'AFIFM3.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD390014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP4_DATA_WIDTH': {
+        'AFIFM4.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD3A0000,
+            'field': [1, 0]
+        },
+        'AFIFM4.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD3A0014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP5_DATA_WIDTH': {
+        'AFIFM5.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD3B0000,
+            'field': [1, 0]
+        },
+        'AFIFM5.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFD3B0014,
+            'field': [1, 0]
+        }
+    },
+    'C_SAXIGP6_DATA_WIDTH': {
+        'AFIFM6.AFIFM_RDCTRL.FABRIC_WIDTH': {
+            'addr': 0xFF9B0000,
+            'field': [1, 0]
+        },
+        'AFIFM6.AFIFM_WRCTRL.FABRIC_WIDTH': {
+            'addr': 0xFF9B0014,
+            'field': [1, 0]
+        }
+    }
+}
+
+ZU_AXIFM_VALUE = {
+    '32': 2,
+    '64': 1,
+    '128': 0
+}
+
+
 class XlnkDevice(Device):
     """Device sub-class for Xlnk based devices
 
@@ -617,6 +724,37 @@ class XlnkDevice(Device):
         array = np.frombuffer(mem, np.uint32, length >> 2, virt_offset)
         return array
 
+    def set_axi_port_width(self, parser):
+        """This method will set the AXI port width.
+
+        This is useful to resolve discrepancy between the PS configurations
+        during boot and the PS configurations required by the bitstream. It
+        is usually to be resolved for full bitstream reconfiguration.
+
+        Check https://www.xilinx.com/support/answers/66295.html for more
+        information on the meaning of register values.
+
+        Currently only zynq ultrascale devices support data width changes.
+
+        """
+        from pynq.registers import Register
+        parameter_dict = parser.ip_dict[parser.ps_name]['parameters']
+        if self.parser.family_ps == 'zynq_ultra_ps_e':
+            for para in ZU_FPD_SLCR_REG:
+                if para in parameter_dict:
+                    width = parameter_dict[para]
+                    for reg_name in ZU_FPD_SLCR_REG[para]:
+                        addr = ZU_FPD_SLCR_REG[para][reg_name]['addr']
+                        f = ZU_FPD_SLCR_REG[para][reg_name]['field']
+                        Register(addr)[f[0]:f[1]] = ZU_FPD_SLCR_VALUE[width]
+            for para in ZU_AXIFM_REG:
+                if para in parameter_dict:
+                    width = parameter_dict[para]
+                    for reg_name in ZU_AXIFM_REG[para]:
+                        addr = ZU_AXIFM_REG[para][reg_name]['addr']
+                        f = ZU_AXIFM_REG[para][reg_name]['field']
+                        Register(addr)[f[0]:f[1]] = ZU_AXIFM_VALUE[width]
+
     def download(self, bitstream, parser=None):
         if not bitstream.binfile_name:
             _preload_binfile(bitstream)
@@ -630,7 +768,8 @@ class XlnkDevice(Device):
             fd.write(flag)
         with open(self.BS_FPGA_MAN, 'w') as fd:
             fd.write(bitstream.binfile_name)
-
+        if parser is not None:
+            self.set_axi_widths(parser)
         super().post_download(bitstream, parser)
 
     def get_bitfile_metadata(self, bitfile_name):

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -286,13 +286,16 @@ def _xclbin_to_dicts(filename):
                 for i, mem in enumerate(mem_data)}
     _add_argument_memory(ip_dict, ip_data, connections, memories)
     
-    clock_topology = xclbin.clock_freq_topology.from_buffer(
-          sections[xclbin.AXLF_SECTION_KIND.CLOCK_FREQ_TOPOLOGY])
+    if xclbin.AXLF_SECTION_KIND.CLOCK_FREQ_TOPOLOGY in sections:
+        clock_topology = xclbin.clock_freq_topology.from_buffer(
+              sections[xclbin.AXLF_SECTION_KIND.CLOCK_FREQ_TOPOLOGY])
            
-    clk_data = _get_object_as_array(clock_topology.m_clock_freq[0],
+        clk_data = _get_object_as_array(clock_topology.m_clock_freq[0],
                            clock_topology.m_count)
                    
-    clock_dict = _clk_data_to_dict(clk_data)
+        clock_dict = _clk_data_to_dict(clk_data)
+    else:
+        clock_dict = {}
 
     return ip_dict, mem_dict, clock_dict
 

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -148,7 +148,7 @@ def _xclxml_to_ip_dict(raw_xml, xclbin_uuid):
                 'phys_addr': int(instance.find('addrRemap').attrib['base'], 0),
                 'addr_range': addr_size,
                 'type': kernel.attrib['vlnv'],
-                'hw_control_protocol' : kernel.attrib['hwControlProtocol'],
+                'hw_control_protocol' : control_protocol,
                 'fullpath': instance.attrib['name'],
                 'registers': deepcopy(registers),
                 'streams': deepcopy(streams),


### PR DESCRIPTION
 * Move the AXI port width setting into the XlnkDevice class to reduce changes needed across other devices and parsers
 * Ensure that ERT and XRT are referring to the same XRT library instance
 * Handle cases were control port and clock data aren't in the xclbin file.