### PR TITLE
Include nest_asyncio as dependency. Fix Xilinx/PYNQ-Dev#351

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ from datetime import datetime
 required = [
     'setuptools>=24.2.0',
     'cffi',
-    'numpy'
+    'numpy',
+    'nest_asyncio'
 ]
 
 extras_required = {


### PR DESCRIPTION
As reported https://github.com/Xilinx/PYNQ-Dev/issues/351 and https://discuss.pynq.io/t/pynq-on-alveo-and-xrt-2021-2/3568/3?u=marioruiz `nest_asyncio` is a dependency on PYNQ for compute acceleration 