### PR TITLE
Moving the location of global state file saving

### DIFF
--- a/pynq/__init__.py
+++ b/pynq/__init__.py
@@ -17,7 +17,7 @@ from .registers import Register
 from .uio import UioController
 
 __all__ = ["lib", "tests"]
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 # This ID will always be tied to a specific release tag
 # since the file will be modified to edit the version
 __git_id__ = "$Id$"


### PR DESCRIPTION
This PR moves the saving of the global state file to after bitstream download to avoid issues in certain interleaving of different overlay downloads.