### PR TITLE
Move DFX memory mapped regions to the `mem_dict`

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -115,7 +115,7 @@ def _complete_description(ip_dict, hierarchy_dict, ignore_version,
     starting_dict['interrupts'] = dict()
     starting_dict['gpio'] = dict()
     starting_dict['memories'] = {re.sub('[^A-Za-z0-9_]', '', k): v
-                                 for k, v in mem_dict.items() if v['used']}
+                                 for k, v in mem_dict.items() if v.get('used')}
     starting_dict['device'] = device
     for k, v in starting_dict['hierarchies'].items():
         v['overlay'] = overlay

--- a/pynq/pl_server/embedded_device.py
+++ b/pynq/pl_server/embedded_device.py
@@ -300,13 +300,14 @@ def _ip_to_topology(mem_dict):
     ]}
     for k, v in mem_dict.items():
         v['xrt_mem_idx'] = len(topology['m_mem_data'])
-        topology['m_mem_data'].append(
-            {'m_type': 'MEM_DDR4',
-             'm_used': 1,
-             'm_sizeKB': v['addr_range'] // 1024,
-             'm_tag': f'MIG{len(topology["m_mem_data"])}',
-             'm_base_address': v['phys_addr']}
-        )
+        if not v.get('dfx'):
+            topology['m_mem_data'].append(
+                {'m_type': 'MEM_DDR4',
+                 'm_used': 1,
+                 'm_sizeKB': v['addr_range'] // 1024,
+                 'm_tag': f'MIG{len(topology["m_mem_data"])}',
+                 'm_base_address': v['phys_addr']}
+            )
     topology['m_count'] = len(topology['m_mem_data'])
     return {'mem_topology': topology}
 
@@ -507,7 +508,7 @@ class EmbeddedDevice(XrtDevice):
             raise RuntimeError("Overlay is not downloaded")
 
         for k, v in self.mem_dict.items():
-            if v['base_address'] == 0:
+            if v.get('base_address') == 0:
                 return self.get_memory(v)
         raise RuntimeError("XRT design does not contain PS memory")
 

--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -408,7 +408,7 @@ class _HWHABC(metaclass=abc.ABCMeta):
             elif memtype == 'REGISTER':
                 if (bdtype == 'BLOCK_CONTAINER' and \
                         v.get('parameters').get('ENABLE_DFX') == 'true') or \
-                        bdtype == 'RDB':
+                        bdtype == 'RBD':
                     self.mem_dict[k] = v
                     v['dfx'] = True
                     del self.ip_dict[k]

--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -403,8 +403,6 @@ class _HWHABC(metaclass=abc.ABCMeta):
             if v.get('memtype', None) == 'MEMORY':
                 self.mem_dict[k] = v
                 v['used'] = 1
-                if 'xilinx.com:ip:axi_bram_ctrl' not in v.get('type'):
-                    del self.ip_dict[k]
 
     def _add_interrupt_pins(self, net, parent, offset, raw_map=None):
         net_pins = self.nets[net] if net else set()

--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -400,9 +400,18 @@ class _HWHABC(metaclass=abc.ABCMeta):
 
         """
         for k, v in list(self.ip_dict.items()):
-            if v.get('memtype', None) == 'MEMORY':
+            memtype = v.get('memtype')
+            bdtype = v.get('bdtype')
+            if memtype == 'MEMORY':
                 self.mem_dict[k] = v
                 v['used'] = 1
+            elif memtype == 'REGISTER':
+                if (bdtype == 'BLOCK_CONTAINER' and \
+                        v.get('parameters').get('ENABLE_DFX')) or \
+                        bdtype == 'RDB':
+                    self.mem_dict[k] = v
+                    v['dfx'] = True
+                    del self.ip_dict[k]
 
     def _add_interrupt_pins(self, net, parent, offset, raw_map=None):
         net_pins = self.nets[net] if net else set()

--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -403,7 +403,8 @@ class _HWHABC(metaclass=abc.ABCMeta):
             if v.get('memtype', None) == 'MEMORY':
                 self.mem_dict[k] = v
                 v['used'] = 1
-                del self.ip_dict[k]
+                if 'xilinx.com:ip:axi_bram_ctrl' not in v.get('type'):
+                    del self.ip_dict[k]
 
     def _add_interrupt_pins(self, net, parent, offset, raw_map=None):
         net_pins = self.nets[net] if net else set()

--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -407,7 +407,7 @@ class _HWHABC(metaclass=abc.ABCMeta):
                 v['used'] = 1
             elif memtype == 'REGISTER':
                 if (bdtype == 'BLOCK_CONTAINER' and \
-                        v.get('parameters').get('ENABLE_DFX')) or \
+                        v.get('parameters').get('ENABLE_DFX') == 'true') or \
                         bdtype == 'RDB':
                     self.mem_dict[k] = v
                     v['dfx'] = True

--- a/pynq/tests/test_mmio.py
+++ b/pynq/tests/test_mmio.py
@@ -63,7 +63,7 @@ def test_mmio():
     """
     mmio_base = mmio_range = None
     for ip in PL.ip_dict:
-        if PL.ip_dict[ip]['type'] == "xilinx.com:ip:axi_bram_ctrl:4.0":
+        if "xilinx.com:ip:axi_bram_ctrl:" in PL.ip_dict[ip]['type'] :
             mmio_base = PL.ip_dict[ip]['phys_addr']
             mmio_range = PL.ip_dict[ip]['addr_range']
             break


### PR DESCRIPTION
Work done in this PR

- Include bram controller in the `ip_dict`
 I think it would be nice if the bram controller is included in the `ip_dict` so the `read `and `write `methods from `DefaultIP` can be used directly. 
- Move DFX memory mapped regions to the mem_dict
 This goes hand in hand with #1352 

This fix Xilinx/PYNQ-DEV#361