### PR TITLE
Bug fix, register map of ap_ctrl_none was not accessible

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -696,7 +696,9 @@ class DefaultIP(metaclass=RegisterIP):
         if 'registers' in description:
             self._registers = description['registers']
             self._register_name = description['fullpath'].rpartition('/')[2]
-            if ('CTRL' in self._registers and
+            if 'CTRL' in self._registers:
+                self._ctrl_reg = True
+            if (hasattr(self, '_ctrl_reg') and
                     self.device.has_capability('CALLABLE')):
                 self._signature, struct_string, self._ptr_list, self.args = \
                     _create_call(self._registers)
@@ -729,8 +731,9 @@ class DefaultIP(metaclass=RegisterIP):
             ert.ert_cmd_state.ERT_CMD_STATE_NEW
         self._packet.m_uert.m_start_cmd_struct.unused = 0
         self._packet.m_uert.m_start_cmd_struct.extra_cu_masks = 0
-        self._packet.m_uert.m_start_cmd_struct.count = \
-            (self._call_struct.size // 4) + 1
+        if hasattr(self, '_ctrl_reg'):
+            self._packet.m_uert.m_start_cmd_struct.count = \
+                (self._call_struct.size // 4) + 1
         self._packet.m_uert.m_start_cmd_struct.opcode = \
             ert.ert_cmd_opcode.ERT_START_CU
         self._packet.m_uert.m_start_cmd_struct.type = \

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -777,8 +777,8 @@ class DefaultIP(metaclass=RegisterIP):
         For details on the function's signature use the `signature` property.
         The type annotations provide the C types that the accelerator
         operates on. Any pointer types should be passed as `ContiguousArray`
-        objects created from the `pynq.Xlnk` class. Scalars should be passed
-        as a compatible python type as used by the `struct` library.
+        objects created from the `pynq.allocate` class. Scalars should be 
+        passed as a compatible python type as used by the `struct` library.
 
         """
         if not self._signature:
@@ -811,8 +811,8 @@ class DefaultIP(metaclass=RegisterIP):
         For details on the function's signature use the `signature` property.
         The type annotations provide the C types that the accelerator
         operates on. Any pointer types should be passed as `ContiguousArray`
-        objects created from the `pynq.Xlnk` class. Scalars should be passed
-        as a compatible python type as used by the `struct` library.
+        objects created from the `pynq.allocate` class. Scalars should be 
+        passed as a compatible python type as used by the `struct` library.
 
         """
         # For now direct people to the sw version until the ERT initialization

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2016, Xilinx, Inc.
+#   Copyright (c) 2016-2020, Xilinx, Inc.
 #   All rights reserved.
 #
 #   Redistribution and use in source and binary forms, with or without
@@ -696,13 +696,12 @@ class DefaultIP(metaclass=RegisterIP):
         if 'registers' in description:
             self._registers = description['registers']
             self._register_name = description['fullpath'].rpartition('/')[2]
-            if 'CTRL' in self._registers:
-                self._ctrl_reg = True
-            if (hasattr(self, '_ctrl_reg') and
+            if ('CTRL' in self._registers and
                     self.device.has_capability('CALLABLE')):
                 self._signature, struct_string, self._ptr_list, self.args = \
                     _create_call(self._registers)
                 self._call_struct = struct.Struct(struct_string)
+                self._ctrl_reg = True
                 self.start_ert = self._start_ert
                 self.start_sw  = self._start_sw
                 self.call = self._call


### PR DESCRIPTION
This PR also includes the following changes
- Remove reference to Xlnk
- Remove `start` and call attributes for free running kernels (ap_ctrl_none ) 