### PR TITLE
Remove preloaded overlay reliance in common notebooks

### DIFF
--- a/boards/Pynq-Z1/base/notebooks/board/asyncio_buttons.ipynb
+++ b/boards/Pynq-Z1/base/notebooks/board/asyncio_buttons.ipynb
@@ -29,11 +29,13 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
-    "from pynq import PL\n",
     "from pynq.overlays.base import BaseOverlay\n",
     "\n",
     "base = BaseOverlay(\"base.bit\")"
@@ -42,7 +44,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
     "deletable": true,
     "editable": true
    },
@@ -57,7 +58,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -75,7 +79,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
     "deletable": true,
     "editable": true
    },
@@ -90,7 +93,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -115,7 +121,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -156,7 +165,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -196,7 +208,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -230,7 +245,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -240,7 +258,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -254,9 +272,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/pynq/notebooks/common/overlay_download.ipynb
+++ b/pynq/notebooks/common/overlay_download.ipynb
@@ -15,50 +15,12 @@
     "*  An hwh file (\\*.hwh).\n",
     "*  A python class (\\*.py).\n",
     "\n",
-    "For example, an overlay called `base` can be loaded by:\n",
-    "```python\n",
-    "from pynq.overlays.base import BaseOverlay\n",
-    "overlay = BaseOverlay(\"base.bit\")\n",
-    "```\n",
-    "Users can also use the absolute file path of the bitstream to instantiate the overlay.\n",
-    "\n",
-    "In this notebook, we get the current bitstream loaded on PL, and try to download it multiple times."
+    "For example, an overlay called `base` can be loaded by:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os, warnings\n",
-    "from pynq import PL\n",
-    "from pynq import Overlay\n",
-    "\n",
-    "if PL.bitfile_name == None or not os.path.exists(PL.bitfile_name):\n",
-    "    warnings.warn('There is no overlay loaded after boot.', UserWarning)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Note**: If you see a warning message in the above cell, it means that no overlay\n",
-    "has been loaded after boot, hence the PL server is not aware of the \n",
-    "current status of the PL. In that case you won't be able to run this notebook\n",
-    "until you manually load an overlay at least once using:\n",
-    "\n",
-    "```python\n",
-    "from pynq import Overlay\n",
-    "ol = Overlay('your_overlay.bit')\n",
-    "```\n",
-    "\n",
-    "If you do not see any warning message, you can safely proceed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -101,7 +63,25 @@
     }
    ],
    "source": [
-    "ol = Overlay(PL.bitfile_name)"
+    "from pynq.overlays.base import BaseOverlay\n",
+    "\n",
+    "ol = BaseOverlay(\"base.bit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `BaseOverlay` class automatically downloads the bitstream, but it can re-downloaded by using the `download()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ol.download()"
    ]
   },
   {
@@ -119,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "''"
+       "'2022/10/6 14:16:52 +710996'"
       ]
      },
      "execution_count": 3,
@@ -128,7 +108,6 @@
     }
    ],
    "source": [
-    "ol.download()\n",
     "ol.timestamp"
    ]
   },
@@ -147,20 +126,16 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/usr/local/share/pynq-venv/lib/python3.10/site-packages/pynq/overlays/base/base.bit'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "PL.bitfile_name"
+    "from pynq import PL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use this class to obtain the absolute path to the loaded bitstream and timestamp"
    ]
   },
   {
@@ -171,10 +146,30 @@
     {
      "data": {
       "text/plain": [
-       "'2022/10/3 21:36:17 +589236'"
+       "'/usr/local/share/pynq-venv/lib/python3.10/site-packages/pynq/overlays/base/base.bit'"
       ]
      },
      "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PL.bitfile_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2022/10/6 14:16:52 +710996'"
+      ]
+     },
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,12 +182,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Users can verify whether an overlay instance is currently loaded using the Overlay is_loaded() method"
+    "Users can verify whether an overlay instance is currently loaded using the Overlay `is_loaded()` method"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +196,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -216,17 +211,17 @@
    "source": [
     "## 3. Overlay downloading overhead\n",
     "\n",
-    "Finally, using Python, we can see the bitstream download time over 50 downloads. We use the Bitstream class to download the bitstream directly, bypassing any Overlay PL state caching."
+    "Finally, using Python, we can see the bitstream download time over 50 downloads."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEICAYAAABfz4NwAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAZA0lEQVR4nO3df7RdZX3n8ffHQIGACGhgIOFXx1iErhYnV2SWrtY6VqN1Cmtm6IpFjR1qKgun2KVLQTvjdFoq7cxYSy0qWiUMUSb1F5GWjkj9US2KN4rF8GNIC4ZMYhKqFBgrI/E7f+wnzSG5uffcm3vPOcl9v9Y66+zznP3s8+zn3HM+Zz/7x01VIUnSU4bdAEnSaDAQJEmAgSBJagwESRJgIEiSGgNBkgQYCOqR5H1J/uOw2zHbkpyWpJIcMgfL/nySX23TFyb5zGy/xj5e95QkjyVZMKDX+7Uk757lZR6W5J4kx8/mcjVzBsI8kuSBJP/Yvki+l+TPkpy86/mqen1V/Xab94VJNve53Dn7wj2QVNWaqnrJXCy7vXcv7nmtTVV1VFXtnIvX2+O1fwz4TeC/zuZyq+px4EPAW2dzuZo5A2H++ddVdRRwIrAN+KNBvOh8D4sD3HnAPVX1f+Zg2R8BViY5bA6WrWkyEOapqvoB8DHgzF1lSa5N8jtJjgRuBk5qWxOPJTkpyTlJxpM8kmRbkne1ql9s9w+3ef9lktcm+XKSP0jyXeA/tyGC/5ZkU6v/viRHtNc+NslNSXa0rZebkizpadvnW9v+ur3Gp5M8Pcma1p6vJTmtn3Vv67IuyXeTbEzyup7nzklyW5KHk2xN8p72C3nX8z/fhjn+Icl7gPQ899okX+p5XElen+S+tk5/nCTtuQVJ/nuSh5Lcn+QN+9rKSvI/gFOAT7d1f8ueW2XT7Z8kZyS5pfXBvUl+aZIuexnwhZ66u177V5I82Nbt9Umem+RvWt+9p2f+Zyb5Quuzh5L8z13PVdVm4HvAuVO9bxqAqvI2T27AA8CL2/RCYDVwXc/z1wK/06ZfCGzeo/5twKvb9FHAuW36NKCAQ3rmfS3wBPAfgEOAI4B3A+uA44CnAp8G3tnmfzrwb1u7ngr8KfCpnuV9HtgI/HPgacBdwP8GXtyWfx3w4X2s95PaR/fldjVwOHA2sAP4V+25ZXRfToe0encDb2zPPQN4BPh3wKHAb7R1/NWedf5Sz+sWcBNwDN0X+g5geXvu9W0dlgDHAp/dsw/39d7tY5367h/gSOBB4Ffac/8CeAg4ax+v/TXgggle+32tD18C/AD4FHA8sBjYDvxsm/+jwNvpfoAeDrxgj+WvA3592J8Pb+UWwjz0qSQP032x/TzTGxf+IfDMJM+oqseq6itTzL+lqv6oqp6g+8J4HfAbVfXdqnoU+F1gBUBV/X1Vfbyqvt+euwL42T2W9+Gq+tuq+ge6LZi/rarPtuX/KfCcqVag7TN5AfDWqvpBVd0BfBB4dWvH+qr6SlU9UVUPAO/vacfLgbuq6mNV9UO6gPvOFC95ZVU9XFWbgM/RBRDALwF/WFWbq+p7wJVTtb0P/fbPK4AHqurDbT2/DnycLugmcgzw6ATlv9368DPA/wU+WlXbqxta+que1/shcCpwUpv/S3ss59H2GhoyA2H+Ob+qjgEOA94AfCHJP+uz7kXAs4B72hDEK6aY/8Ge6UV0v/7XtyGFh4G/aOUkWZjk/Um+neQRumGoY/Lko2i29Uz/4wSPj+pjHU4CdgXSLt+m+1VLkme14arvtHb8Lt2Wwa66/7ROVVV7rONEegPj+z1tfNKy+lhOP/rtn1OB5+16H9p7cSGwr7+D79Fttc309d5CN7R2e5INSf79Hst5KvDwPl5bA2QgzFNVtbOqPgHspPvFvNcsE9S5r6peSTcs8HvAx9Ltb9jXJXN7yx+i+5I4q6qOabenVbeDG+BNwE8Az6uqo4GfaeVhdm0BjkvS+wV3CrBrh+l7gXuApa0db+tpw1bgn47KavsDTmZmttINF+0y1XJm87LEDwJf6HkfjqnuiKWL9zH/39D9EJiRqvpOVb2uqk4Cfg24Oskze2Z5NvDNmS5fs8dAmKfSOY9u/PruCWbZBjw9ydN66rwqyaKq+hG7f9HtpBsb/xHw4/t6vVbnA8AfpB13nmRxkpe2WZ5KFxgPJzkOeMf+rN8k7XgQ+GvgnUkOT/JTdFs+a3ra8QjwWJIzgN4vyT8Dzkryb9rO3F9n37+qp7IWuLT1wTFMfejlNibp32m6CXhWklcnObTdnpvk2fuY/8/Ze/iub0kuyO4DBL5HF24723OL6fYpTTX8qAEwEOafTyd5jO5L7wpgZVVt2HOmqrqHbmfg37VhhZOA5cCGVv8PgRVtTPj7bVlfbvPu64iRt9Lt+PxKG475LN1WAXTj8UfQbUl8hW44aa68km7H6Bbgk8A7quqW9tybgV+mG9f+ANB7RMxDwAV04/1/DywFvjzDNnwA+Azdr+9v0H3pPkH7opzAO4HfbP375hm+JgBtuOwldPtvttANa/0e3TDiRD4NnNH+BmbiucBX29/NOuDSqrq/PffLwOrqzknQkKUbBpU0TEleBryvqk4ddlsmkmQVcGZVvXEWl3kY3VDRz1TV9tlarmbOQJCGIN35Fz9Ht5VwAt1RPl+ZzS9cabr6GjJKd9r8nUnuSDLeyo5rJ7bc1+6P7Zn/8nQn/NzbM0ZMkmVtORuTXNV2yknzUYDfohtT/wbdfpz/NNQWad7rawshyQPAWBtD3VX2+3SH712Z5DLg2Kp6a5Iz6caez6E7tO6zwLOqameS24FL6caI/xy4qqpunu2VkiRN3/7sVD6P7kxX2v35PeU3VNXjbcfRRuCcJCcCR1fVbe347et66kiShqzfC44V8JkkBby/qq4BTqiqrQBVtTW7L2G7mCcfQra5lf2wTe9Zvpe2A2sVwJFHHrnsjDPO6LOZkiSA9evXP1RVi6ZTp99AeH5VbWlf+rckuWeSeSfaL1CTlO9d2AXONQBjY2M1Pj7eZzMlSQBJvj3dOn0NGVXVlna/ne647XOAbW0YiHa/67CxzTz5rMsldMc6b+bJZ2buKpckjYApAyHJkbtO82+XKXgJ8C26E0xWttlWAje26XXAinSXOj6d7uSd29vw0qNJzm1HF72mp44kacj6GTI6AfhkO0L0EOAjVfUXSb4GrE1yEbCJ7gxOqmpDkrV0l999Arikdv9Xp4vpLrF8BN3VGD3CSJJGxMifmOY+BEmaviTrq2psOnW8lpEkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCphEISRYk+UaSm9rj45LckuS+dn9sz7yXJ9mY5N4kL+0pX5bkzvbcVUkyu6sjSZqp6WwhXArc3fP4MuDWqloK3Noek+RMYAVwFrAcuDrJglbnvcAqYGm7Ld+v1kuSZk1fgZBkCfALwAd7is8DVrfp1cD5PeU3VNXjVXU/sBE4J8mJwNFVdVtVFXBdTx1J0pD1u4XwbuAtwI96yk6oqq0A7f74Vr4YeLBnvs2tbHGb3rN8L0lWJRlPMr5jx44+myhJ2h9TBkKSVwDbq2p9n8ucaL9ATVK+d2HVNVU1VlVjixYt6vNlJUn745A+5nk+8ItJXg4cDhyd5HpgW5ITq2prGw7a3ubfDJzcU38JsKWVL5mgXJI0AqbcQqiqy6tqSVWdRrez+C+r6lXAOmBlm20lcGObXgesSHJYktPpdh7f3oaVHk1ybju66DU9dSRJQ9bPFsK+XAmsTXIRsAm4AKCqNiRZC9wFPAFcUlU7W52LgWuBI4Cb202SNALSHfAzusbGxmp8fHzYzZCkA0qS9VU1Np06nqksSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVIz+oGwfj2cdhqsWTPslkjSQW30AwHg29+GVasMBUmaQwdGIAB8//vw9rcPuxWSdNA6cAIBYNOmYbdAkg5aB1YgnHLKsFsgSQetAycQFi6EK64Ydisk6aB1YATCqafCNdfAhRcOuyWSdNDan3+hORjLloH/MU2S5tyBsYUgSZpzBoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiSgj0BIcniS25N8M8mGJL/Vyo9LckuS+9r9sT11Lk+yMcm9SV7aU74syZ3tuauSZG5WS5I0Xf1sITwOvKiqfho4G1ie5FzgMuDWqloK3Noek+RMYAVwFrAcuDrJgras9wKrgKXttnz2VkWStD+mDITqPNYeHtpuBZwHrG7lq4Hz2/R5wA1V9XhV3Q9sBM5JciJwdFXdVlUFXNdTR5I0ZH3tQ0iyIMkdwHbglqr6KnBCVW0FaPfHt9kXAw/2VN/cyha36T3LJ3q9VUnGk4zv2LFjGqsjSZqpvgKhqnZW1dnAErpf+z85yewT7ReoSconer1rqmqsqsYWLVrUTxMlSftpWkcZVdXDwOfpxv63tWEg2v32Nttm4OSeakuALa18yQTlkqQR0M9RRouSHNOmjwBeDNwDrANWttlWAje26XXAiiSHJTmdbufx7W1Y6dEk57aji17TU0eSNGSH9DHPicDqdqTQU4C1VXVTktuAtUkuAjYBFwBU1YYka4G7gCeAS6pqZ1vWxcC1wBHAze0mSRoB6Q74GV1jY2M1Pj4+7GZI0gElyfqqGptOHc9UliQBBoIkqTEQJEmAgSBJagyEQVqzBk47DZ7ylO5+zZr53Q51RuX9GIV2jEIbRqUdw2hDVY30bdmyZTUrrr++6tRTq5Lu/vrrB7u866+vWriwCnbfFi7cv3bMZJ1GqR2z+X7MlH8Xo9OOUWjDqLRjFtoAjNc0v2+H/oU/1W1WAmG23+CZLO/UU588/67bqacOrg2j0o5R+MDNRTv8u9i/doxCG0alHbPQBgNhX2b7DZ7J8pKJ6ySDa8OotGMUPnBz0Q7/LvavHaPQhlFpxyy0wUDYl9l+g2eyvNn+8pnpOo1CO0bhAzcX7fDvYv/aMQptGJV2DGkLYX7sVD7llOmVz8XyrrgCFi58ctnChV35oNowKu2Y7fdj06bplc9VO/y72L92jEIbRqUds92Gfk03QQZ9O2j2IeyqN1s7MPdnnYbdjtl+P2b6a8q/i9Frxyi0YVTasZ9twCGjSQz7aJK5MAptmGk7RuEDN9vtmIvlHahtGJV2jEIbhtSOmQSCF7fTwWHNGnj727tholNO6TatL7xw2K2ShmYmF7fr5/LX0ui78EIDQNpP82OnsiRpSgaCJAkwECRJjYEgSQIMBElSYyCMiskudTuTy+COwuV7D1aDfD98H/szCp+Rg+G9mu6JC4O+7XVi2mQneMz2CVIzPZlkNi91O8gzgUehL+aiHbNZZ9Dvx2T1ht0Xg2zDZPVG4TMy6LOR+6jHQX+m8iC/OOfqQzyRyS69MKiriY5KX4xCOE5WZ5BXd52s3ij0xaiE4yh8RmZ7eTPtix4HfyAM8otzLj7E+zLZ1RAHdTXRUemLUQjHyeoM8uquk9Ubhb4YlXAchc/IIK9o2me9gz8QBvnFORcf4n0ZhQ/dqPTFKITjKHwRT1VvFPpivoXjbLdhjj9XMwmEA2un8mSXkZ3tyzDP9NK5s32p25lcBncmdUalLwb5Hs+kzqDej6nqjUJfDPLS56Pwnsx2Gwb5uerXdBNk0Ld5sQ9hV71h7rgblb4YhTHrUdmZO1m9UeiLUdmHMFk/TbXM2fqMzMXy9rMeB/2Q0a7OGNQX5xweATCSRqUvhh2OM60zaKPQF6MQjoM0222Yw76YSSB4+WtJOgjN5PLXB9Y+BEnSnDEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkZspASHJyks8luTvJhiSXtvLjktyS5L52f2xPncuTbExyb5KX9pQvS3Jne+6qJJmb1ZIkTVc/WwhPAG+qqmcD5wKXJDkTuAy4taqWAre2x7TnVgBnAcuBq5MsaMt6L7AKWNpuy2dxXSRJ+2HKQKiqrVX19Tb9KHA3sBg4D1jdZlsNnN+mzwNuqKrHq+p+YCNwTpITgaOr6rZ2WvV1PXUkSUM2rX0ISU4DngN8FTihqrZCFxrA8W22xcCDPdU2t7LFbXrP8oleZ1WS8STjO3bsmE4TJUkz1HcgJDkK+Djwxqp6ZLJZJyirScr3Lqy6pqrGqmps0aJF/TZRkrQf+gqEJIfShcGaqvpEK97WhoFo99tb+Wbg5J7qS4AtrXzJBOWSpBHQz1FGAf4EuLuq3tXz1DpgZZteCdzYU74iyWFJTqfbeXx7G1Z6NMm5bZmv6akjSRqyQ/qY5/nAq4E7k9zRyt4GXAmsTXIRsAm4AKCqNiRZC9xFd4TSJVW1s9W7GLgWOAK4ud0kSSPA/4cgSQch/x+CJGnGDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkS0EcgJPlQku1JvtVTdlySW5Lc1+6P7Xnu8iQbk9yb5KU95cuS3NmeuypJZn91JEkz1c8WwrXA8j3KLgNuraqlwK3tMUnOBFYAZ7U6VydZ0Oq8F1gFLG23PZcpSRqiKQOhqr4IfHeP4vOA1W16NXB+T/kNVfV4Vd0PbATOSXIicHRV3VZVBVzXU0eSNAJmug/hhKraCtDuj2/li4EHe+bb3MoWt+k9yyeUZFWS8STjO3bsmGETJUnTMds7lSfaL1CTlE+oqq6pqrGqGlu0aNGsNU6StG8zDYRtbRiIdr+9lW8GTu6ZbwmwpZUvmaBckjQiZhoI64CVbXolcGNP+YokhyU5nW7n8e1tWOnRJOe2o4te01NHkjQCDplqhiQfBV4IPCPJZuAdwJXA2iQXAZuACwCqakOStcBdwBPAJVW1sy3qYrojlo4Abm43SdKISHfQz+gaGxur8fHxYTdDkg4oSdZX1dh06nimsiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQKGEAhJlie5N8nGJJcN+vUlSRMbaCAkWQD8MfAy4EzglUnOHGQbJEkTG/QWwjnAxqr6u6r6f8ANwHkDboMkaQKHDPj1FgMP9jzeDDxvz5mSrAJWtYePJ/nWANp2IHgG8NCwGzEi7Ivd7Ivd7IvdfmK6FQYdCJmgrPYqqLoGuAYgyXhVjc11ww4E9sVu9sVu9sVu9sVuScanW2fQQ0abgZN7Hi8Btgy4DZKkCQw6EL4GLE1yepIfA1YA6wbcBknSBAY6ZFRVTyR5A/C/gAXAh6pqwxTVrpn7lh0w7Ivd7Ivd7Ivd7Ivdpt0XqdprCF+SNA95prIkCTAQJEnNyAbCfL7ERZIPJdnee/5FkuOS3JLkvnZ/7DDbOChJTk7yuSR3J9mQ5NJWPu/6I8nhSW5P8s3WF7/VyuddX+ySZEGSbyS5qT2el32R5IEkdya5Y9fhpjPpi5EMBC9xwbXA8j3KLgNuraqlwK3t8XzwBPCmqno2cC5wSftbmI/98Tjwoqr6aeBsYHmSc5mffbHLpcDdPY/nc1/8XFWd3XMexrT7YiQDgXl+iYuq+iLw3T2KzwNWt+nVwPmDbNOwVNXWqvp6m36U7sO/mHnYH9V5rD08tN2KedgXAEmWAL8AfLCneF72xT5Muy9GNRAmusTF4iG1ZVScUFVbofuSBI4fcnsGLslpwHOArzJP+6MNkdwBbAduqap52xfAu4G3AD/qKZuvfVHAZ5Ksb5f+gRn0xaAvXdGvvi5xofkjyVHAx4E3VtUjyUR/Ige/qtoJnJ3kGOCTSX5yyE0aiiSvALZX1fokLxxyc0bB86tqS5LjgVuS3DOThYzqFoKXuNjbtiQnArT77UNuz8AkOZQuDNZU1Sda8bztD4Cqehj4PN2+pvnYF88HfjHJA3RDyi9Kcj3zsy+oqi3tfjvwSbph92n3xagGgpe42Ns6YGWbXgncOMS2DEy6TYE/Ae6uqnf1PDXv+iPJorZlQJIjgBcD9zAP+6KqLq+qJVV1Gt33w19W1auYh32R5MgkT901DbwE+BYz6IuRPVM5ycvpxgh3XeLiiuG2aHCSfBR4Id2lfLcB7wA+BawFTgE2ARdU1Z47ng86SV4A/BVwJ7vHit9Gtx9hXvVHkp+i2zm4gO7H3Nqq+i9Jns4864tebcjozVX1ivnYF0l+nG6rALrdAB+pqitm0hcjGwiSpMEa1SEjSdKAGQiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVLz/wFJLZPEaCWwrAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEICAYAAABfz4NwAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAX70lEQVR4nO3de7RdZX3u8e9jYoEACsTAgYSbxyiCo1XZIh4dlhYraD3COOfQEVttvFSqAyt66lCiPcf2tKlae1Fr0eI1HimcFC9EWiuIdyvijngLlxIFQ0okoYBArdTE3/ljvtushL2Tvdde2Zeu72eMNdZc75zvfN/17jCfNd851yJVhSRJD5ntDkiS5gYDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgaAeSd6d5H/Ndj8GLclxSSrJwn2w788l+a22/BtJrhx0GxO0e0yS+5MsmKH2fjvJ2wa8z/2S3Jjk8EHuV/0zEIZIkluT/Fs7kNyd5O+SHD22vqpeVlV/2LY9LcnmSe53nx1w55Oquriqnrkv9t3+ds/oaWtTVR1UVTv2RXu7tf1zwO8Bbx3kfqvqAeD9wOsGuV/1z0AYPv+1qg4CjgTuAP5yJhod9rCY584Cbqyqf94H+/4bYGWS/fbBvjVFBsKQqqofA5cBJ46VJflgkj9KciDwSeCodjZxf5KjkpySZDTJvUnuSPLnreoX2vM9bdunJHlhki8n+YskdwG/36YI/jTJplb/3UkOaG0fmuSKJNva2csVSZb19O1zrW//2Nr4RJLFSS5u/flakuMm897be1mX5K4kG5O8tGfdKUm+kuSeJFuSvLN9Qh5b/yttmuOHSd4JpGfdC5N8qed1JXlZkpvbe/qrJGnrFiT5syR3JrklySsmOstK8n+BY4BPtPf+2t3PyqY6PklOSHJVG4ObkvzaHobsWcDne+qOtf2iJLe19/ayJE9K8q02du/s2f5RST7fxuzOJP9vbF1VbQbuBk7d299NM6CqfAzJA7gVeEZbXgSsAT7Us/6DwB+15dOAzbvV/wrwgrZ8EHBqWz4OKGBhz7YvBLYDvwMsBA4A3gasAw4DDgY+Abypbb8Y+O+tXwcDfwt8vGd/nwM2Av8ZeDhwPfBPwDPa/j8EfGCC971L/+gObhcC+wOPB7YBp7d1J9MdnBa2ejcAr2rrHgHcC/wP4KHAq9t7/K2e9/ylnnYLuAI4hO6Avg04s617WXsPy4BDgU/vPoYT/e0meE+THh/gQOA24EVt3ROBO4GTJmj7a8A547T97jaGzwR+DHwcOBxYCmwFfrFtfwnwBroPoPsDT9tt/+uAV872fx8+yjOEIfTxJPfQHdh+hanNC/8EeFSSR1TV/VV1zV62v72q/rKqttMdMF4KvLqq7qqq+4A/BlYAVNW/VNVHqupHbd1q4Bd3298Hquq7VfVDujOY71bVp9v+/xZ4wt7eQLtm8jTgdVX146r6BvBe4AWtH+ur6pqq2l5VtwJ/3dOPZwPXV9VlVfUTuoD7wV6afHNV3VNVm4DP0gUQwK8Bb6+qzVV1N/DmvfV9EiY7Ps8Bbq2qD7T3+XXgI3RBN55DgPvGKf/DNoZXAv8KXFJVW6ubWvpiT3s/AY4Fjmrbf2m3/dzX2tAsMxCGz9lVdQiwH/AK4PNJ/tMk674EeDRwY5uCeM5etr+tZ3kJ3af/9W1K4R7gH1o5SRYl+esk309yL9001CHZ9S6aO3qW/22c1wdN4j0cBYwF0pjv032qJcmj23TVD1o//pjuzGCs7s/eU1XVbu9xPL2B8aOePu6yr0nsZzImOz7HAk8e+zu0v8VvABP9O7ib7qyt3/ZeSze1dm2SDUlevNt+DgbumaBtzSADYUhV1Y6q+iiwg+4T84M2GafOzVX1PLppgbcAl6W73jDRT+b2lt9Jd5A4qaoOaY+HV3eBG+B3gccAT66qhwFPb+VhsG4HDkvSe4A7Bhi7YPou4EZgeevH63v6sAX42V1Z7XrA0fRnC9100Zi97WeQP0t8G/D5nr/DIdXdsfTyCbb/Ft0Hgb5U1Q+q6qVVdRTw28CFSR7Vs8ljgW/2u38NjoEwpNI5i27++oZxNrkDWJzk4T11np9kSVX9lJ2f6HbQzY3/FHjkRO21Ou8B/iLtvvMkS5Oc0TY5mC4w7klyGPDG6by/PfTjNuAfgTcl2T/Jz9Od+Vzc0497gfuTnAD0HiT/DjgpyX9rF3NfycSfqvdmLXB+G4ND2Putl3ewh/GdoiuARyd5QZKHtseTkjx2gu3/ngdP301aknOy8waBu+nCbUdbt5TumtLeph81AwyE4fOJJPfTHfRWAyurasPuG1XVjXQXA7/XphWOAs4ENrT6bwdWtDnhH7V9fbltO9EdI6+ju/B5TZuO+TTdWQF08/EH0J1JXEM3nbSvPI/uwujtwMeAN1bVVW3da4Bfp5vXfg/Qe0fMncA5dPP9/wIsB77cZx/eA1xJ9+n7OrqD7nbagXIcbwJ+r43va/psE4A2XfZMuus3t9NNa72FbhpxPJ8ATmj/BvrxJOCr7d/NOuD8qrqlrft1YE1130nQLEs3DSppNiV5FvDuqjp2tvsyniTnAidW1asGuM/96KaKnl5VWwe1X/XPQJBmQbrvX/wS3VnCEXR3+VwzyAOuNFV7nTJK8v4kW5N8p6fsrem+nPOtJB9rc6Bj61al+7LPTT3zwyQ5Ocm327p3tAty0rAK8Ad0c+rX0V3H+d+z2iMNvb2eISR5OnA/3ReYHtfKngl8pqq2J3kLQFW9LsmJdPPOp9DdVvdp4NFVtSPJtcD5dPPDfw+8o6o+uY/elyRpivZ6hlBVXwDu2q3syvZlF+gO8GN3EJwFXFpVD7SLRhuBU5IcCTysqr7S7t3+EHD2gN6DJGkABvGDYy9m550YS9n19rHNrewnbXn38nG1C1jnAhx44IEnn3DCCQPopiQNj/Xr199ZVUumUmdagZDkDXS3yo3dwz3edYHaQ/m4quoi4CKAkZGRGh0dnU43JWnoJPn+VOv0HQhJVtL9JsrptfNCxGZ2/cblMrr7nDez67cyx8olSXNEX19MS3Im3ZeMntu+lDRmHbAi3c8cH0/3xZ1rq2oLcF+SU9vdRb8JXD7NvkuSBmivZwhJLqH7KeRHpPs/aL0RWEX3rcar2t2j11T3f9vakGQt3U/vbgfOq53/R6eX0/288gF0v8ToHUaSNIfM+S+meQ1BkqYuyfqqGplKHX/LSJIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBkwiEJO9PsjXJd3rKDktyVZKb2/OhPetWJdmY5KYkZ/SUn5zk223dO5Jk8G9HktSvyZwhfBA4c7eyC4Crq2o5cHV7TZITgRXASa3OhUkWtDrvAs4FlrfH7vuUJM2ivQZCVX0BuGu34rOANW15DXB2T/mlVfVAVd0CbAROSXIk8LCq+kpVFfChnjqSpDmg32sIR1TVFoD2fHgrXwrc1rPd5la2tC3vXi5JmiMGfVF5vOsCtYfy8XeSnJtkNMnotm3bBtY5SdLE+g2EO9o0EO15ayvfDBzds90y4PZWvmyc8nFV1UVVNVJVI0uWLOmzi5Kkqeg3ENYBK9vySuDynvIVSfZLcjzdxeNr27TSfUlObXcX/WZPHUnSHLBwbxskuQQ4DXhEks3AG4E3A2uTvATYBJwDUFUbkqwFrge2A+dV1Y62q5fT3bF0APDJ9pAkzRHpbvqZu0ZGRmp0dHS2uyFJ80qS9VU1MpU6flNZkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpmVYgJHl1kg1JvpPkkiT7JzksyVVJbm7Ph/ZsvyrJxiQ3JTlj+t2XJA1K34GQZCnwSmCkqh4HLABWABcAV1fVcuDq9pokJ7b1JwFnAhcmWTC97kuSBmW6U0YLgQOSLAQWAbcDZwFr2vo1wNlt+Szg0qp6oKpuATYCp0yzfUnSgPQdCFX1z8CfApuALcAPq+pK4Iiq2tK22QIc3qosBW7r2cXmVvYgSc5NMppkdNu2bf12UZI0BdOZMjqU7lP/8cBRwIFJnr+nKuOU1XgbVtVFVTVSVSNLlizpt4uSpCmYzpTRM4BbqmpbVf0E+CjwX4A7khwJ0J63tu03A0f31F9GN8UkSZoDphMIm4BTkyxKEuB04AZgHbCybbMSuLwtrwNWJNkvyfHAcuDaabQvSRqghf1WrKqvJrkM+DqwHbgOuAg4CFib5CV0oXFO235DkrXA9W3786pqxzT7L0kakFSNO40/Z4yMjNTo6Ohsd0OS5pUk66tqZCp1/KayJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQKmGQhJDklyWZIbk9yQ5ClJDktyVZKb2/OhPduvSrIxyU1Jzph+9yVJgzLdM4S3A/9QVScAvwDcAFwAXF1Vy4Gr22uSnAisAE4CzgQuTLJgmu1Lkgak70BI8jDg6cD7AKrq36vqHuAsYE3bbA1wdls+C7i0qh6oqluAjcAp/bYvSRqs6ZwhPBLYBnwgyXVJ3pvkQOCIqtoC0J4Pb9svBW7rqb+5lT1IknOTjCYZ3bZt2zS6KEmarOkEwkLgicC7quoJwL/SpocmkHHKarwNq+qiqhqpqpElS5ZMo4uSpMmaTiBsBjZX1Vfb68voAuKOJEcCtOetPdsf3VN/GXD7NNqXJA1Q34FQVT8AbkvymFZ0OnA9sA5Y2cpWApe35XXAiiT7JTkeWA5c22/7kqTBWjjN+r8DXJzk54DvAS+iC5m1SV4CbALOAaiqDUnW0oXGduC8qtoxzfYlSQMyrUCoqm8AI+OsOn2C7VcDq6fTpiRp3/CbypIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJGEAgJFmQ5LokV7TXhyW5KsnN7fnQnm1XJdmY5KYkZ0y3bUnS4AziDOF84Iae1xcAV1fVcuDq9pokJwIrgJOAM4ELkywYQPuSpAGYViAkWQb8KvDenuKzgDVteQ1wdk/5pVX1QFXdAmwETplO+5KkwZnuGcLbgNcCP+0pO6KqtgC058Nb+VLgtp7tNreyB0lybpLRJKPbtm2bZhclSZPRdyAkeQ6wtarWT7bKOGU13oZVdVFVjVTVyJIlS/rtoiRpChZOo+5TgecmeTawP/CwJB8G7khyZFVtSXIksLVtvxk4uqf+MuD2abQvSRqgvs8QqmpVVS2rquPoLhZ/pqqeD6wDVrbNVgKXt+V1wIok+yU5HlgOXNt3zyVJAzWdM4SJvBlYm+QlwCbgHICq2pBkLXA9sB04r6p27IP2JUl9SNW40/hzxsjISI2Ojs52NyRpXkmyvqpGplLHbypLkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUzL9AuPhiOO44eMhDuueLL57tHknSns2X41ZV9fUAjgY+C9wAbADOb+WHAVcBN7fnQ3vqrAI2AjcBZ0ymnZOh6thjqz784e6xaFEV7HwsWtSVV3XPxx5bleysM2aidf3UmSttzfX9zee+z/X9zee+D9tY7Om4tS/GogFGa6rH9alW+FlFOBJ4Yls+GPgn4ETgT4ALWvkFwFva8onAN4H9gOOB7wIL9tbOyb0DuHjxroM69hgbkD0N+njrXv7yqdfpd92g25rr+5vPfZ/r+5vPfR/GsTj22F3Lxx6LFw9+LKYZCGkH62lLcjnwzvY4raq2JDkS+FxVPSbJqnZG8qa2/aeA36+qr+xpvyNJje69cTjmGPj+9x+87thju+fx1i1YADt2TK1Ov+sG3dZc39987vtc39987vswjsWmTd1he7KmMxa33vqzl0nWV9XI5BtmMIGQ5DjgC8DjgE1VdUjPurur6tAk7wSuqaoPt/L3AZ+sqsv2tO9JBcKeBj3pnqfyPvdUp991g25rru9vPvd9ru9vPvd90PubD32f6MPqoPuXwE9/2vNy6oEw7YvKSQ4CPgK8qqru3dOm45SNO+pJzk0ymmTXLFi8GBYt2nXjRYtg9epu0MdzzDETr1uwYOp1+l036Lbm+v7mc9/n+v7mc9+HcSxWrx7/uLV48WD7N1H5VPR7DaGdWTwU+BTwP3vKbgKO7LnOcFNbXgWs6tnuU8BTpnQNYU8XYebCHON8mM90LOb//uZz34dxLMaOT7sftwb9fgdwDWFKG+8WBgE+BLxtt/K3sutF5T9pyyex60Xl7zHZi8oTXEV/kInCYk/r+qkzV9qa6/ubz32f6/ubz30fxrGYyL4Yi6afQOj7GkKSpwFfBL4NjE1cvR74KrAWOAbYBJxTVXe1Om8AXgxsp5ti+uTe2hkZGanR0b1eRZAk9ejnGsLCfhurqi8x/nUBgNMnqLMaWN1vm5KkfWf+fVNZkrRPGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCZiFQEhyZpKbkmxMcsFMty9JGt+MBkKSBcBfAc8CTgSel+TEmeyDJGl8M32GcAqwsaq+V1X/DlwKnDXDfZAkjWPhDLe3FLit5/Vm4Mm7b5TkXODc9vKBJN+Zgb7NB48A7pztTswRjsVOjsVOjsVOj5lqhZkOhIxTVg8qqLoIuAggyWhVjezrjs0HjsVOjsVOjsVOjsVOSUanWmemp4w2A0f3vF4G3D7DfZAkjWOmA+FrwPIkxyf5OWAFsG6G+yBJGseMThlV1fYkrwA+BSwA3l9VG/ZS7aJ937N5w7HYybHYybHYybHYacpjkaoHTeFLkoaQ31SWJAEGgiSpmbOBMMw/cZHk/Um29n7/IslhSa5KcnN7PnQ2+zhTkhyd5LNJbkiyIcn5rXzoxiPJ/kmuTfLNNhZ/0MqHbizGJFmQ5LokV7TXQzkWSW5N8u0k3xi73bSfsZiTgeBPXPBB4Mzdyi4Arq6q5cDV7fUw2A78blU9FjgVOK/9WxjG8XgA+OWq+gXg8cCZSU5lOMdizPnADT2vh3ksfqmqHt/zPYwpj8WcDASG/CcuquoLwF27FZ8FrGnLa4CzZ7JPs6WqtlTV19vyfXT/8S9lCMejOve3lw9tj2IIxwIgyTLgV4H39hQP5VhMYMpjMVcDYbyfuFg6S32ZK46oqi3QHSSBw2e5PzMuyXHAE4CvMqTj0aZIvgFsBa6qqqEdC+BtwGuBn/aUDetYFHBlkvXtp3+gj7GY6Z+umKxJ/cSFhkeSg4CPAK+qqnuT8f6J/MdXVTuAxyc5BPhYksfNcpdmRZLnAFuran2S02a5O3PBU6vq9iSHA1clubGfnczVMwR/4uLB7khyJEB73jrL/ZkxSR5KFwYXV9VHW/HQjgdAVd0DfI7uWtMwjsVTgecmuZVuSvmXk3yY4RwLqur29rwV+BjdtPuUx2KuBoI/cfFg64CVbXklcPks9mXGpDsVeB9wQ1X9ec+qoRuPJEvamQFJDgCeAdzIEI5FVa2qqmVVdRzd8eEzVfV8hnAskhyY5OCxZeCZwHfoYyzm7DeVkzybbo5w7CcuVs9uj2ZOkkuA0+h+yvcO4I3Ax4G1wDHAJuCcqtr9wvN/OEmeBnwR+DY754pfT3cdYajGI8nP010cXED3YW5tVf2fJIsZsrHo1aaMXlNVzxnGsUjySLqzAuguA/xNVa3uZyzmbCBIkmbWXJ0ykiTNMANBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElq/j+rT6H1tU7jegAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -244,48 +239,6 @@
     "\n",
     "length = 50\n",
     "time_log = []\n",
-    "bits = Bitstream(PL.bitfile_name)\n",
-    "for i in range(length):\n",
-    "    start = time.time()\n",
-    "    bits.download()\n",
-    "    end = time.time()\n",
-    "    time_log.append((end-start)*1000)\n",
-    "\n",
-    "%matplotlib inline\n",
-    "plt.plot(range(length), time_log, 'ro')\n",
-    "plt.title('Bitstream loading time (ms)')\n",
-    "plt.axis([0, length, 0, 5000])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, using the Overlay object, the first download of the overlay is cached and stored in a global state file. If the bitstream we want to upload doesn't change the Overlay class simply bypasses the download and allows quick access to interact with the PL without the download overhead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEICAYAAABfz4NwAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAZ9UlEQVR4nO3de5RlZX3m8e9jg4hc5NY40M1NbUTIMu1QIllegvECOo5gJjhNEkWjtrBgAhldKiYzmgvRJN5CjJBGERgRxAvSGsmIjpdoQKxW5E5opIWy2+5GRHBUxm5/88d+yz401V1Vp05XVVvfz1pnnX3evd93v+et6vPUfvfep1NVSJL0qJnugCRpdjAQJEmAgSBJagwESRJgIEiSGgNBkgQYCOqR5Lwk/2Om+zFoSQ5OUkl22AZtfznJa9vyHyT5/KD3sYX9HpjkJ0nmTdP+Xp/kfQNuc6cktyXZd5Dtqn8GwhySZFWSn7UPkh8l+eckB4yur6pTquov27bHJBmZYLvb7AN3e1JVl1TVC7dF2+1n9/yefd1dVbtW1cZtsb/N9v1o4M+Avxtku1X1EHAB8OZBtqv+GQhzz3+uql2B/YC1wD9Mx07nelhs544Hbquq72+Dtj8KnJxkp23QtibJQJijqurnwCeAw0fLklyY5K+S7AJcBezfjiZ+kmT/JEclGU7yQJK1Sd7Tqn61Pd/ftv2tJK9K8vUk701yH/D2NkXwriR3t/rnJdm57XvPJJ9Nsr4dvXw2ycKevn259e3f2j4+k2TvJJe0/nwzycETee/tvSxPcl+SlUle17PuqCTXJLk/yZok729/IY+uf0Gb5vhxkvcD6Vn3qiRf63ldSU5Jckd7T/+YJG3dvCTvTnJvkruSnL6lo6wk/ws4EPhMe+9v2vyobLLjk+SwJFe3Mbg9ycu3MmQvAr7SU3d0369Ock97b6ckeXqSG9rYvb9n+ycl+Uobs3uTfGx0XVWNAD8Cjh7v56ZpUFU+5sgDWAU8vy0/FrgIuLhn/YXAX7XlY4CRzepfA7yiLe8KHN2WDwYK2KFn21cBG4D/BuwA7Ay8D1gO7AXsBnwGeEfbfm/gv7R+7QZ8HPh0T3tfBlYCTwQeB9wC/Dvw/Nb+xcCHt/C+H9Y/ug+3DwCPARYD64HntXVH0n047dDq3Qqc2dbtAzwA/B6wI/An7T2+tuc9f61nvwV8FtiD7gN9PXBcW3dKew8LgT2BL2w+hlv62W3hPU14fIBdgHuAV7d1/xG4FzhiC/v+JnDiGPs+r43hC4GfA58G9gUWAOuA327bXwr8Kd0foI8BnrVZ+8uBP57pfx8+yiOEOejTSe6n+2B7AZObF/4F8KQk+1TVT6rq2nG2X11V/1BVG+g+MF4H/ElV3VdVDwJ/DSwBqKofVtUnq+qnbd3ZwG9v1t6Hq+rOqvox3RHMnVX1hdb+x4GnjfcG2jmTZwFvrqqfV9X1wAeBV7R+rKiqa6tqQ1WtAv6ppx8vBm6pqk9U1S/oAu4H4+zynVV1f1XdDXyJLoAAXg78fVWNVNWPgHeO1/cJmOj4vARYVVUfbu/zW8An6YJuLHsAD45R/pdtDD8P/F/g0qpaV93U0r/27O8XwEHA/m37r23WzoNtH5phBsLcc0JV7QHsBJwOfCXJf5hg3dcAhwK3tSmIl4yz/T09y/Pp/vpf0aYU7gf+pZWT5LFJ/inJ95I8QDcNtUcefhXN2p7ln43xetcJvIf9gdFAGvU9ur9qSXJom676QevHX9MdGYzW/dV7qqra7D2OpTcwftrTx4e1NYF2JmKi43MQ8IzRn0P7WfwBsKXfgx/RHbX1u7830U2tXZfk5iR/tFk7uwH3b2HfmkYGwhxVVRur6lPARrq/mB+xyRh17qiqk+imBf4G+ES68w1b+src3vJ76T4kjqiqPdrjcdWd4AZ4A/Bk4BlVtTvwnFYeBms1sFeS3g+4A4HRE6bnArcBi1o/3trThzXAr67KaucDDqA/a+imi0aN184gv5b4HuArPT+HPaq7YunULWx/A90fAn2pqh9U1euqan/g9cAHkjypZ5OnAN/pt30NjoEwR6VzPN389a1jbLIW2DvJ43rq/GGS+VX1Szb9RbeRbm78l8ATtrS/Vud84L1p150nWZDk2LbJbnSBcX+SvYC3TeX9baUf9wD/BrwjyWOSPJXuyOeSnn48APwkyWFA74fkPwNHJPnddjL3j9nyX9XjuRw4o43BHox/6eVatjK+k/RZ4NAkr0iyY3s8PclTtrD953jk9N2EJTkxmy4Q+BFduG1s6xbQnVMab/pR08BAmHs+k+QndB96ZwMnV9XNm29UVbfRnQz8bptW2B84Dri51f97YEmbE/5pa+vrbdstXTHyZroTn9e26Zgv0B0VQDcfvzPdkcS1dNNJ28pJdCdGVwNXAG+rqqvbujcCv083r30+0HtFzL3AiXTz/T8EFgFf77MP5wOfp/vr+9t0H7obaB+UY3gH8GdtfN/Y5z4BaNNlL6Q7f7Oablrrb+imEcfyGeCw9jvQj6cD32i/N8uBM6rqrrbu94GLqrsnQTMs3TSopJmU5EXAeVV10Ez3ZSxJlgKHV9WZA2xzJ7qpoudU1bpBtav+GQjSDEh3/8Vz6Y4SHk93lc+1g/zAlSZr3CmjJAck+VKSW9sVAme08r3ajS13tOc9e+qcle6Gn9t75ohJcmSSG9u6c9pJOWkuCvDndHPq36Y7j/M/Z7RHmvPGPUJIsh+wX1V9q12ZsQI4ge4mnPuq6p1J3gLsWVVvTnI43dzzUXSX1n0BOLSqNia5DjiDbo74c8A5VXXVtnlrkqTJGPcIoarWtBtXRk9G3Up3zfbxdHe60p5PaMvHA5dV1UPtxNFK4KgWLLtX1TXt+u2Le+pIkmbYpL5wrH0XytOAbwCPr6o10IVGNn2F7QIefgnZSCv7RVvevHys/SwFlgLssssuRx522GGT6aYkzXkrVqy4t6rmT6bOhAMhya50J77OrKoHtjL9P9aK2kr5IwurlgHLAIaGhmp4eHii3ZQkAUm+N9k6E7oPIcmOdGFwSbu7FWBtmwYaPc8wetnYCA+/63Ih3bXOIzz8zszRcknSLDCRq4wCfAi4tare07NqOXByWz4ZuLKnfEm6rzo+hO7mneva9NKDSY5ubb6yp44kaYZNZMromXTfBHljkutb2Vvp7ta8PMlrgLvp7uCkqm5Ocjnd1+9uAE6rTf+r06l0X7G8M923MXqFkSTNErP+xjTPIUjS5CVZUVVDk6njdxlJkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1IwbCEkuSLIuyU09ZR9Lcn17rBr9v5aTHJzkZz3rzuupc2SSG5OsTHJOkmyTdyRJ6ssOE9jmQuD9wMWjBVX1X0eXk7wb+HHP9ndW1eIx2jkXWApcC3wOOA64atI9liRtE+MeIVTVV4H7xlrX/sp/OXDp1tpIsh+we1VdU1VFFy4nTLq3kqRtZqrnEJ4NrK2qO3rKDkny7SRfSfLsVrYAGOnZZqSVSZJmiYlMGW3NSTz86GANcGBV/TDJkcCnkxwBjHW+oLbUaJKldNNLHHjggVPsoiRpIvo+QkiyA/C7wMdGy6rqoar6YVteAdwJHEp3RLCwp/pCYPWW2q6qZVU1VFVD8+fP77eLkqRJmMqU0fOB26rqV1NBSeYnmdeWnwAsAr5bVWuAB5Mc3c47vBK4cgr7liQN2EQuO70UuAZ4cpKRJK9pq5bwyJPJzwFuSPId4BPAKVU1ekL6VOCDwEq6IwevMJKkWSTdRT+z19DQUA0PD890NyRpu5JkRVUNTaaOdypLkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiRgAoGQ5IIk65Lc1FP29iTfT3J9e7y4Z91ZSVYmuT3JsT3lRya5sa07J0kG/3YkSf2ayBHChcBxY5S/t6oWt8fnAJIcDiwBjmh1PpBkXtv+XGApsKg9xmpTkjRDxg2EqvoqcN8E2zseuKyqHqqqu4CVwFFJ9gN2r6prqqqAi4ET+uyzJGkbmMo5hNOT3NCmlPZsZQuAe3q2GWllC9ry5uVjSrI0yXCS4fXr10+hi5Kkieo3EM4FnggsBtYA727lY50XqK2Uj6mqllXVUFUNzZ8/v88uSpImo69AqKq1VbWxqn4JnA8c1VaNAAf0bLoQWN3KF45RLkmaJfoKhHZOYNTLgNErkJYDS5LslOQQupPH11XVGuDBJEe3q4teCVw5hX5LkgZsh/E2SHIpcAywT5IR4G3AMUkW0037rAJeD1BVNye5HLgF2ACcVlUbW1On0l2xtDNwVXtIkmaJdBf9zF5DQ0M1PDw8092QpO1KkhVVNTSZOt6pLEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVIzbiAkuSDJuiQ39ZT9XZLbktyQ5Ioke7Tyg5P8LMn17XFeT50jk9yYZGWSc5Jkm7wjSVJfJnKEcCFw3GZlVwO/UVVPBf4dOKtn3Z1Vtbg9TukpPxdYCixqj83blCTNoHEDoaq+Cty3Wdnnq2pDe3ktsHBrbSTZD9i9qq6pqgIuBk7oq8eSpG1iEOcQ/gi4quf1IUm+neQrSZ7dyhYAIz3bjLSyMSVZmmQ4yfD69esH0EVJ0nimFAhJ/hTYAFzSitYAB1bV04D/Dnw0ye7AWOcLakvtVtWyqhqqqqH58+dPpYuSpAnaod+KSU4GXgI8r00DUVUPAQ+15RVJ7gQOpTsi6J1WWgis7nffkqTB6+sIIclxwJuBl1bVT3vK5yeZ15afQHfy+LtVtQZ4MMnR7eqiVwJXTrn3kqSBGfcIIcmlwDHAPklGgLfRXVW0E3B1u3r02nZF0XOAv0iyAdgInFJVoyekT6W7YmlnunMOvecdJEkzLG22Z9YaGhqq4eHhme6GJG1XkqyoqqHJ1PFOZUkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJKacQMhyQVJ1iW5qadsryRXJ7mjPe/Zs+6sJCuT3J7k2J7yI5Pc2Nadk/afMUuSZoeJHCFcCBy3WdlbgC9W1SLgi+01SQ4HlgBHtDofSDKv1TkXWAosao/N25QkzaBxA6Gqvgrct1nx8cBFbfki4ISe8suq6qGqugtYCRyVZD9g96q6pqoKuLinjiRpFuj3HMLjq2oNQHvet5UvAO7p2W6klS1oy5uXjynJ0iTDSYbXr1/fZxclSZMx6JPKY50XqK2Uj6mqllXVUFUNzZ8/f2CdkyRtWb+BsLZNA9Ge17XyEeCAnu0WAqtb+cIxyiVJs0S/gbAcOLktnwxc2VO+JMlOSQ6hO3l8XZtWejDJ0e3qolf21JEkzQI7jLdBkkuBY4B9kowAbwPeCVye5DXA3cCJAFV1c5LLgVuADcBpVbWxNXUq3RVLOwNXtYckaZZId9HP7DU0NFTDw8Mz3Q1J2q4kWVFVQ5Op453KkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDV9B0KSJye5vufxQJIzk7w9yfd7yl/cU+esJCuT3J7k2MG8BUnSIOzQb8Wquh1YDJBkHvB94Arg1cB7q+pdvdsnORxYAhwB7A98IcmhVbWx3z5IkgZnUFNGzwPurKrvbWWb44HLquqhqroLWAkcNaD9S5KmaFCBsAS4tOf16UluSHJBkj1b2QLgnp5tRlrZIyRZmmQ4yfD69esH1EVJ0tZMORCSPBp4KfDxVnQu8ES66aQ1wLtHNx2jeo3VZlUtq6qhqhqaP3/+VLsoSZqAQRwhvAj4VlWtBaiqtVW1sap+CZzPpmmhEeCAnnoLgdUD2L8kaQAGEQgn0TNdlGS/nnUvA25qy8uBJUl2SnIIsAi4bgD7lyQNQN9XGQEkeSzwAuD1PcV/m2Qx3XTQqtF1VXVzksuBW4ANwGleYSRJs8eUAqGqfgrsvVnZK7ay/dnA2VPZpyRp2/BOZUkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJKaKQVCklVJbkxyfZLhVrZXkquT3NGe9+zZ/qwkK5PcnuTYqXZekjQ4gzhCeG5VLa6qofb6LcAXq2oR8MX2miSHA0uAI4DjgA8kmTeA/UuSBmBbTBkdD1zUli8CTugpv6yqHqqqu4CVwFHbYP+SpD5MNRAK+HySFUmWtrLHV9UagPa8bytfANzTU3eklT1CkqVJhpMMr1+/fopdlCRNxA5TrP/MqlqdZF/g6iS3bWXbjFFWY21YVcuAZQBDQ0NjbiNJGqwpHSFU1er2vA64gm4KaG2S/QDa87q2+QhwQE/1hcDqqexfkjQ4fQdCkl2S7Da6DLwQuAlYDpzcNjsZuLItLweWJNkpySHAIuC6fvcvSRqsqUwZPR64IsloOx+tqn9J8k3g8iSvAe4GTgSoqpuTXA7cAmwATquqjVPqvSRpYPoOhKr6LvCbY5T/EHjeFuqcDZzd7z4lSduOdypLkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1PQdCEkOSPKlJLcmuTnJGa387Um+n+T69nhxT52zkqxMcnuSYwfxBiRJg9H3/6kMbADeUFXfSrIbsCLJ1W3de6vqXb0bJzkcWAIcAewPfCHJoVW1cQp9kCQNSN9HCFW1pqq+1ZYfBG4FFmylyvHAZVX1UFXdBawEjup3/5KkwRrIOYQkBwNPA77Rik5PckOSC5Ls2coWAPf0VBth6wEiSZpGUw6EJLsCnwTOrKoHgHOBJwKLgTXAu0c3HaN6baHNpUmGkwyvX79+ql2UJE3AlAIhyY50YXBJVX0KoKrWVtXGqvolcD6bpoVGgAN6qi8EVo/VblUtq6qhqhqaP3/+VLooSZqgqVxlFOBDwK1V9Z6e8v16NnsZcFNbXg4sSbJTkkOARcB1/e5fkjRYU7nK6JnAK4Abk1zfyt4KnJRkMd100Crg9QBVdXOSy4Fb6K5QOs0rjCRp9ug7EKrqa4x9XuBzW6lzNnB2v/uUJG073qksSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJKAGQiEJMcluT3JyiRvGbfCihVw8MFwySXd60su6V4/6lEPL+933aDbm859zfb2tue+z/b2tue+Oxbbdiymoqqm7QHMA+4EngA8GvgOcPjW6hwJVVD12MdWnXpq9zxaNlr+kY90j8muG3R707mv2d7e9tz32d7e9tx3x2LbjkUPYHiyn9FpH9TTIslvAW+vqmPb67NaKL1jS3WGkhoefTFvHmzc+MiNDjqoe/7e9ya3btDtTee+Znt723PfZ3t723PfHYtt195BB8GqVb96mWRFVQ09csMtm+5A+D3guKp6bXv9CuAZVXX6ZtstBZYC7A1HHjxtPZSk7dcKWNHz8slVtdtk6u8w4P6MJ2OUPSKRqmoZsAwgyfC9k0y5X1dJhieb+L+uHItNHItNHItNkgyPv9XDTfdJ5RHggJ7XC4HV09wHSdIYpjsQvgksSnJIkkcDS4Dl09wHSdIYpnXKqKo2JDkd+N90VxxdUFU3j1Nt2bbv2XbDsdjEsdjEsdjEsdhk0mMxrSeVJUmzl3cqS5IAA0GS1MzaQJj0V1z8GklyQZJ1SW7qKdsrydVJ7mjPe85kH6dLkgOSfCnJrUluTnJGK59z45HkMUmuS/KdNhZ/3srn3FiMSjIvybeTfLa9npNjkWRVkhuTXD96uWk/YzErAyHJPOAfgRcBhwMnJTl8Zns1rS4Ejtus7C3AF6tqEfDF9nou2AC8oaqeAhwNnNZ+F+bieDwE/E5V/SawGDguydHMzbEYdQZwa8/ruTwWz62qxT33YUx6LGZlIABHASur6rtV9f+Ay4DjZ7hP06aqvgrct1nx8cBFbfki4ITp7NNMqao1VfWttvwg3T/+BczB8WhfUfOT9nLH9ijm4FgAJFkI/Cfggz3Fc3IstmDSYzFbA2EBcE/P65FWNpc9vqrWQPchCew7w/2ZdkkOBp4GfIM5Oh5tiuR6YB1wdVXN2bEA3ge8CfhlT9lcHYsCPp9kRfvqH+hjLKb7qysmakJfcaG5I8muwCeBM6vqgWSsX5Fff1W1EVicZA/giiS/McNdmhFJXgKsq6oVSY6Z4e7MBs+sqtVJ9gWuTnJbP43M1iMEv+LikdYm2Q+gPa+b4f5MmyQ70oXBJVX1qVY8Z8cDoKruB75Md65pLo7FM4GXJllFN6X8O0k+wtwcC6pqdXteB1xBN+0+6bGYrYHgV1w80nLg5LZ8MnDlDPZl2qQ7FPgQcGtVvadn1ZwbjyTz25EBSXYGng/cxhwci6o6q6oWVtXBdJ8P/6eq/pA5OBZJdkmy2+gy8ELgJvoYi1l7p3KSF9PNEY5+xcXZM9uj6ZPkUuAYYB9gLfA24NPA5cCBwN3AiVW1+YnnXztJngX8K3Ajm+aK30p3HmFOjUeSp9KdHJxH98fc5VX1F0n2Zo6NRa82ZfTGqnrJXByLJE+gOyqA7jTAR6vq7H7GYtYGgiRpes3WKSNJ0jQzECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpOb/A1tM7J3zwnCkAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "length = 50\n",
-    "time_log = []\n",
     "for i in range(length):\n",
     "    start = time.time()\n",
     "    ol.download()\n",
@@ -295,7 +248,7 @@
     "%matplotlib inline\n",
     "plt.plot(range(length), time_log, 'ro')\n",
     "plt.title('Bitstream loading time (ms)')\n",
-    "plt.axis([0, length, 0, 2000])\n",
+    "plt.axis([0, length, 0, 1200])\n",
     "plt.show()"
    ]
   }

--- a/pynq/notebooks/common/zynq_clocks.ipynb
+++ b/pynq/notebooks/common/zynq_clocks.ipynb
@@ -25,6 +25,7 @@
      "data": {
       "application/javascript": [
        "\n",
+       "try {\n",
        "require(['notebook/js/codecell'], function(codecell) {\n",
        "  codecell.CodeCell.options_default.highlight_modes[\n",
        "      'magic_text/x-csrc'] = {'reg':[/^%%microblaze/]};\n",
@@ -32,7 +33,27 @@
        "      Jupyter.notebook.get_cells().map(function(cell){\n",
        "          if (cell.cell_type == 'code'){ cell.auto_highlight(); } }) ;\n",
        "  });\n",
-       "});\n"
+       "});\n",
+       "} catch (e) {};\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "try {\n",
+       "require(['notebook/js/codecell'], function(codecell) {\n",
+       "  codecell.CodeCell.options_default.highlight_modes[\n",
+       "      'magic_text/x-csrc'] = {'reg':[/^%%pybind11/]};\n",
+       "  Jupyter.notebook.events.one('kernel_ready.Kernel', function(){\n",
+       "      Jupyter.notebook.get_cells().map(function(cell){\n",
+       "          if (cell.cell_type == 'code'){ cell.auto_highlight(); } }) ;\n",
+       "  });\n",
+       "});\n",
+       "} catch (e) {};\n"
       ]
      },
      "metadata": {},
@@ -40,30 +61,17 @@
     }
    ],
    "source": [
-    "import os, warnings\n",
-    "from pynq import PL\n",
-    "from pynq import Overlay\n",
+    "from pynq.overlays.base import BaseOverlay\n",
     "\n",
-    "if PL.bitfile_name == None or not os.path.exists(PL.bitfile_name):\n",
-    "    warnings.warn('There is no overlay loaded after boot.', UserWarning)"
+    "ol = BaseOverlay(\"base.bit\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "**Note**: If you see a warning message in the above cell, it means that no overlay\n",
-    "has been loaded after boot, hence the PL server is not aware of the \n",
-    "current status of the PL. In that case you won't be able to run this notebook\n",
-    "until you manually load an overlay at least once using:\n",
-    "\n",
-    "```python\n",
-    "from pynq import Overlay\n",
-    "ol = Overlay('your_overlay.bit')\n",
-    "```\n",
-    "\n",
-    "If you do not see any warning message, you can safely proceed.\n",
-    "\n",
     "### Show All Clocks\n",
     "\n",
     "The following example shows all the current clock rates on the board. "
@@ -73,7 +81,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [
     {
@@ -143,15 +151,14 @@
    "metadata": {},
    "source": [
     "### Reset Clock Rates\n",
-    "Recover the original clock rates. This can be done by simply reloading the overlay\n",
-    "(overlay will be downloaded automatically after instantiation)."
+    "Recover the original clock rates. This can be done by simply reloading the overlay."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [
     {
@@ -166,7 +173,7 @@
     }
    ],
    "source": [
-    "_ = Overlay(PL.bitfile_name)\n",
+    "ol.download()\n",
     "\n",
     "print(f'FCLK0: {Clocks.fclk0_mhz:.6f}MHz')\n",
     "print(f'FCLK1: {Clocks.fclk1_mhz:.6f}MHz')\n",


### PR DESCRIPTION
* Removed PL from asyncio_buttons notebook, imported but not used
* Now load overlay directly in zynq_clocks and download_overlay notebooks, instead of relying on a preloaded one with PL.