### PR TITLE
Explained where to get the VLNV value for bindto attribute

### DIFF
--- a/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
+++ b/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
@@ -231,6 +231,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The argument that we feed into the `bindto` class is in the VLNV (vendor, library, name, and version) format. To find the correct VLNV for an IP you must used the `.ip_dict` method on the overlay which is explained [here.](https://pynq.readthedocs.io/en/latest/pynq_libraries/overlay.html) \n",
+    "  \n",
     "Now if we reload the overlay and query the help again we can see that our new driver is bound to the IP."
    ]
   },


### PR DESCRIPTION
Small edit of the PYNQ Documentation. Resolution of the closed pull request #1376 