### PR TITLE
Allow partial bitstream not to be downloaded, so metadata is populated

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -450,7 +450,6 @@ class Overlay(Bitstream):
             Whether the overlay should be downloaded.
 
         """
-        self.device.reset(self.parser)
         pr_block = self.__getattr__(partial_region)
         pr_block.download(bitfile_name=partial_bit, dtbo=dtbo, program=program)
 

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -423,7 +423,7 @@ class Overlay(Bitstream):
         elif self.dtbo:
             super().insert_dtbo()
 
-    def pr_download(self, partial_region, partial_bit, dtbo=None):
+    def pr_download(self, partial_region, partial_bit, dtbo=None, program=True):
         """The method to download a partial bitstream onto PL.
 
         In this method, the corresponding parser will only be
@@ -446,10 +446,13 @@ class Overlay(Bitstream):
             The name of the partial bitstream.
         dtbo : str
             The path of the dtbo file.
+        program : bool
+            Whether the overlay should be downloaded.
 
         """
+        self.device.reset(self.parser)
         pr_block = self.__getattr__(partial_region)
-        pr_block.download(bitfile_name=partial_bit, dtbo=dtbo)
+        pr_block.download(bitfile_name=partial_bit, dtbo=dtbo, program=program)
 
     def is_loaded(self):
         """This method checks whether a bitstream is loaded.
@@ -1011,7 +1014,7 @@ class DefaultHierarchy(_IPMap, metaclass=RegisterHierarchy):
         """
         return False
 
-    def download(self, bitfile_name, dtbo=None):
+    def download(self, bitfile_name, dtbo=None, program=True):
         """Function to download a partial bitstream for the hierarchy block.
 
         Since it is hard to know which hierarchy is to be reconfigured by only
@@ -1025,13 +1028,15 @@ class DefaultHierarchy(_IPMap, metaclass=RegisterHierarchy):
             The name of the partial bitstream.
         dtbo : str
             The relative or absolute path of the partial dtbo file.
+        program : bool
+            Whether the overlay should be downloaded.
 
         """
         if self.pr_loaded:
             self._find_bitstream_by_abs(self.pr_loaded).remove_dtbo()
         self._locate_metadata(bitfile_name, dtbo)
         self._parse(bitfile_name)
-        self._load_bitstream(bitfile_name)
+        self._load_bitstream(bitfile_name, program)
         if dtbo:
             self.bitstreams[bitfile_name].insert_dtbo()
 
@@ -1083,6 +1088,7 @@ class DefaultHierarchy(_IPMap, metaclass=RegisterHierarchy):
             if s is not None and p is not None
         }
 
-    def _load_bitstream(self, bitfile_name):
-        self.bitstreams[bitfile_name].download()
+    def _load_bitstream(self, bitfile_name, program):
+        if program:
+            self.bitstreams[bitfile_name].download()
         self.pr_loaded = self.bitstreams[bitfile_name].bitfile_name


### PR DESCRIPTION
Add new parameter `program` to the partial bitstream method, this allow users to load the metadata of a partial region without actually downloading the bitstream. This mimics the `download` parameter in the `Overlay` class. 