### PR TITLE
Disable certificate checking when cloning X11

### DIFF
--- a/sdbuild/packages/x11/qemu.sh
+++ b/sdbuild/packages/x11/qemu.sh
@@ -20,7 +20,7 @@ rm -rf /home/xilinx/.config/chromium/Singleton*
 mkdir /root/armsoc_build
 cd /root/armsoc_build
 
-git clone https://anongit.freedesktop.org/git/xorg/driver/xf86-video-armsoc.git
+git clone https://anongit.freedesktop.org/git/xorg/driver/xf86-video-armsoc.git -c http.sslverify=false
 cd xf86-video-armsoc
 git apply /armsoc.patch --ignore-whitespace
 ./autogen.sh


### PR DESCRIPTION
This is less-than optimal and the correct solution is to upgrade
ca-certificates in our rootfs.