### PR TITLE
Fix bug, return `XrtDevice` only for x86 machines

### DIFF
--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -37,7 +37,7 @@ import warnings
 import weakref
 import numpy as np
 from pynq.buffer import PynqBuffer
-from pynq.ps import CPU_ARCH, x86_ARCH
+from pynq.ps import CPU_ARCH_IS_x86
 from .device import Device
 
 from pynq._3rdparty import xrt
@@ -315,7 +315,7 @@ class XrtStream:
 class XrtDevice(Device):
     @classmethod
     def _probe_(cls):
-        if not xrt.XRT_SUPPORTED or CPU_ARCH != x86_ARCH:
+        if not xrt.XRT_SUPPORTED or not CPU_ARCH_IS_x86:
             return []
         num = xrt.xclProbe()
         devices = [XrtDevice(i) for i in range(num)]

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019-2021, Xilinx, Inc.
+#   Copyright (c) 2019-2022, Xilinx, Inc.
 #   All rights reserved.
 #
 #   Redistribution and use in source and binary forms, with or without
@@ -37,13 +37,14 @@ import warnings
 import weakref
 import numpy as np
 from pynq.buffer import PynqBuffer
+from pynq.ps import CPU_ARCH, x86_ARCH
 from .device import Device
 
 from pynq._3rdparty import xrt
 from pynq._3rdparty import ert
 
 __author__ = "Peter Ogden"
-__copyright__ = "Copyright 2019-2021, Xilinx"
+__copyright__ = "Copyright 2019-2022, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 
@@ -314,7 +315,7 @@ class XrtStream:
 class XrtDevice(Device):
     @classmethod
     def _probe_(cls):
-        if not xrt.XRT_SUPPORTED:
+        if not xrt.XRT_SUPPORTED or CPU_ARCH != x86_ARCH:
             return []
         num = xrt.xclProbe()
         devices = [XrtDevice(i) for i in range(num)]

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2016, Xilinx, Inc.
+#   Copyright (c) 2016-2022, Xilinx, Inc.
 #   All rights reserved.
 #
 #   Redistribution and use in source and binary forms, with or without
@@ -31,11 +31,12 @@ import os
 import warnings
 
 __author__ = "Yun Rock Qu"
-__copyright__ = "Copyright 2017, Xilinx"
+__copyright__ = "Copyright 2017-2022, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 ZYNQ_ARCH = "armv7l"
 ZU_ARCH = "aarch64"
+x86_ARCH = "x86_64"
 CPU_ARCH = os.uname().machine
 CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH, ZU_ARCH]
 

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -36,9 +36,9 @@ __email__ = "pynq_support@xilinx.com"
 
 ZYNQ_ARCH = "armv7l"
 ZU_ARCH = "aarch64"
-x86_ARCH = "x86_64"
 CPU_ARCH = os.uname().machine
 CPU_ARCH_IS_SUPPORTED = CPU_ARCH in [ZYNQ_ARCH, ZU_ARCH]
+CPU_ARCH_IS_x86 = "x86" in CPU_ARCH
 
 DEFAULT_PL_CLK_MHZ = 100.0
 


### PR DESCRIPTION
Check for x86 architecture to create `XrtDevice`, this avoids creating two devices for edge platforms

Fix Xilinx/PYNQ-Dev#356