### PR TITLE
Workaround missing expat library for gcc-mb build

### DIFF
--- a/sdbuild/packages/gcc-mb/Makefile
+++ b/sdbuild/packages/gcc-mb/Makefile
@@ -22,8 +22,8 @@ ${GCC_MB_WORKDIR}/samples: | ${GCC_MB_SOURCEDIR}/samples ${GCC_MB_WORKDIR}
 ${GCC_MB_WORKDIR}/patches: | ${GCC_MB_SOURCEDIR}/patches ${GCC_MB_WORKDIR}
 	cp -r ${GCC_MB_SOURCEDIR}/patches $@
 
-${NATIVE_BUILD_arm}: | ${GCC_MB_WORKDIR}/samples
-	cd ${GCC_MB_WORKDIR} && ct-ng arm-unknown-linux-gnueabihf && ct-ng build
+${NATIVE_BUILD_arm}: | ${GCC_MB_WORKDIR}/samples ${GCC_MB_WORKDIR}/patches
+	cd ${GCC_MB_WORKDIR} && ct-ng arm-unknown-linux-gnueabihf && sed -i -e 's:2.2.6:2.3.0:' .config && ct-ng build
 
 ${GCC_MB_WORKDIR}/arm/microblazeel-xilinx-elf/bin/mb-gcc: | ${NATIVE_BUILD_arm}
 


### PR DESCRIPTION
The Expat team has removed expat 2.2.6 from distribution due to security issues. As this is only version known to the current version of crosstool-ng all gcc-mb builds are failing at present. To work around this we force crosstool-ng to use version 2.3.0 until a new release becomes available.