### PR TITLE
Assign partial dictionary directly.

### DIFF
--- a/pynq/pl_server/server.py
+++ b/pynq/pl_server/server.py
@@ -348,20 +348,7 @@ class DeviceClient:
             for k, v in parser.ip_dict.items():
                 parent = '/'.join(k.split('/')[:-1]) + '/' + v['mem_id']
                 if parent in self._ip_dict:
-                    ip_name = v['fullpath']
-                    merged_ip_dict[ip_name] = dict()
-                    merged_ip_dict[ip_name]['fullpath'] = v['fullpath']
-                    merged_ip_dict[ip_name]['parameters'] = v['parameters']
-                    merged_ip_dict[ip_name]['phys_addr'] = \
-                        self._ip_dict[parent]['phys_addr'] + v['phys_addr']
-                    merged_ip_dict[ip_name]['addr_range'] = v['addr_range']
-                    merged_ip_dict[ip_name]['registers'] = v['registers']
-                    merged_ip_dict[ip_name]['state'] = None
-                    merged_ip_dict[ip_name]['type'] = v['type']
-                    merged_ip_dict[ip_name]['gpio'] = {}
-                    merged_ip_dict[ip_name]['interrupts'] = {}
-                    merged_ip_dict[ip_name]['mem_id'] = v['mem_id']
-
+                    merged_ip_dict[v['fullpath']] = v
         else:
             raise ValueError("Cannot find HWH PR region parser.")
         self._ip_dict = merged_ip_dict

--- a/pynq/pl_server/server.py
+++ b/pynq/pl_server/server.py
@@ -342,13 +342,10 @@ class DeviceClient:
         merged_ip_dict = deepcopy(self._ip_dict)
         if type(parser) is HWH:
             for k in merged_ip_dict.copy():
-                if k.startswith(hier) and 's_axi_control' not in k:
+                if k.startswith(hier):
                     merged_ip_dict.pop(k)
-
             for k, v in parser.ip_dict.items():
-                parent = '/'.join(k.split('/')[:-1]) + '/' + v['mem_id']
-                if parent in self._ip_dict:
-                    merged_ip_dict[v['fullpath']] = v
+                merged_ip_dict[v['fullpath']] = v
         else:
             raise ValueError("Cannot find HWH PR region parser.")
         self._ip_dict = merged_ip_dict


### PR DESCRIPTION
- Assign partial dictionary directly.
- There is a bug in the way phys_addr was treated. The partial HWH provides the absolute offset address not the relative offset address in respect to the partial region apertures 