### PR TITLE
Fix mb-ar *.o issue in Vitis 2020.1

### DIFF
--- a/boards/ip/audio_direct_1.1/drivers/audio_direct_v1_0/src/Makefile
+++ b/boards/ip/audio_direct_1.1/drivers/audio_direct_v1_0/src/Makefile
@@ -13,10 +13,12 @@ INCLUDEFILES=*.h
 LIBSOURCES=*.c
 OUTS = *.o
 
+OBJECTS =	$(addsuffix .o, $(basename $(wildcard *.c)))
+
 libs:
 	echo "Compiling audio_direct..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS}
 	make clean
 
 include:

--- a/boards/ip/boolean_generator_1.1/drivers/boolean_generator_v1_0/src/Makefile
+++ b/boards/ip/boolean_generator_1.1/drivers/boolean_generator_v1_0/src/Makefile
@@ -13,10 +13,12 @@ INCLUDEFILES=*.h
 LIBSOURCES=*.c
 OUTS = *.o
 
+OBJECTS =	$(addsuffix .o, $(basename $(wildcard *.c)))
+
 libs:
 	echo "Compiling boolean_generator..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS}
 	make clean
 
 include:

--- a/boards/ip/fsm_io_switch_1.1/drivers/fsm_io_switch_v1_0/src/Makefile
+++ b/boards/ip/fsm_io_switch_1.1/drivers/fsm_io_switch_v1_0/src/Makefile
@@ -13,10 +13,12 @@ INCLUDEFILES=*.h
 LIBSOURCES=*.c
 OUTS = *.o
 
+OBJECTS =	$(addsuffix .o, $(basename $(wildcard *.c)))
+
 libs:
 	echo "Compiling fsm_io_switch..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS}
 	make clean
 
 include:

--- a/boards/ip/gclk_generator_1.0/drivers/gclk_generator_v1_0/src/Makefile
+++ b/boards/ip/gclk_generator_1.0/drivers/gclk_generator_v1_0/src/Makefile
@@ -13,10 +13,12 @@ INCLUDEFILES=*.h
 LIBSOURCES=*.c
 OUTS = *.o
 
+OBJECTS =	$(addsuffix .o, $(basename $(wildcard *.c)))
+
 libs:
 	echo "Compiling gclk_generator..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS}
 	make clean
 
 include:

--- a/boards/ip/io_switch_1.1/drivers/io_switch_v1_0/src/Makefile
+++ b/boards/ip/io_switch_1.1/drivers/io_switch_v1_0/src/Makefile
@@ -13,10 +13,12 @@ INCLUDEFILES=*.h
 LIBSOURCES=*.c
 OUTS = *.o
 
+OBJECTS =	$(addsuffix .o, $(basename $(wildcard *.c)))
+
 libs:
 	echo "Compiling io_switch..."
 	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
-	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OUTS}
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS}
 	make clean
 
 include:


### PR DESCRIPTION
Fix for issue #1172 