### PR TITLE
MMIO enhancements to support read and write using different datatype

### DIFF
--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -129,12 +129,12 @@ class MMIO:
         idx = offset >> 2
 
         dtype = kwargs.get('dtype')
-        lsb = int(array[idx])
+        lsb = int(self.array[idx])
         if dtype in [np.int8, np.uint8, np.int16, np.uint16, np.uint32,
                      np.int32, int]:
             lsb = dtype(lsb)
         elif dtype in [np.int64, np.uint64]:
-            msb = int(array[idx + 1])
+            msb = int(self.array[idx + 1])
             lsb = dtype((msb << 32) + lsb)
         elif dtype in [np.float32, float]:
             lsb = dtype(struct.unpack('!f', lsb.to_bytes(4, 'big'))[0])

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -39,25 +39,25 @@ __copyright__ = "Copyright 2022, Xilinx"
 __email__ = "pynq_support@xilinx.com"
 
 
-def _array_to_value(array, idx, datatype):
+def _array_to_value(array, idx, dtype):
     lsb = int(array[idx])
-    if datatype==np.uint32 or datatype == np.int32 or datatype==int:
-        return datatype(lsb)
-    elif datatype == np.int8 or datatype == np.uint8:
-        return datatype(lsb & 0xFF)
-    elif datatype == np.int16 or datatype == np.uint16:
-        return datatype(lsb & 0xFFFF)
-    elif datatype == np.int64 or datatype == np.uint64:
+    if dtype==np.uint32 or dtype == np.int32 or dtype==int:
+        return dtype(lsb)
+    elif dtype == np.int8 or dtype == np.uint8:
+        return dtype(lsb & 0xFF)
+    elif dtype == np.int16 or dtype == np.uint16:
+        return dtype(lsb & 0xFFFF)
+    elif dtype == np.int64 or dtype == np.uint64:
         msb = int(array[idx + 1])
-        return datatype((msb << 32) + lsb)
-    elif datatype == float or datatype == np.float32:
-        return datatype(struct.unpack('!f', lsb.to_bytes(4, 'big'))[0])
-    elif datatype == np.float16:
+        return dtype((msb << 32) + lsb)
+    elif dtype == float or dtype == np.float32:
+        return dtype(struct.unpack('!f', lsb.to_bytes(4, 'big'))[0])
+    elif dtype == np.float16:
         lsb = lsb & 0xFFFF
         y = struct.pack("H", lsb)
-        return datatype((np.frombuffer(y, dtype=np.float16)[0]))
-    elif datatype == np.float128 or datatype == np.float64:
-            warnings.warn("datatype \'{}\' is not supported".format(datatype))
+        return dtype((np.frombuffer(y, dtype=np.float16)[0]))
+    elif dtype == np.float128 or dtype == np.float64:
+            warnings.warn("dtype \'{}\' is not supported".format(dtype))
     return lsb
 
 
@@ -152,7 +152,7 @@ class MMIO:
             raise MemoryError('Unaligned read: offset must be multiple of 4.')
         idx = offset >> 2
 
-        return _array_to_value(self.array, idx, kwargs.get('datatype'))
+        return _array_to_value(self.array, idx, kwargs.get('dtype'))
 
     def write(self, offset, data):
         """The method to write data to MMIO.

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -118,9 +118,11 @@ class MMIO:
         """
 
         if 'length' in kwargs:
-            warnings.warn("Keyword length has been deprecated.")
+            warnings.warn("Keyword length has been deprecated.",
+                          DeprecationWarning)
         if 'word_order' in kwargs:
-            warnings.warn("Keyword word_order has been deprecated.")
+            warnings.warn("Keyword word_order has been deprecated.",
+                          DeprecationWarning)
 
         if offset < 0:
             raise ValueError("Offset cannot be negative.")

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -57,7 +57,7 @@ def _array_to_value(array, idx, datatype):
         y = struct.pack("H", lsb)
         return datatype((np.frombuffer(y, dtype=np.float16)[0]))
     elif datatype == np.float128 or datatype == np.float64:
-            warnings.warn("datatype \'{}\' is not supported".format(datatypefl))
+            warnings.warn("datatype \'{}\' is not supported".format(datatype))
     return lsb
 
 

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -167,7 +167,7 @@ class MMIO:
 
         dtype = type(data)
         if dtype == int:
-            data = data.to_bytes()
+            data = data.to_bytes(4, 'little', signed=True)
         elif dtype in [np.int8, np.uint8, np.int16, np.uint16, np.uint32,
                        np.int32, int, np.int64, np.uint64]:
             data = data.tobytes()

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -184,9 +184,6 @@ class MMIO:
         else:
             length = len(data)
             num_words = length >> 2
-            if length % 4:
-                raise MemoryError(
-                    'Unaligned write: data length must be multiple of 4.')
             buf = np.frombuffer(data, np.uint32, num_words, 0)
             for i in range(len(buf)):
                 self.array[idx + i] = buf[i]

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -173,7 +173,7 @@ class MMIO:
             data = data.tobytes()
         elif dtype in [np.float32, float]:
             data = struct.pack('f', np.float32(data))
-        else:
+        elif dtype is not bytes:
             raise ValueError("dtype \'{}\' is not supported".format(dtype))
 
         if self.device.has_capability('REGISTER_RW'):

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -27,12 +27,10 @@
 #   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import mmap
-import warnings
 import numpy as np
 import pynq._3rdparty.tinynumpy as tnp
 import struct
+import warnings
 
 __author__ = "Yun Rock Qu, Mario Ruiz"
 __copyright__ = "Copyright 2022, Xilinx"

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -39,24 +39,16 @@ __email__ = "pynq_support@xilinx.com"
 
 def _array_to_value(array, idx, dtype):
     lsb = int(array[idx])
-    if dtype==np.uint32 or dtype == np.int32 or dtype==int:
+    if dtype in [np.int8, np.uint8, np.int16, np.uint16, np.uint32, np.int32,
+                 int]:
         return dtype(lsb)
-    elif dtype == np.int8 or dtype == np.uint8:
-        return dtype(lsb & 0xFF)
-    elif dtype == np.int16 or dtype == np.uint16:
-        return dtype(lsb & 0xFFFF)
-    elif dtype == np.int64 or dtype == np.uint64:
+    elif dtype in [np.int64, np.uint64]:
         msb = int(array[idx + 1])
         return dtype((msb << 32) + lsb)
-    elif dtype == float or dtype == np.float32:
+    elif dtype in [np.float32, float]:
         return dtype(struct.unpack('!f', lsb.to_bytes(4, 'big'))[0])
-    elif dtype == np.float16:
-        lsb = lsb & 0xFFFF
-        y = struct.pack("H", lsb)
-        return dtype((np.frombuffer(y, dtype=np.float16)[0]))
-    elif dtype == np.float128 or dtype == np.float64:
-            warnings.warn("dtype \'{}\' is not supported".format(dtype))
-    return lsb
+    else:
+        raise ValueError("dtype \'{}\' is not supported".format(dtype))
 
 
 class _AccessHook:

--- a/pynq/mmio.py
+++ b/pynq/mmio.py
@@ -136,8 +136,8 @@ class MMIO:
                      np.int32, int]:
             lsb = dtype(lsb)
         elif dtype in [np.int64, np.uint64]:
-            msb = int(self.array[idx + 1])
-            lsb = dtype((msb << 32) + lsb)
+            msb = np.uint64(np.uint64(self.array[idx + 1]) * 2**32)
+            lsb = dtype(msb + np.uint64(lsb))
         elif dtype in [np.float32, float]:
             lsb = dtype(struct.unpack('!f', lsb.to_bytes(4, 'big'))[0])
         elif dtype:
@@ -170,9 +170,10 @@ class MMIO:
         dtype = type(data)
         if dtype == int:
             data = data.to_bytes(4, 'little', signed=True)
-        elif dtype in [np.int8, np.uint8, np.int16, np.uint16, np.uint32,
-                       np.int32, int, np.int64, np.uint64]:
+        elif dtype in [np.uint32, np.int32, int, np.int64, np.uint64]:
             data = data.tobytes()
+        elif dtype in [np.int8, np.uint8, np.int16, np.uint16]:
+            data = np.int32(data).tobytes()
         elif dtype in [np.float32, float]:
             data = struct.pack('f', np.float32(data))
         elif dtype is not bytes:

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -828,7 +828,7 @@ class DefaultIP(metaclass=RegisterIP):
         else:
             return self.device.execute_bo(bo)
 
-    def read(self, offset=0):
+    def read(self, offset=0, **kwargs):
         """Read from the MMIO device
 
         Parameters
@@ -837,7 +837,7 @@ class DefaultIP(metaclass=RegisterIP):
             Address to read
 
         """
-        return self.mmio.read(offset)
+        return self.mmio.read(offset, **kwargs)
 
     def write(self, offset, value):
         """Write to the MMIO device

--- a/tests/test_mmio.py
+++ b/tests/test_mmio.py
@@ -24,12 +24,13 @@ TEST_READ_DATA = [
 ]
 
 TEST_DATA_NUMPY = [
-    (300, np.uint32(53970361), int(53970361).to_bytes(4, 'little')),
-    (256, -14921033, int(np.uint32(-14921033)).to_bytes(4, 'little')),
-    (248, np.uint16(12045), np.uint16(12045).tobytes()),
-    (260, np.int16(-12045), np.int16(-12045).tobytes()),
-    (260, np.uint8(248), np.uint8(248).tobytes()),
-    (200, np.int8(-99), np.int8(-99).tobytes()),
+    (300, int(53970361), int(53970361).to_bytes(4, 'little')),
+    (300, np.uint32(543394), np.uint32(543394).tobytes()),
+    (256, np.int32(-14921033), np.int32(-14921033).tobytes()),
+    (248, np.uint16(12045), np.int32(12045).tobytes()),
+    (260, np.int16(-12045), np.int32(-12045).tobytes()),
+    (260, np.uint8(248), np.int32(248).tobytes()),
+    (200, np.int8(-99), np.int32(-99).tobytes()),
     (260, np.uint64(4181616581), np.uint64(4181616581).tobytes()),
     (200, np.int64(-14103463169), np.int64(-14103463169).tobytes()),
 ]
@@ -152,6 +153,16 @@ def test_reg_write_numpy(transaction, register_device):
     mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
     with device.check_transactions([], [(BASE_ADDRESS+offset, bytesobj)]):
         mmio.write(offset, value)
+
+
+@pytest.mark.parametrize('transaction', TEST_DATA_NUMPY)
+def test_reg_read_numpy(transaction, mmap_device):
+    offset, value, bytesobj = transaction
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    mmio.write(offset, value)
+    read = mmio.read(offset, dtype=type(value))
+    assert value == read
 
 
 @pytest.mark.parametrize('transaction', TEST_DATA_FLOAT)

--- a/tests/test_mmio.py
+++ b/tests/test_mmio.py
@@ -129,22 +129,6 @@ def test_unaligned_offset_read(device):
         'Unaligned read: offset must be multiple of 4.'
 
 
-def test_unsupported_length_read(device):
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
-    with pytest.raises(ValueError) as excinfo:
-        mmio.read(4, 6)
-    assert str(excinfo.value) == \
-        "MMIO currently only supports 1, 2, 4 and 8-byte reads."
-
-
-def test_bad_endianness_read(device):
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
-    with pytest.raises(ValueError) as excinfo:
-        mmio.read(4, 8, 'middle')
-    assert str(excinfo.value) == \
-        "MMIO only supports big and little endian."
-
-
 def test_float_write(device):
     mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
     with pytest.raises(ValueError) as excinfo:
@@ -162,71 +146,6 @@ def test_oob_read(device):
     mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
     with pytest.raises(IndexError):
         mmio.read(ADDR_RANGE)
-
-
-def test_active_device_4byte_read(register_device):
-    device = register_device
-    pynq.Device.active_device = device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE)
-    testdata = struct.pack('I', 0x12345678)
-    with device.check_transactions([TEST_READ_DATA[0]], []):
-        read = mmio.read(4)
-    assert read == 0x12345678
-    assert mmio.device == device
-    pynq.Device.active_device = None
-
-
-def test_active_device_2byte_read(register_device):
-    device = register_device
-    pynq.Device.active_device = device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE)
-    with device.check_transactions([TEST_READ_DATA[0]], []):
-        read = mmio.read(4, 2)
-    assert read == 0x5678
-    assert mmio.device == device
-    pynq.Device.active_device = None
-
-
-def test_active_device_1byte_read(register_device):
-    device = register_device
-    pynq.Device.active_device = device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE)
-    with device.check_transactions([TEST_READ_DATA[0]], []):
-        read = mmio.read(4, 1)
-    assert read == 0x78
-    assert mmio.device == device
-    pynq.Device.active_device = None
-
-
-def test_8byte_littleendian_read(register_device):
-    device = register_device
-    pynq.Device.active_device = device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE)
-    with device.check_transactions(TEST_READ_DATA, []):
-        read = mmio.read(4, 8, 'little')
-    assert read == 0xbeefcafe12345678
-    assert mmio.device == device
-    pynq.Device.active_device = None
-
-
-def test_8byte_bigendian_read(register_device):
-    device = register_device
-    pynq.Device.active_device = device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE)
-    with device.check_transactions(TEST_READ_DATA, []):
-        read = mmio.read(4, 8, 'big')
-    assert read == 0x12345678beefcafe
-    assert mmio.device == device
-    pynq.Device.active_device = None
-
-
-def test_mmap_bad_length_write(mmap_device):
-    device = mmap_device
-    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
-    with pytest.raises(MemoryError) as excinfo:
-        mmio.write(4, bytes(range(6)))
-    assert str(excinfo.value) == \
-        "Unaligned write: data length must be multiple of 4."
 
 
 def test_deprecated_debug_keyword(mmap_device):

--- a/tests/test_mmio.py
+++ b/tests/test_mmio.py
@@ -1,7 +1,8 @@
-import warnings
-import struct
-import pytest
+import numpy as np
 import pynq
+import pytest
+import struct
+import warnings
 
 
 from .mock_devices import MockDeviceBase, MockRegisterDevice
@@ -22,6 +23,21 @@ TEST_READ_DATA = [
     (BASE_ADDRESS + 8, struct.pack('I', 0xbeefcafe))
 ]
 
+TEST_DATA_NUMPY = [
+    (300, np.uint32(53970361), int(53970361).to_bytes(4, 'little')),
+    (256, -14921033, int(np.uint32(-14921033)).to_bytes(4, 'little')),
+    (248, np.uint16(12045), np.uint16(12045).tobytes()),
+    (260, np.int16(-12045), np.int16(-12045).tobytes()),
+    (260, np.uint8(248), np.uint8(248).tobytes()),
+    (200, np.int8(-99), np.int8(-99).tobytes()),
+    (260, np.uint64(4181616581), np.uint64(4181616581).tobytes()),
+    (200, np.int64(-14103463169), np.int64(-14103463169).tobytes()),
+]
+
+TEST_DATA_FLOAT = [
+    (8, 98.576, int(0x42c526e9).to_bytes(4, 'little')),
+    (48, np.single(-32.587), int(0xc2025917).to_bytes(4, 'little'))
+]
 
 @pytest.fixture
 def register_device():
@@ -129,11 +145,40 @@ def test_unaligned_offset_read(device):
         'Unaligned read: offset must be multiple of 4.'
 
 
-def test_float_write(device):
+@pytest.mark.parametrize('transaction', TEST_DATA_NUMPY)
+def test_reg_write_numpy(transaction, register_device):
+    offset, value, bytesobj = transaction
+    device = register_device
     mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    with device.check_transactions([], [(BASE_ADDRESS+offset, bytesobj)]):
+        mmio.write(offset, value)
+
+
+@pytest.mark.parametrize('transaction', TEST_DATA_FLOAT)
+def test_reg_write_float(transaction, register_device):
+    offset, pyobj, bytesobj = transaction
+    device = register_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    with device.check_transactions([], [(BASE_ADDRESS+offset, bytesobj)]):
+        mmio.write(offset, pyobj)
+
+
+def test_reg_read_float(mmap_device):
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    offset, testdata = (956, np.float32(102.687))
+    mmio.write(offset, testdata)
+    read = mmio.read(offset, dtype=type(testdata))
+    assert np.isclose(read, testdata, rtol=1e-05, atol=1e-08, equal_nan=False)
+
+
+def test_reg_write_unsupported_type(mmap_device):
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    value = np.half(20.22)
     with pytest.raises(ValueError) as excinfo:
-        mmio.write(4, 8.5)
-    assert str(excinfo.value) == "Data type must be int or bytes."
+        mmio.write(4, value)
+    assert str(excinfo.value) == "dtype \'{}\' is not supported".format(type(value))
 
 
 def test_oob_write(device):
@@ -159,3 +204,27 @@ def test_deprecated_debug_keyword(mmap_device):
             'Warning is not of type DeprecationWarning'
         assert "debug" in str(w[-1].message), \
             'Warning not related to keyword debug'
+
+def test_deprecated_length_keyword(mmap_device):
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        read = mmio.read(4, length=1)
+        assert len(w) == 1, 'No warnings when providing keyword debug'
+        assert issubclass(w[-1].category, DeprecationWarning), \
+            'Warning is not of type DeprecationWarning'
+        assert "length" in str(w[-1].message), \
+            'Keyword length has been deprecated.'
+
+def test_deprecated_word_order_keyword(mmap_device):
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        read = mmio.read(4, word_order='little')
+        assert len(w) == 1, 'No warnings when providing keyword debug'
+        assert issubclass(w[-1].category, DeprecationWarning), \
+            'Warning is not of type DeprecationWarning'
+        assert "word_order" in str(w[-1].message), \
+            'Keyword word_order has been deprecated.'

--- a/tests/test_mmio.py
+++ b/tests/test_mmio.py
@@ -183,6 +183,15 @@ def test_reg_read_float(mmap_device):
     assert np.isclose(read, testdata, rtol=1e-05, atol=1e-08, equal_nan=False)
 
 
+def test_reg_read_unsopported_type(mmap_device):
+    device = mmap_device
+    mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)
+    offset, value = (956, np.float16(102.687))
+    with pytest.raises(ValueError) as excinfo:
+        read = mmio.read(offset, dtype=type(value))
+    assert str(excinfo.value) == "dtype \'{}\' is not supported".format(type(value))
+
+
 def test_reg_write_unsupported_type(mmap_device):
     device = mmap_device
     mmio = pynq.MMIO(BASE_ADDRESS, ADDR_RANGE, device=device)


### PR DESCRIPTION
Support different datatypes for MMIO read and write.

- Merge write functionality in a single method
- MMIO.read arguments `word_order` and `length` are deprecated
- MMIO.write detects datatype automatically 
- MMIO.read returns the datatype based on the dtype keyword (**kwargs). Eg. `mmio.read(offset,dtype=np.float)`, default is int

Fix #634 