### PR TITLE
Resolves: Exception when an interrupt controller is in a hierarchy

### DIFF
--- a/pynq/metadata/interrupt_controllers_view.py
+++ b/pynq/metadata/interrupt_controllers_view.py
@@ -86,17 +86,17 @@ class InterruptControllersView(MetadataView):
             controller_list = controller_list + self._walk_for_irq_controllers(ps_irq)
 
         for controller in controller_list:
-            repr_dict[controller.name] = {}
-            repr_dict[controller.name]["parent"] = ""
+            repr_dict[controller.hierarchy_name] = {"name": controller.name}
+            repr_dict[controller.hierarchy_name]["parent"] = ""
             if "interrupt_controller_index" in controller.ext:
-                repr_dict[controller.name]["index"] = controller.ext[
+                repr_dict[controller.hierarchy_name]["index"] = controller.ext[
                     "interrupt_controller_index"
                 ].index
             else:
                 raise RuntimeError(
                     f"Cannot determine the index for interrupt controller {controller.ref}"
                 )
-            repr_dict[controller.name]["raw_irq"] = ps.irq_map[
+            repr_dict[controller.hierarchy_name]["raw_irq"] = ps.irq_map[
                 controller.ext["interrupt_controller_index"].index
             ]
 

--- a/pynq/metadata/interrupt_pins_view.py
+++ b/pynq/metadata/interrupt_pins_view.py
@@ -44,7 +44,7 @@ class InterruptPinsView(MetadataView):
 
         pins = []
         for ctrler_name in self._controllers:
-            irq_controller = self._md.blocks[ctrler_name]
+            irq_controller = self._md.blocks[self._controllers[ctrler_name]["name"]]
             if "intr" in irq_controller.ports:
                 pins = pins + self._walk_for_irq_pins(
                     irq_controller.ports["intr"].sig()
@@ -95,7 +95,7 @@ class InterruptPinsView(MetadataView):
 
         for ctrler_name in self._controllers:
             pins = []
-            irq_controller = self._md.blocks[ctrler_name]
+            irq_controller = self._md.blocks[self._controllers[ctrler_name]["name"]]
             if "intr" in irq_controller.ports:
                 pins = pins + self._walk_for_irq_pins(
                     irq_controller.ports["intr"].sig()


### PR DESCRIPTION
(#1433).

Index 'PL.interrupt_controllers' by the 'hierarchy_name' rather than the 'name' of the controller. 

This can be done in several other ways, such as by changing `interrupt_pins` to use the `name` instead of the `hierarchy_name`. I chose one way pretty much arbitrarily.

It would nice if this issue is resolved, either by this PR or by some other way.