### PR TITLE
Check for device-tree apply errors

### DIFF
--- a/pynq/devicetree.py
+++ b/pynq/devicetree.py
@@ -131,6 +131,19 @@ class DeviceTreeSegment:
                   'wb', buffering=0) as f:
             f.write(dtbo_data)
 
+        # The only way to detect a DTBO insert failure is to try and
+        # read back the contents of the dtbo attribute and see if
+        # it is non-empty
+
+        with open(os.path.join(self.sysfs_dir, 'dtbo'),
+                'rb', buffering=0) as f:
+            # The entire DTBO file has to be read in a single syscall
+            # otherwise and IO error will occur
+            read_back = f.read(1024*1024)
+            if read_back != dtbo_data:
+                raise RuntimeError('Device tree {} canoot be applied'.format(
+                    self.dtbo_name))
+
         if not self.is_dtbo_applied():
             raise RuntimeError('Device tree {} cannot be applied.'.format(
                 self.dtbo_name))


### PR DESCRIPTION
The only consistent way to check if a device-tree has been successfully
applied is to see if the dtbo file contains the expected data.

Fixes: Xilinx/PYNQ-Dev#325