### PR TITLE
xclbin parsing typo fixes

### DIFF
--- a/pynq/pl_server/embedded_device.py
+++ b/pynq/pl_server/embedded_device.py
@@ -215,13 +215,13 @@ class BinfileHandler(BitstreamHandler):
 
 class XclbinHandler(BitstreamHandler):
     def __init__(self, filepath):
-        from .xclbin_parser import parse_sections
+        from .xclbin_parser import parse_xclbin_header
         super().__init__(filepath)
         self._data = self._filepath.read_bytes()
-        self._sections, _ = parse_sections(self._data)
+        self._sections, _ = parse_xclbin_header(self._data)
 
     def get_bin_data(self):
-        from pynq._3rd_party.xclbin import AXLF_SECTION_KIND
+        from pynq._3rdparty.xclbin import AXLF_SECTION_KIND
         if AXLF_SECTION_KIND.BITSTREAM in self._sections:
             return bit2bin(self._sections[AXLF_SECTION_KIND.BITSTREAM])
         return None


### PR DESCRIPTION
Was getting errors of right functions not being found when trying to load an overlay with xclbin alone with `pynq.Overlay('dpu.xclbin')`
* inside  xclbin_parser `parse_sections` doesn't exist, looks like `parse_xclbin_header` should be used instead
* typo `pynq._3rd_party` -> `pynq._3rdparty`