### PR TITLE
Refactor how contexts are stored, use xclIPName2Index to get correct CU index

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -712,7 +712,8 @@ class DefaultIP(metaclass=RegisterIP):
         else:
             self._registers = None
         if 'index' in description:
-            self.cu_mask = 1 << description['adjusted_index']
+            cu_index = self.device.open_contex(description)
+            self.cu_mask = 1 << cu_index
             self._setup_packet_prototype()
         if 'streams' in description:
             self.streams = {}

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019, Xilinx, Inc.
+#   Copyright (c) 2019-2021, Xilinx, Inc.
 #   All rights reserved.
 #
 #   Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 
 
 __author__ = "Peter Ogden"
-__copyright__ = "Copyright 2019, Xilinx"
+__copyright__ = "Copyright 2019-2021, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 import ctypes
@@ -156,10 +156,12 @@ def _xclxml_to_ip_dict(raw_xml, xclbin_uuid):
                 'state': None,
                 'interrupts': {},
                 'gpio': {},
-                'xclbin_uuid': xclbin_uuid
+                'xclbin_uuid': xclbin_uuid,
+                'cu_name' : ":".join((kernel.attrib['vlnv'].split(':')[2],
+                    instance.attrib['name']))
             }
-    for i, d in enumerate(sorted(ip_dict.values(), key=lambda x: x['phys_addr'])):
-        d['adjusted_index'] = i
+    for i, d in enumerate(sorted(ip_dict.values(),
+        key=lambda x: x['phys_addr'])): d['cu_index'] = i
     return {k: v for k, v in sorted(ip_dict.items())}
 
 
@@ -199,7 +201,7 @@ def _get_object_as_array(obj, number):
 
 def _mem_data_to_dict(idx, mem):
     if mem.m_type == 9:
-        # Streaming Endpoint
+        # Streaming Endpoing
         return {
             "raw_type": mem.m_type,
             "used": mem.m_used,

--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -201,7 +201,7 @@ def _get_object_as_array(obj, number):
 
 def _mem_data_to_dict(idx, mem):
     if mem.m_type == 9:
-        # Streaming Endpoing
+        # Streaming Endpoint
         return {
             "raw_type": mem.m_type,
             "used": mem.m_used,


### PR DESCRIPTION
- Refactor code to store contexts in a dict
- Include xclIPName2Index binding to get correct CU index
- Rename adjusted_indext to cu_index
- The context for each kernel is open when the IP object is used for the first time (\_\_init\_\_)