### PR TITLE
Support numpy and float data types in MMIO read/write

### DIFF
--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -147,8 +147,10 @@ class MMIO:
         idx = offset >> 2
         if offset % 4:
             raise MemoryError('Unaligned read: offset must be multiple of 4.')
+        if data_type == 'float' and length != 4:
+            raise ValueError("reading floating point is only valid when "
+                "length is equal to 4")
 
-        # Read data out
         lsb = int(self.array[idx])
         if length == 8:
             if word_order == 'little':

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -176,9 +176,9 @@ class MMIO:
         if offset % 4:
             raise MemoryError('Unaligned write: offset must be multiple of 4.')
 
-        if type(data) is int:
+        if isinstance(data, (int, np.int32, np.uint32)):
             self.array[idx] = np.uint32(data)
-        elif type(data) is bytes:
+        elif isinstance(data, bytes):
             length = len(data)
             num_words = length >> 2
             if length % 4:


### PR DESCRIPTION
 - Support for write/read floating point numbers
 - Support for write/read numpy.uint32 and numpy.int32 numbers. Fix #634 
 - Merge write functionality in a single method
 - `MMIO.read` arguments `word_order` and `data_type` are passed as keywords (`**kwargs`)
 - Update test cases to verify new data types read/write operations
