### PR TITLE
DMA driver fix refactoring

### DIFF
--- a/pynq/lib/dma.py
+++ b/pynq/lib/dma.py
@@ -649,7 +649,7 @@ class DMA(DefaultIP):
                     self.sendchannel = _SGDMAChannel(
                         self.mmio,
                         max_size,
-                        6,
+                        data_width,
                         DMA_TYPE_TX,
                         dre,
                         self.mm2s_introut)
@@ -666,7 +666,7 @@ class DMA(DefaultIP):
                     self.sendchannel = _SGDMAChannel(
                         self.mmio,
                         max_size,
-                        6,
+                        data_width,
                         DMA_TYPE_TX,
                         dre)
                 else:
@@ -707,7 +707,7 @@ class DMA(DefaultIP):
                     self.recvchannel = _SGDMAChannel(
                         self.mmio,
                         max_size,
-                        6,
+                        data_width,
                         DMA_TYPE_RX,
                         dre,
                         self.s2mm_introut)
@@ -724,7 +724,7 @@ class DMA(DefaultIP):
                     self.recvchannel = _SGDMAChannel(
                         self.mmio,
                         max_size,
-                        6,
+                        data_width,
                         DMA_TYPE_RX,
                         dre)
                 else:


### PR DESCRIPTION
Resolves #1320 fix 4 lines that were incorrectly changed during refacturing

These lines have a wrong value: `6` instead of `data_width`, in [dma.py](https://github.com/Xilinx/PYNQ/blob/59515a9b5de6fad0ff0538bfc50010b16f53c9a8/pynq/lib/dma.py):
[652](https://github.com/Xilinx/PYNQ/blob/59515a9b5de6fad0ff0538bfc50010b16f53c9a8/pynq/lib/dma.py#L652)
[669](https://github.com/Xilinx/PYNQ/blob/59515a9b5de6fad0ff0538bfc50010b16f53c9a8/pynq/lib/dma.py#L669)
[710](https://github.com/Xilinx/PYNQ/blob/59515a9b5de6fad0ff0538bfc50010b16f53c9a8/pynq/lib/dma.py#L710)
[727](https://github.com/Xilinx/PYNQ/blob/59515a9b5de6fad0ff0538bfc50010b16f53c9a8/pynq/lib/dma.py#L727)