### PR TITLE
Remove dtbo when freeing overlay

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -384,6 +384,8 @@ class Overlay(Bitstream):
     def free(self):
         if hasattr(self.device, 'free_bitstream'):
             self.device.free_bitstream()
+        if self.dtbo:
+            self.remove_dtbo()
 
     def download(self, dtbo=None):
         """The method to download a full bitstream onto PL.


### PR DESCRIPTION
Clear the DBTO when the free method is called. 