### PR TITLE
check to see if y2k22 patch exists

### DIFF
--- a/boards/ip/hls/build_ip.sh
+++ b/boards/ip/hls/build_ip.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# check if y2k22 patch has been applied
+if [ ! -f $XILINX_HLS/common/scripts/automg_patch_20220104.tcl ]; then
+	echo "Please make sure you have applied the y2k22 patch to your installation"
+	echo "https://support.xilinx.com/s/article/76960?language=en_US"
+fi
+
 for f in */script.tcl
 do
   vitis_hls -f $f


### PR DESCRIPTION
Base overlay builds fail for people if you don't have the y2k22 patch applied. We can add a check to see if the patch script exists in their installation, and, if it doesn't, raise a warning. This won't be necessary in future releases with newer Vivado/Vitis versions.