### PR TITLE
remove jupyter dependcy for bootpy

### DIFF
--- a/sdbuild/packages/bootpy/bootpy.service
+++ b/sdbuild/packages/bootpy/bootpy.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Executing boot.py from the boot partition
-Requires=jupyter.service
-After=jupyter.service boot.mount
+After=boot.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This makes bootpy and jupyter services run in parallel, bringing up initial overlay that blinks the LEDs faster (especially on Z2).