### PR TITLE
Bug fixes for awsxclbin files

### DIFF
--- a/pynq/pl_server/xclbin_parser.py
+++ b/pynq/pl_server/xclbin_parser.py
@@ -297,7 +297,7 @@ def _xclbin_to_dicts(filename, xclbin_data=None):
                                            connectivity.m_count)
     elif xclbin.AXLF_SECTION_KIND.CONNECTIVITY in sections:
         connectivity = xclbin.connectivity.from_buffer(
-            sections[xclbin.AXLF_SECTION_KIND.GROUP_CONNECTIVITY])
+            sections[xclbin.AXLF_SECTION_KIND.CONNECTIVITY])
         connections = _get_object_as_array(connectivity.m_connection[0],
                                            connectivity.m_count)
     else:


### PR DESCRIPTION
- In one example the physical address of the kernel is 0, and the kernel was not being added to the ip_dict
- Read from the correct section, I assume this was a copy paste issue 