### PR TITLE
Use the system-wide files to get XRT version

### DIFF
--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -93,7 +93,7 @@ def _get_xrt_version_embedded():
 def _get_xrt_version_x86():
     import json
     try:
-        with open(os.environ['XILINX_XRT'] + '/version.json', 'r') as f:
+        with open('/opt/xilinx/xrt/version.json', 'r') as f:
             details = json.loads(f.read())
         return tuple(
             int(s) for s in details['BUILD_VERSION'].split('.'))

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -86,6 +86,7 @@ def _get_xrt_version_embedded():
         return tuple(
             int(s) for s in details.split('.'))
     except Exception:
+        warnings.warn('Unable to determine XRT version')
         return (0, 0, 0)
 
 
@@ -97,6 +98,7 @@ def _get_xrt_version_x86():
         return tuple(
             int(s) for s in details['BUILD_VERSION'].split('.'))
     except Exception:
+        warnings.warn('Unable to determine XRT version')
         return (0, 0, 0)
 
 

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -79,9 +79,9 @@ _xrt_errors = {
 }
 
 
-def _get_xrt_version_embedded():
+def _get_xrt_version_embedded(path='/sys/module/zocl'):
     try:
-        with open('/sys/module/zocl/version', 'r') as f:
+        with open(path + '/version', 'r') as f:
             details = f.readline().replace('\n','')
         return tuple(
             int(s) for s in details.split('.'))

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -93,7 +93,7 @@ def _get_xrt_version_embedded():
 def _get_xrt_version_x86():
     import json
     try:
-        with open('/opt/xilinx/xrt/version.json', 'r') as f:
+        with open(os.environ['XILINX_XRT'] + '/version.json', 'r') as f:
             details = json.loads(f.read())
         return tuple(
             int(s) for s in details['BUILD_VERSION'].split('.'))

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -70,6 +70,7 @@ def test_xrt_normal(monkeypatch, recwarn):
 
 def test_xrt_version_x86(monkeypatch, tmp_path):
     monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    os.chmod('/path/to/xrt', 0o666)
     file = pathlib.Path("/path/to/xrt/version.json")
     file.parent.mkdir(parents=True, exist_ok=True)
     with file.open( 'w') as f:

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -69,11 +69,13 @@ def test_xrt_normal(monkeypatch, recwarn):
 
 
 def test_xrt_version_x86(monkeypatch, tmp_path):
-    file = pathlib.Path("/opt/xilinx/xrt/version.json")
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+    file = pathlib.Path("/path/to/xrt/version.json")
     file.parent.mkdir(parents=True, exist_ok=True)
     with file.open( 'w') as f:
         f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
     import pynq.pl_server.xrt_device
     xrt = importlib.reload(pynq._3rdparty.xrt)
     xrt_device = importlib.reload(pynq.pl_server.xrt_device)
@@ -86,10 +88,10 @@ def test_xrt_version_embedded(monkeypatch, tmp_path):
 
 
 def test_xrt_version_fail_x86(monkeypatch, tmp_path):
-    file = "/opt/xilinx/xrt/version.json"
-    if os.path.isfile(file):
-        os.remove(file)
+    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt2')
     import pynq.pl_server.xrt_device
+    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
     with pytest.warns(UserWarning, match='Unable to determine XRT version'):
         xrt = importlib.reload(pynq._3rdparty.xrt)
         xrt_device = importlib.reload(pynq.pl_server.xrt_device)

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -69,8 +69,8 @@ def test_xrt_normal(monkeypatch, recwarn):
 
 
 def test_xrt_version_x86(monkeypatch, tmp_path):
-    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
-    file = pathlib.Path("/path/to/xrt/version.json")
+    monkeypatch.setenv('XILINX_XRT', '/opt/xilinx/xrt')
+    file = pathlib.Path("/opt/xilinx/xrt/version.json")
     file.parent.mkdir(parents=True, exist_ok=True)
     os.chmod('/path/to/xrt', 0o666)
     with file.open( 'w') as f:

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -70,9 +70,9 @@ def test_xrt_normal(monkeypatch, recwarn):
 
 def test_xrt_version_x86(monkeypatch, tmp_path):
     monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
-    os.chmod('/path/to/xrt', 0o666)
     file = pathlib.Path("/path/to/xrt/version.json")
     file.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod('/path/to/xrt', 0o666)
     with file.open( 'w') as f:
         f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -72,7 +72,6 @@ def test_xrt_version_x86(monkeypatch, tmp_path):
     monkeypatch.setenv('XILINX_XRT', '/opt/xilinx/xrt')
     file = pathlib.Path("/opt/xilinx/xrt/version.json")
     file.parent.mkdir(parents=True, exist_ok=True)
-    os.chmod('/path/to/xrt', 0o666)
     with file.open( 'w') as f:
         f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -77,7 +77,7 @@ def test_xrt_version_x86(monkeypatch, tmp_path):
     import pynq.pl_server.xrt_device
     xrt = importlib.reload(pynq._3rdparty.xrt)
     xrt_device = importlib.reload(pynq.pl_server.xrt_device)
-    assert xrt_device._xrt_version == (2, 12, 447)
+    assert xrt_device._get_xrt_version_x86() == (2, 12, 447)
 
 
 def test_xrt_version_embedded(monkeypatch, tmp_path):

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -1,8 +1,13 @@
+# Copyright (C) 2022 Xilinx, Inc
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import importlib
-import pynq._3rdparty.xrt
-import pytest
 import ctypes
 import os
+import pathlib
+import pynq._3rdparty.xrt
+import pytest
 
 class FakeXrt:
     def __init__(self, path):
@@ -63,48 +68,41 @@ def test_xrt_normal(monkeypatch, recwarn):
     assert len(recwarn) == 0
 
 
-def test_xrt_version(monkeypatch, tmp_path):
-    with open(tmp_path / 'xbutil', 'w') as f:
-        f.write("""#!/bin/bash
-echo '{"runtime": {"build": {"version": "2.5.3"}}}'
-""")
-    os.chmod(tmp_path / 'xbutil', 0o777)
-    monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
-    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
+def test_xrt_version_x86(monkeypatch, tmp_path):
+    file = pathlib.Path("/opt/xilinx/xrt/version.json")
+    file.parent.mkdir(parents=True, exist_ok=True)
+    with file.open( 'w') as f:
+        f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
-    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
     import pynq.pl_server.xrt_device
     xrt = importlib.reload(pynq._3rdparty.xrt)
     xrt_device = importlib.reload(pynq.pl_server.xrt_device)
-    assert xrt_device._xrt_version == (2, 5, 3)
+    assert xrt_device._xrt_version == (2, 12, 447)
 
 
-def test_xrt_version_fail(monkeypatch, tmp_path):
-    with open(tmp_path / 'xbutil', 'w') as f:
-        f.write("""#!/bin/bash
-exit 1
-""")
-    os.chmod(tmp_path / 'xbutil', 0o777)
-    monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
-    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt')
-    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
-    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+def test_xrt_version_embedded(monkeypatch, tmp_path):
+    """To implement this test"""
+    pass
+
+
+def test_xrt_version_fail_x86(monkeypatch, tmp_path):
+    file = "/opt/xilinx/xrt/version.json"
+    if os.path.isfile(file):
+        os.remove(file)
     import pynq.pl_server.xrt_device
-    with pytest.warns(UserWarning, match='xbutil failed to run'):
+    with pytest.warns(UserWarning, match='Unable to determine XRT version'):
         xrt = importlib.reload(pynq._3rdparty.xrt)
         xrt_device = importlib.reload(pynq.pl_server.xrt_device)
     assert xrt_device._xrt_version == (0, 0, 0)
 
 
 def test_xrt_version_unsupported(monkeypatch, tmp_path):
-    with open(tmp_path / 'xbutil', 'w') as f:
-        f.write("""#!/bin/bash
-echo '{"runtime": {"build": {"version": "2.5.3"}}}'
-""")
-    os.chmod(tmp_path / 'xbutil', 0o777)
+    file = pathlib.Path("/opt/xilinx/xrt/version.json")
+    file.parent.mkdir(parents=True, exist_ok=True)
+    with file.open( 'w') as f:
+        f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
     monkeypatch.delenv('XILINX_XRT', raising=False)
-    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
     import pynq.pl_server.xrt_device
     xrt = importlib.reload(pynq._3rdparty.xrt)
     xrt_device = importlib.reload(pynq.pl_server.xrt_device)

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -69,10 +69,8 @@ def test_xrt_normal(monkeypatch, recwarn):
 
 
 def test_xrt_version_x86(monkeypatch, tmp_path):
-    monkeypatch.setenv('XILINX_XRT', '/opt/xilinx/xrt')
-    file = pathlib.Path("/opt/xilinx/xrt/version.json")
-    file.parent.mkdir(parents=True, exist_ok=True)
-    with file.open( 'w') as f:
+    monkeypatch.setenv('XILINX_XRT', str(tmp_path))
+    with open(tmp_path / 'version.json', 'w') as f:
         f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
     monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
@@ -99,9 +97,8 @@ def test_xrt_version_fail_x86(monkeypatch, tmp_path):
 
 
 def test_xrt_version_unsupported(monkeypatch, tmp_path):
-    file = pathlib.Path("/opt/xilinx/xrt/version.json")
-    file.parent.mkdir(parents=True, exist_ok=True)
-    with file.open( 'w') as f:
+    monkeypatch.setenv('XILINX_XRT', str(tmp_path))
+    with open(tmp_path / 'version.json', 'w') as f:
         f.write("""{\n  "BUILD_VERSION" : "2.12.447"\n}\n\n""")
     monkeypatch.setenv('PATH', str(tmp_path) + ':' + os.environ['PATH'])
     monkeypatch.delenv('XILINX_XRT', raising=False)

--- a/tests/test_xrt.py
+++ b/tests/test_xrt.py
@@ -81,12 +81,18 @@ def test_xrt_version_x86(monkeypatch, tmp_path):
 
 
 def test_xrt_version_embedded(monkeypatch, tmp_path):
-    """To implement this test"""
-    pass
+    with open(tmp_path / 'version', 'w') as f:
+        f.write("""2.12.447\n""")
+    monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
+    monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)
+    import pynq.pl_server.xrt_device
+    xrt = importlib.reload(pynq._3rdparty.xrt)
+    xrt_device = importlib.reload(pynq.pl_server.xrt_device)
+    assert xrt_device._get_xrt_version_embedded(str(tmp_path)) == (2, 12, 447)
 
 
 def test_xrt_version_fail_x86(monkeypatch, tmp_path):
-    monkeypatch.setenv('XILINX_XRT', '/path/to/xrt2')
+    monkeypatch.setenv('XILINX_XRT', str(tmp_path))
     import pynq.pl_server.xrt_device
     monkeypatch.delenv('XCL_EMULATION_MODE', raising=False)
     monkeypatch.setattr(ctypes, 'CDLL', FakeXrt)


### PR DESCRIPTION
Instead of running `xbutil` use the already present files in the system to get the XRT version. This seems to be a cleaner way of doing this.

This solves interoperability with XRT > 2.12

Fix #1344 