### PR TITLE
Release the zocl call by calling `device.close()`

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -386,6 +386,7 @@ class Overlay(Bitstream):
             self.device.free_bitstream()
         if self.dtbo:
             self.remove_dtbo()
+        self.device.close()
 
     def download(self, dtbo=None):
         """The method to download a full bitstream onto PL.

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -468,7 +468,6 @@ class XrtDevice(Device):
         if self.handle:
             xrt.xclClose(self.handle)
         self.handle = None
-        super().close()
 
     def get_memory(self, desc):
         if desc['streaming']:


### PR DESCRIPTION
- Release the zocl call by calling `device.close()`
- keep `pl_server` alive
- grab XRT handle in `_xrt_download` if the handle is empty

With these changes after a `Overlay.free()` the instance of zocl is released, and by not stopping the pl_server we can download another overlay from the same notebook.