### PR TITLE
Remove Ubuntu 16.04 and Docker from sdbuild setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,68 +3,9 @@
 
 Vagrant.configure("2") do |config|
 
-	# Based on Ubuntu Xenial 16.04; this is the default VM
-	# run `vagrant up xenial`
-	config.vm.define "xenial", primary: true do |xenial|
-		xenial.vm.box = "ubuntu/xenial64"
-		xenial.vm.synced_folder ".", "/pynq", 
-			owner: "vagrant", group: "vagrant"
-		xenial.vm.provider "virtualbox" do |vb|
-			vb.gui = true
-			vb.name = "pynq_ubuntu_16_04"
-			vb.memory = "8192"
-			vb.customize ["modifyvm", :id, "--vram", "128"]
-			vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
-			disk_image = File.join(File.dirname(File.expand_path(__FILE__)), 
-				'ubuntu_16_04.vdi')
-			unless File.exist?(disk_image)
-			vb.customize ['createhd', 
-						'--filename', disk_image, 
-						'--size', 160 * 1024]
-		end
-			vb.customize ['storageattach', :id, 
-						'--storagectl', 'SCSI', 
-						'--port', 2, '--device', 0, 
-						'--type', 'hdd', 
-						'--medium', disk_image]
-			vb.customize ['storageattach', :id, 
-						'--storagectl', 'IDE', 
-						'--port', '0', '--device', '1', 
-						'--type', 'dvddrive', 
-						'--medium', 'emptydrive']
-		end
-
-		xenial.vm.provision "shell", inline: <<-SHELL
-			parted /dev/sdc mklabel msdos
-			parted /dev/sdc mkpart primary 100 100%
-			partprobe
-			mkfs.xfs /dev/sdc1
-			mkdir /workspace
-			echo `blkid /dev/sdc1 | awk '{print$2}' | sed -e 's/"//g'` \
-				/workspace   xfs   noatime,nobarrier   0   0 >> /etc/fstab
-			mount /workspace
-			chown -R vagrant:vagrant /workspace
-			chmod 777 -R /workspace
-		SHELL
-
-		xenial.vm.provision "shell",
-			inline: "apt-get update"
-
-		xenial.vm.provision "shell", 
-			inline: "/bin/bash /pynq/sdbuild/scripts/setup_host.sh"
-
-
-		xenial.vm.provision "shell", 
-			inline: "apt-get install -y --force-yes ubuntu-desktop"
-
-		xenial.vm.provision "shell", inline: <<-SHELL
-			cat /root/.profile | grep PATH >> /home/vagrant/.profile
-		SHELL
-	end
-
-	# Based on Ubuntu Bionic 18.04
+	# Based on Ubuntu Bionic 18.04; this is the default VM
 	# run `vagrant up bionic`
-	config.vm.define "bionic", autostart: false do |bionic|
+	config.vm.define "bionic", primary: true do |bionic|
 		bionic.vm.box = "ubuntu/bionic64"
 		bionic.vm.synced_folder ".", "/pynq", 
 			owner: "vagrant", group: "vagrant"

--- a/docs/source/pynq_sd_card.rst
+++ b/docs/source/pynq_sd_card.rst
@@ -31,7 +31,6 @@ It is recommended to use a Ubuntu OS to build the image. The currently supported
 ================  ==================
 Supported OS      Code name
 ================  ==================   
-Ubuntu 16.04       xenial
 Ubuntu 18.04       bionic
 ================  ==================
 
@@ -71,7 +70,7 @@ If you do not have a Ubuntu OS, and you need a Ubuntu VM, do the following:
         vagrant up
 
      The above command will take about 20 minutes to finish.
-     By default, our vagrant file will prepare a Ubuntu 16.04 OS. If you would
+     By default, our vagrant file will prepare a Ubuntu 18.04 OS. If you would
      like to use another OS, do:
      
      .. code-block:: console
@@ -128,6 +127,7 @@ If you do not have a Ubuntu OS, and you need a Ubuntu VM, do the following:
      v2.4               2018.3
      v2.5               2019.1
      v2.6               2020.1
+     v2.7               2020.2
      ================  ================
 
 Use existing Ubuntu OS

--- a/sdbuild/scripts/setup_host.sh
+++ b/sdbuild/scripts/setup_host.sh
@@ -40,9 +40,6 @@ zerofree
 u-boot-tools
 rpm2cpio
 curl
-docker-ce
-docker-ce-cli
-containerd.io
 libsdl1.2-dev
 libpixman-1-dev
 libc6-dev
@@ -63,39 +60,16 @@ set -e
 
 sudo apt-get update
 
-if [[ $(lsb_release -rs) == "16.04" ]]; then
-    echo "Install packages on Ubuntu 16.04..."
-    sudo apt purge -y libgnutls-dev
-elif [[ $(lsb_release -rs) == "18.04" ]]; then
+if [[ $(lsb_release -rs) == "18.04" ]]; then
     echo "Install packages on Ubuntu 18.04..."
 else
     echo "Error: current OS not supported."
     exit 1
 fi
 
-# Setup docker and containerd using repository before installing them
-sudo apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
-sudo apt-get update
-
-sudo dpkg --add-architecture i386
-sudo apt-get update
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
 sudo apt-get update
 sudo apt-get install -y $PACKAGES
-
-# Double-check docker can run with or without sudo
-sudo service docker start
-sudo chmod 777 /var/run/docker.sock
-docker run hello-world
-sudo docker run hello-world
 
 # Install up-to-date versions of crosstool and qemu
 if [ -e tools ]; then


### PR DESCRIPTION
Xenial is no longer supported for building PYNQ images and docker
has never been a requirement so remove it as well

Fixes Xilinx/PYNQ-Dev#322