### PR TITLE
DMA: incorporate array offset into descriptors

### DIFF
--- a/pynq/lib/dma.py
+++ b/pynq/lib/dma.py
@@ -410,9 +410,9 @@ class _SGDMAChannel:
             remain -= d_len
 
             # Buffer address (64-bit)
-            self._descr[i, 2] = (array.physical_address + (i * blk_size)) & 0xFFFFFFFF
+            self._descr[i, 2] = (array.physical_address + start + (i * blk_size)) & 0xFFFFFFFF
             self._descr[i, 3] = (
-                (array.physical_address + (i * blk_size)) >> 32
+                (array.physical_address + start + (i * blk_size)) >> 32
             ) & 0xFFFFFFFF
 
             # First block


### PR DESCRIPTION
See https://github.com/Xilinx/PYNQ/issues/1392

Array offset was ignored when filling out descriptors but was used as expected when checking for alignment ([Line 355](https://github.com/Xilinx/PYNQ/blob/master/pynq/lib/dma.py#L355)).

