### PR TITLE
Added missing clear_state function

### DIFF
--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -75,6 +75,22 @@ class DeviceMeta(type):
     def active_device(cls, value):
         cls._active_device = value
 
+def clear_state(dict_in):
+    """Clear the state information for a given dictionary.
+    Parameters
+    ----------
+    dict_in : obj
+        Input dictionary to be cleared.
+    """
+    if not isinstance(dict_in,dict):
+        return dict_in
+
+    for k,v in dict_in.items():
+        if isinstance(v,dict):
+            dict_in[k] =  clear_state(v)
+        if k == 'state':
+            dict_in[k] = None
+    return dict_in
 
 class Device(metaclass=DeviceMeta):
     """Construct a new Device Instance


### PR DESCRIPTION
This function was missing from device.py, it's used to clear the state of items in the ip_dict and mem_dict on reset. 