### PR TITLE
Docs / OverlayTutorial: corrected link to new git repo

### DIFF
--- a/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
+++ b/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
@@ -13,7 +13,7 @@
     " * Provide a simple way for developers of new hardware designs to test new IP\n",
     " * Facilitate reuse of IP between Overlays\n",
     " \n",
-    "This tutorial is primarily designed to demonstrate the final two points, walking through the process of interacting with a new IP, developing a driver, and finally building a more complex system from multiple IP blocks. All of the code and block diagrams can be found [here](https://github.com/PeterOgden/overlay_tutorial). For these examples to work copy the contents of the overlays directory into the home directory on the PYNQ-Z1 board."
+    "This tutorial is primarily designed to demonstrate the final two points, walking through the process of interacting with a new IP, developing a driver, and finally building a more complex system from multiple IP blocks. All of the code and block diagrams can be found [here](https://github.com/schelleg/overlay_tutorial). For these examples to work copy the contents of the overlays directory into the home directory on the PYNQ-Z1 board."
    ]
   },
   {


### PR DESCRIPTION
The git repo of the overlay tutorial was formerly maintained by PeterOgden. This  repository moved to https://github.com/schelleg/overlay_tutorial