### PR TITLE
Fix bug, only consider the . pertaining to the extension

### DIFF
--- a/pynq/devicetree.py
+++ b/pynq/devicetree.py
@@ -54,7 +54,7 @@ def get_dtbo_path(bitfile_name):
         The absolute path of the dtbo file.
 
     """
-    return ''.join(bitfile_name.split('.', -1)[:-1]) + '.dtbo'
+    return os.path.splitext(bitfile_name)[0] + '.dtbo'
 
 
 def get_dtbo_base_name(dtbo_path):


### PR DESCRIPTION
Critical bug to fix for 2.7

Given a bistream in this path `'/usr/local/share/pynq-venv/lib/python3.8/site-packages/kv260_pynq/overlays/base.bit'`, the old code will return `'/usr/local/share/pynq-venv/lib/python38/site-packages/kv260_pynq/overlays/base.dtbo' as dtbo path.
`

This PR uses `os.path.splitext` which ensures that the basename is not modified.