### PR TITLE
Support PS block within a hierarchy

### DIFF
--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -182,7 +182,7 @@ class _HWHABC(metaclass=abc.ABCMeta):
             mod_type = mod.get('MODTYPE')
             full_path = mod.get('FULLNAME').lstrip('/')
             if mod_type == self.family_ps:
-                self.ps_name = mod.get('INSTANCE')
+                self.ps_name = full_path
                 self.init_clk_dict(mod)
                 self.init_full_ip_dict(mod)
                 self.add_ps_to_ip_dict(mod)


### PR DESCRIPTION
There is no change for designs with the PS block in the top level. For designs with the PS block within a hierarchy, the PS is added correctly to the `ip_dict`

Fixes #620 #1075 