### PR TITLE
Fix typo and remove confusing variable expansion

### DIFF
--- a/docs/source/pynq_sd_card.rst
+++ b/docs/source/pynq_sd_card.rst
@@ -357,7 +357,7 @@ officially supported boards. This means, in particular, that:
 Building from a board repository
 ================================
 
-To build from a third-party board repository pass the ``${BOARDDIR}`` variable to the
+To build from a third-party board repository, pass the ``BOARDDIR`` variable to the
 sdbuild makefile.
 
 .. code-block:: console
@@ -365,6 +365,6 @@ sdbuild makefile.
    cd <PYNQ repository>/sdbuild/
    make BOARDDIR=${BOARD_REPO}
 
-The board repo should be provided as an absolute path. The ``${BOARDDIR}`` variable
-can be combined with the ``${BOARD}`` variable if the repository contains multiple
+The board repo should be provided as an absolute path. The ``BOARDDIR`` variable
+can be combined with the ``BOARDS`` variable if the repository contains multiple
 boards and only a subset should be built.


### PR DESCRIPTION
See also: https://github.com/Xilinx/PYNQ/pull/1302

I decided to not change any wording. I am, however, pretty sure the the variable expansion does not make sense in this section and decided to remove it.

Most important is changing the "BOARD" variable to "BOARDS" (the typo).


If you would like to implement some different change to fix/improve this documentation section, feel free to just close the PR without a merge. ( Don't really care about the "how", just want to see this section improved :wink: )