### PR TITLE
Remove restrictions on CI branches

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,7 @@ name: Python
 
 on:
   push:
-    branches: [ image_v2.6.2 ]
   pull_request:
-    branches: [ image_v2.6.2 ]
 
 jobs:
   build:


### PR DESCRIPTION
All of our branches should be tested by Github actions. Note that this will only apply to PR and pushes that have this commit as part of their history so our old commits will not be affected by this change.