### PR TITLE
PL.reset update - fixes microblaze state not clearing

### DIFF
--- a/pynq/pl_server/server.py
+++ b/pynq/pl_server/server.py
@@ -51,14 +51,18 @@ def clear_state(dict_in):
 
     Parameters
     ----------
-    dict_in : dict
+    dict_in : obj
         Input dictionary to be cleared.
 
     """
-    if type(dict_in) is dict:
-        for i in dict_in:
-            if 'state' in dict_in[i]:
-                dict_in[i]['state'] = None
+    if not isinstance(dict_in,dict):
+        return dict_in
+
+    for k,v in dict_in.items():
+        if isinstance(v,dict):
+            dict_in[k] =  clear_state(v)
+        if k == 'state':
+            dict_in[k] = None
     return dict_in
 
 
@@ -261,6 +265,7 @@ class DeviceClient:
             if os.path.isfile(hwh_name):
                 self._ip_dict = clear_state(self._ip_dict)
                 self._gpio_dict = clear_state(self._gpio_dict)
+                self._hierarchy_dict = clear_state(self._hierarchy_dict)
             else:
                 self.clear_dict()
         if timestamp is not None:


### PR DESCRIPTION
Microblaze state dictionary entry was not being emptied on a PL reset due to movement of state key... this fixes the state clearing regardless of where that state is held in the hierarchical dictionary.