### PR TITLE
Bugfix, do not issue AXI4-Lite read transaction when the access type is write-only

### DIFF
--- a/pynq/registers.py
+++ b/pynq/registers.py
@@ -120,7 +120,8 @@ class Register:
 
     """
 
-    def __init__(self, address, width=32, debug=False, buffer=None):
+    def __init__(self, address, width=32, debug=False, buffer=None,
+                 access='read-write'):
         """Instantiate a register object.
 
         Parameters
@@ -141,6 +142,7 @@ class Register:
         self.address = address
         self.width = width
         self.debug = debug
+        self.access = access
 
         if width == 32:
             register_type = 'u4'
@@ -172,6 +174,8 @@ class Register:
         """
         lower, upper, reverse = _calc_index(index, self.width)
         curr_val = int(self._buffer[0])
+        if self.access == 'write-only':
+            return self.access
         if lower == upper:
             self._debug("Reading index {} at address {}"
                         .format(index, hex(self.address)))
@@ -268,9 +272,14 @@ class Register:
         """
         if hasattr(self, '_fields') and self._fields:
             field_desc = []
-            for k in self._fields.keys():
-                field_desc.append("{}={}".format(k, getattr(self, k)))
+            for k, v in self._fields.items():
+                if v['access'] != 'write-only':
+                    field_desc.append("{}={}".format(k, getattr(self, k)))
+                else:
+                    field_desc.append("{}={}".format(k, 'write-only'))
             return "Register({})".format(", ".join(field_desc))
+        elif self.access == 'write-only':
+            return "Register(value={})".format(self.access)
         else:
             return "Register(value={})".format(self[:])
 
@@ -324,8 +333,8 @@ class Register:
             else:
                 attr_dict[attrname] = property(
                     functools.partial(Register.__getitem__, index=index),
-                    functools.partial(Register._reordered_setitem, index=index),
-                    doc=doc)
+                    functools.partial(Register._reordered_setitem,
+                                      index=index), doc=doc)
         return type("Register" + name, (Register,), attr_dict)
 
     @classmethod
@@ -371,12 +380,10 @@ class RegisterMap:
                                "create_subclass can be instantiated")
         if hasattr(buffer, 'view'):
             array32 = buffer.view(dtype='u4')
-            array64 = buffer.view(dtype='u8')
         else:
             array32 = np.frombuffer(buffer=buffer, dtype=np.uint32,
                                     count=self._map_size // 4)
-            array64 = np.frombuffer(buffer=buffer, dtype=np.uint64,
-                                    count=self._map_size // 8)
+
         self._instances = {}
         for k, v in self._register_classes.items():
             if v[2] <= 32:
@@ -393,8 +400,9 @@ class RegisterMap:
                         v[2], k
                     ))
                 continue
+
             self._instances[k] = v[0](
-                address=v[1], width=align_width, buffer=array)
+                address=v[1], width=align_width, buffer=array, access=v[5])
 
     def _set_value(self, value, name):
         self._instances[name][:] = value
@@ -404,9 +412,9 @@ class RegisterMap:
 
     def __repr__(self):
         register_info = []
-        for k, v in sorted(self._instances.items(), key=lambda x: x[1].address):
-            register_info.append(
-                "  {} = {}".format(k, repr(v)))
+        for k, v in \
+                sorted(self._instances.items(), key=lambda x: x[1].address):
+            register_info.append("  {} = {}".format(k, repr(v)))
         return "RegisterMap {\n" + ",\n".join(register_info) + "\n}"
 
     @classmethod
@@ -446,7 +454,8 @@ class RegisterMap:
             else:
                 register_class = Register
             register_classes[attrname] = (
-                register_class, v['address_offset'], v['size'])
+                register_class, v['address_offset'], v['size'],
+                None, None, v['access'])
             upper_range = v['address_offset'] + v['size'] // 8
             if upper_range > address_high:
                 address_high = upper_range

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -446,6 +446,7 @@ REGMAP_TESTS = {
     'aligned_4': (32, 'I', 0x12345678, 0x87654321),
     'aligned_8': (40, 'Q', 0x123456789ABCDEF0, 0x0FEDCBA987654321),
     'unaligned_8': (52, 'Q', 0x123456789ABCDEF0, 0x0FEDCBA987654321),
+    'write_only': (68, 'I', 0x12345678, 0x87654321),
     'space_special__': (72, 'I', 0x12345678, 0x87654321),
     'r001_numbered': (76, 'I', 0x12345678, 0x87654321),
     'out_of_order': (80, 'I', 0x123456, 0x876543),
@@ -459,6 +460,8 @@ def test_regmap_rw(mock_registermap, register_name):
 
     width = struct.calcsize(struct_string)
     buf[offset:offset+width] = memoryview(struct.pack(struct_string, start))
+    if register_name == 'write_only':
+        start = 'write-only'
     assert getattr(rm, register_name)[:] == start
     setattr(rm, register_name, end)
     assert struct.unpack(struct_string, buf[offset:offset+width])[0] == end
@@ -473,6 +476,8 @@ def test_regmap_rw_mmio(register_name):
     offset, struct_string, start, end = REGMAP_TESTS[register_name]
     read_transaction = (ADDRESS+offset, struct.pack(struct_string, start))
     write_transaction = (ADDRESS+offset, struct.pack(struct_string, end))
+    if register_name == 'write_only':
+        start = 'write-only'
     with device.check_transactions([read_transaction], []):
         value = getattr(rm, register_name)[:]
         assert value == start

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -331,7 +331,7 @@ def test_repr_plain(width):
 
 
 def test_repr_fields(mock_register):
-    assert "Register(read_field=1, write_field=2, rw_field_1=3, rw_field_2=4, r0_number_field=5, space_special__=6)" == repr(mock_register)  # NOQA
+    assert "Register(read_field=1, write_field=write-only, rw_field_1=3, rw_field_2=4, r0_number_field=5, space_special__=6)" == repr(mock_register)  # NOQA
 
 
 def test_reg_debug_bit(width, capsys):
@@ -446,7 +446,6 @@ REGMAP_TESTS = {
     'aligned_4': (32, 'I', 0x12345678, 0x87654321),
     'aligned_8': (40, 'Q', 0x123456789ABCDEF0, 0x0FEDCBA987654321),
     'unaligned_8': (52, 'Q', 0x123456789ABCDEF0, 0x0FEDCBA987654321),
-    'write_only': (68, 'I', 0x12345678, 0x87654321),
     'space_special__': (72, 'I', 0x12345678, 0x87654321),
     'r001_numbered': (76, 'I', 0x12345678, 0x87654321),
     'out_of_order': (80, 'I', 0x123456, 0x876543),
@@ -491,12 +490,12 @@ def test_regmap_read_only(mock_registermap):
 
 
 expected_regmap_repr = """RegisterMap {
-  test_register = Register(read_field=0, write_field=1, rw_field_1=1, rw_field_2=1, r0_number_field=2, space_special__=1),
+  test_register = Register(read_field=0, write_field=write-only, rw_field_1=1, rw_field_2=1, r0_number_field=2, space_special__=1),
   aligned_4 = Register(value=589439264),
   aligned_8 = Register(value=3399704436437297448),
   unaligned_8 = Register(value=4267786510494217524),
   read_only = Register(value=1128415552),
-  write_only = Register(value=1195787588),
+  write_only = Register(value=write-only),
   space_special__ = Register(value=1263159624),
   r001_numbered = Register(value=1330531660),
   out_of_order = Register(value=1397903696)


### PR DESCRIPTION
- Do not issue AXI4-Lite read transaction when the access type is write-only
- Remove unused `array64`
- Update test to check for write-only