### PR TITLE
Add driver and Python-based XVC server for Debug Bridge

### DIFF
--- a/docs/source/pynq_libraries.rst
+++ b/docs/source/pynq_libraries.rst
@@ -65,6 +65,7 @@ Supported IP
     pynq_libraries/audio.rst
     pynq_libraries/axigpio.rst
     pynq_libraries/axiiic.rst
+    pynq_libraries/debugbridge.rst
     pynq_libraries/dma.rst
     pynq_libraries/logictools.rst
     pynq_libraries/video.rst

--- a/docs/source/pynq_libraries/debugbridge.rst
+++ b/docs/source/pynq_libraries/debugbridge.rst
@@ -1,0 +1,61 @@
+.. _pynq-libraries-debugbridge:
+
+DebugBridge
+===========
+
+The *DebugBridge* class provides register descriptor and 
+a *Xilinx Virtual Cable* (XVC) server on Debug Bridge IP 
+in *AXI to BSCAN* and *AXI to JTAG* configurations.
+
+The XVC server in this class bridges between Vivado hardware 
+servers and the Debug Hub through Ethernet. Vivado then will 
+operate the Debug Bridge as a virtual JTAG adapter.
+
+When instantiating a Debug Bridge IP in the overlay
+in *AXI to BSCAN* configuration, the debug hub for debugging
+IPs will be connected to the Debug Bridge by default. 
+Under this configuration, the XVC connection enables conventional 
+debugging IPs, including ILAs and VIOs, to work with overlays.
+The XVC connection also allows remote debugging without physically 
+attaching a JTAG adapter.
+
+Another use case is to control a Debug Bridge IP in *AXI to JTAG* 
+configuration. In this config, the Debug Bridge runs as 
+a remote JTAG adapter for another Xilinx FPGA with its JTAG pins
+connected to the Debug Bridge in the PYNQ host.
+
+This class provides a Python implementation of the XVC server v1.0 
+for ease of use and integration with PYNQ overlays. More details about
+XVC could be found in the `Product Page <https://www.xilinx.com/products/intellectual-property/xvc.html>`_ 
+and the `Official Wiki <https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/644579329/Xilinx+Virtual+Cable>`_.
+
+Use ``start_xvc_server()`` and ``stop_xvc_server()`` methods to setup and kill the XVC server.
+
+.. code-block:: Python
+
+    start_xvc_server(bufferLen=4096, serverAddress="0.0.0.0",
+                     serverPort=2542, reconnect=True, verbose=True)
+
+Create and start an XVC server listening to the specified address and port.
+The server will be running in a separate thread.
+Each Debug Bridge allows one and only one hardware server to connect at once.
+
+* ``bufferLen`` is the length of data buffer for XVC shift commands in bytes
+* ``serverAddress`` is the address the XVC server listens to
+* ``serverPort`` is the port the XVC server listens to
+* ``reconnect`` when True allows listening to the next connection when the previous one is disconnected
+* ``verbose`` when True prints the connection status of the XVC server
+
+.. code-block:: Python
+
+    stop_xvc_server()
+
+Stop the XVC server and break active connections.
+
+.. warning::
+    Stop the XVC server with ``stop_xvc_server()`` before 
+    downloading any overlay.
+    
+    The XVC server cannot detect overlay replacement. Downloading 
+    another overlay with an XVC server running will cause access to an
+    uninitialized PL, eventually halt the PS.

--- a/pynq/lib/__init__.py
+++ b/pynq/lib/__init__.py
@@ -40,6 +40,7 @@ from .button import Button
 from .iic import AxiIIC
 from .wifi import Wifi
 from .cmac import CMAC
+from .debugbridge import DebugBridge
 
 from .rpi import Rpi
 

--- a/pynq/lib/debugbridge.py
+++ b/pynq/lib/debugbridge.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from pynq import DefaultIP
+from threading import Thread, Event
+from struct import Struct
+import socket
+
+
+class _DebugBridgeXVCServerThread(Thread):
+    def __init__(self, dbridge, bufferLen=4096, serverAddress="0.0.0.0",
+                 serverPort=2542, reconnect=True, verbose=True):
+        Thread.__init__(self)
+
+        self.dbridge = dbridge
+        self.bufferLen = 4096
+
+        self.dbridge = dbridge
+        self.dbrf = self.dbridge.register_map
+        self.mmio = self.dbridge.mmio
+
+        # Bufflen in number of bytes
+        self.xvcInfo = bytes(f"xvcServer_v1.0:{self.bufferLen}\n", 'UTF-8')
+        self.tckval = 0
+
+        self.serverAddress = serverAddress
+        self.serverPort = serverPort
+        self.reconnect = reconnect
+        self.clientAddress = None
+        self.clientSocket = None
+
+        self._stopevent = Event()
+
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        self.verbose = verbose
+
+    def _xvcServer(self):
+        wordstruct = Struct('<L')
+
+        def _sock_recvall(size):
+            return self.clientSocket.recv(size, socket.MSG_WAITALL)
+
+        def _sock_recvall_into(buf, size):
+            return self.clientSocket.recv_into(buf, size, socket.MSG_WAITALL)
+
+        def _sock_send(buf):
+            return self.clientSocket.send(buf)
+
+        def _word_unpack(buf):
+            return wordstruct.unpack(buf)[0]
+
+        # Use fixed buffer to reduce overhead
+        tmsVec = bytearray(self.bufferLen)
+        tmsView = memoryview(tmsVec)
+        tdiVec = bytearray(self.bufferLen)
+        tdiView = memoryview(tdiVec)
+        tdoVec = bytearray(self.bufferLen)
+        tdoView = memoryview(tdoVec)
+
+        while not self._stopevent.isSet():
+            msg = _sock_recvall(2).decode()
+
+            if msg == 'ge':  # 'getinfo:'
+                _sock_recvall(6)
+                _sock_send(self.xvcInfo)
+            elif msg == 'se':  # 'settck:<tck period>
+                _sock_recvall(5)
+                newtck = _sock_recvall(4)
+                self.tckval = _word_unpack(newtck)
+                _sock_send(newtck)
+            elif msg == 'sh':  # 'shift:<num bits><tms vector><tdi vector>
+                _sock_recvall(4)
+                # Get required bit and word count
+                numbits = _word_unpack(_sock_recvall(4))
+                numbytes = (numbits + 7) // 8
+                numwords = (numbytes + 3) // 4
+                numpackbytes = numwords * 4
+                # Receive data to be transmitted
+                _sock_recvall_into(tmsVec, numbytes)
+                _sock_recvall_into(tdiVec, numbytes)
+
+                # Set default shift length
+                # self.dbrf.LENGTH = 32
+                self.mmio.write(0x00, 32)
+
+                for i, ((tms,), (tdi,)) in enumerate(
+                    zip(wordstruct.iter_unpack(tmsView[:numpackbytes]),
+                        wordstruct.iter_unpack(tdiView[:numpackbytes]))
+                ):
+                    if i + 1 == numwords:
+                        # Set final shift length
+                        # self.dbrf.LENGTH = numbits % 32
+                        self.mmio.write(0x00, numbits % 32)
+
+                    # Write data
+                    # MSBs of the last word won't be shifted
+                    # self.dbrf.TMS_VECTOR = tms
+                    self.mmio.write(0x04, tms)
+                    # self.dbrf.TDI_VECTOR = tdi
+                    self.mmio.write(0x08, tdi)
+
+                    # Set enable
+                    # self.dbrf.CTRL = 1
+                    self.mmio.write(0x10, 0x01)
+
+                    # Wait for finish
+                    # while int(self.dbrf.CTRL) != 0:
+                    while self.mmio.read(0x10) != 0:
+                        pass
+
+                    # Read and pack
+                    # wordstruct.pack_into(tdoVec, i<<2,
+                    #                       int(self.dbrf.TDO_VECTOR) )
+                    wordstruct.pack_into(tdoVec, i << 2, self.mmio.read(0x0C))
+
+                # Transmit result
+                _sock_send(tdoView[:numbytes])
+            elif not msg:
+                break
+            else:
+                print(f"XVC Invalid cmd {msg}")
+                break
+
+    def run(self):
+        self.server.bind((self.serverAddress, self.serverPort))
+        if self.verbose:
+            print("XVC server started")
+
+        while not self._stopevent.isSet():
+            self.server.listen(0)
+            self.clientSocket, self.clientAddress = self.server.accept()
+
+            if self._stopevent.isSet():
+                break
+
+            try:
+                if self.verbose:
+                    print(f"Connection from : {self.clientAddress}")
+                self._xvcServer()
+            except ConnectionResetError:
+                if self.verbose:
+                    print(f"Client at {self.clientAddress} "
+                          "disconnected by exception...")
+            except OSError:
+                if self.verbose:
+                    print(f"Client at {self.clientAddress} "
+                          "disconnected by stop...")
+            else:
+                if self.verbose:
+                    print(f"Client at {self.clientAddress} "
+                          "disconnected...")
+            finally:
+                self.clientSocket.close()
+                self.clientSocket = None
+
+            if not self.reconnect:
+                break
+
+        self.server.close()
+        if self.verbose:
+            print("XVC server stopped")
+
+    def stop(self, timeout=None):
+        self._stopevent.set()
+        if not self.clientSocket is None:
+            self.clientSocket.close()
+        else:
+            # Workaround to stop a listening socket
+            try:
+                ubSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                ubSocket.setblocking(False)
+                ubSocket.connect((self.serverAddress, self.serverPort))
+            except:
+                pass
+        Thread.join(self, timeout)
+
+
+class DebugBridge(DefaultIP):
+    """Class for Interacting with the Debug Bridge in AXI -
+    BSCAN and AXI - JTAG mode.
+
+    Including a Python-based Xilinx Virtual Cable server for
+    remote debugging with on-chip debuggers incuding ILAs and
+    VIOs, or use the AXI - JTAG mode to debug another Xilinx
+    device.
+
+    The server could be controlled through `start_xvc_server`
+    and `stop_xvc_server` methods.
+
+    Note
+    ----
+    
+    The server needs to be manually stopped before loading
+    another overlay or the PS might halt.
+
+    """
+
+    def __init__(self, description, *args, **kwargs):
+        """Create an instance of the Debug Bridge Driver.
+        Parameters
+        ----------
+        description : dict
+            The entry in the IP dict describing the DMA engine
+        """
+        if type(description) is not dict or args or kwargs:
+            raise RuntimeError('Description is not valid', str(description))
+
+        # Insert register dict as they are not provided in the IP descriptor
+        description['registers']['LENGTH'] = {
+            'access': 'read-write',
+            'address_offset': 0x00,
+            'description': 'Shift Bit Length Register',
+            'fields': {
+                'length': {
+                    'access': 'read-write',
+                    'bit_offset': 0,
+                    'bit_width': 6,
+                    'description': 'Shift Bit Length Register'
+                }
+            },
+            'size': 32
+        }
+        description['registers']['TMS_VECTOR'] = {
+            'access': 'read-write',
+            'address_offset': 0x04,
+            'description': 'Test Mode Select (TMS) Bit Vector',
+            'fields': {
+                'tms': {
+                    'access': 'read-write',
+                    'bit_offset': 0,
+                    'bit_width': 32,
+                    'description': 'Test Mode Select (TMS) Bit Vector'
+                }
+            },
+            'size': 32
+        }
+        description['registers']['TDI_VECTOR'] = {
+            'access': 'read-write',
+            'address_offset': 0x08,
+            'description': 'Test Data In (TDI) Bit Vector',
+            'fields': {
+                'tdi': {
+                    'access': 'read-write',
+                    'bit_offset': 0,
+                    'bit_width': 32,
+                    'description': 'Test Data In (TDI) Bit Vector'
+                }
+            },
+            'size': 32
+        }
+        description['registers']['TDO_VECTOR'] = {
+            'access': 'read',
+            'address_offset': 0x0C,
+            'description': 'Test Data Out (TDO) Bit Vector',
+            'fields': {
+                'tdo': {
+                    'access': 'read',
+                    'bit_offset': 0,
+                    'bit_width': 32,
+                    'description': 'Test Data Out (TDO) Bit Vector'
+                }
+            },
+            'size': 32
+        }
+        description['registers']['CTRL'] = {
+            'access': 'read-write',
+            'address_offset': 0x10,
+            'description': 'Shift Control Register',
+            'fields': {
+                'en': {
+                    'access': 'read-write',
+                    'bit_offset': 0,
+                    'bit_width': 1,
+                    'description': 'Enable shift operation'
+                },
+                'loopback': {
+                    'access': 'read-write',
+                    'bit_offset': 1,
+                    'bit_width': 1,
+                    'description': 'Control bit to loopback TDI to TDO '
+                                   'inside Debug Bridge IP'
+                }
+            },
+            'size': 32
+        }
+
+        super().__init__(description=description)
+        self.description = description
+
+        if 'parameters' not in description:
+            raise RuntimeError('Unable to get parameters from description; '
+                               'Users must use *.hwh files for overlays.')
+
+        self.serverThread = None
+
+    bindto = ['xilinx.com:ip:debug_bridge:3.0']
+
+    def start_xvc_server(self, bufferLen=4096, serverAddress="0.0.0.0",
+                         serverPort=2542, reconnect=True, verbose=True):
+        """Start a XVC server and listen to the specified address and
+        port for Vivado HW server to connect.
+
+        Parameters
+        ----------
+        bufferLen: int
+            The length of the buffer for XVC shift
+            command in bytes
+
+        serverAddress : str
+            The address the XVC server listens to
+
+        serverPort : int
+            The port the XVC server listens to
+
+        reconnect : bool
+            If True, listen to the next connection when the
+            previous client is disconnected or interrupted
+
+        verbose : bool
+            If True, print the conenction status
+            of the XVC server
+        """
+
+        if self.serverThread:
+            self.stop_xvc_server()
+
+        self.serverThread = _DebugBridgeXVCServerThread(
+            dbridge=self,
+            bufferLen=bufferLen,
+            serverAddress=serverAddress,
+            serverPort=serverPort,
+            reconnect=reconnect,
+            verbose=verbose
+        )
+        self.serverThread.start()
+
+    def stop_xvc_server(self):
+        """Stop the running XVC server and disconnect active client.
+        """
+        self.serverThread.stop()
+        self.serverThread = None
+
+    def __del__(self):
+        if self.serverThread:
+            self.stop_xvc_server()


### PR DESCRIPTION
Hello! I have found that debugging with ILAs and VIOs are still quite handy for developing overlays, so I ported the XVC server in XAPP1251 to the PYNQ library for an easy access to the debuggers through a Debug Bridge in AXI to BSCAN config.

I have tested it with a Zynq-7000 devboard with USB RNDIS connection. It could achieve a reasonable speed for simple debugging with >500Kb on the network interface, at the cost of one core maxed out for polling during transmissions.