### PR TITLE
Raise a warning when xbutil exists but fails to run

### DIFF
--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -82,6 +82,9 @@ def _get_xrt_version():
     try:
         output = subprocess.run(['xbutil', 'dump'], stdout=subprocess.PIPE,
                                 universal_newlines=True)
+        if output.returncode != 0:
+            warnings.warn(
+                    'xbutil failed to run - unable to determine XRT version')
         details = json.loads(output.stdout)
         return tuple(
             int(s) for s in details['runtime']['build']['version'].split('.'))

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -1,5 +1,6 @@
 import importlib
 import pynq._3rdparty.xrt
+import pytest
 import ctypes
 import os
 
@@ -89,8 +90,9 @@ exit 1
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
     monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
     import pynq.pl_server.xrt_device
-    xrt = importlib.reload(pynq._3rdparty.xrt)
-    xrt_device = importlib.reload(pynq.pl_server.xrt_device)
+    with pytest.warns(UserWarning, match='xbutil failed to run'):
+        xrt = importlib.reload(pynq._3rdparty.xrt)
+        xrt_device = importlib.reload(pynq.pl_server.xrt_device)
     assert xrt_device._xrt_version == (0, 0, 0)
 
 


### PR DESCRIPTION
Fixes: Xilinx/PYNQ-Dev#318