### PR TITLE
Deprecating execute_bo_with_waitlist for XRT >=2.11.

### DIFF
--- a/docs/source/getting_started/pynq_alveo.rst
+++ b/docs/source/getting_started/pynq_alveo.rst
@@ -111,23 +111,6 @@ method. The overlay will be freed automatically when a new ``Overlay`` object
 is created in the same process (i.e. Python session) as the currently-loaded 
 overlay. All resources will be freed automatically when the process exits.
 
-Efficient Scheduling of Multiple Kernels
-----------------------------------------
-
-If PYNQ is running on XRT version ``2.3`` or later then ``start`` and ``call`` 
-have an optional keyword parameter ``waitfor`` that can be used to create a
-dependency graph which is executed in the hardware. This frees the CPU from
-scheduling the execution of the accelerators and drastically decreases the time
-between accelerator invocations. The ``waitfor`` is a list of wait handles
-returned by previous executions that must have completed prior to this task
-being scheduled.  As an example consider the following snippet that chains two
-calls to a vector addition accelerator to compute the sum of three arrays.
-
-.. code:: python
-
-    handle = ol.vadd_1.start(input1, input2, output)
-    ol.vadd_1.call(input3, output, output, waitfor=(handle,))
-
 Kernel Streams
 --------------
 

--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -593,6 +593,9 @@ class XrtDevice(Device):
         return wh
 
     def execute_bo_with_waitlist(self, bo, waitlist):
+        if _xrt_version >= (2, 11, 0):
+            raise RuntimeError("waitfor list to schedule dependent executions "
+                "is not supported by XRT anymore.")
         wait_array = (ctypes.c_uint * len(waitlist))()
         for i in range(len(waitlist)):
             wait_array[i] = waitlist[i].bo


### PR DESCRIPTION
Raise a RuntimeError exception when ``execute_bo_with_waitlist`` is called,
this method depends on ``xclExecBufWithWaitList`` which is deprecated
since XRT >= 2.11

Fix Xilinx/PYNQ-DEV#358