### PR TITLE
Fixed module disappearing outside pr area

### DIFF
--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -275,7 +275,7 @@ class Device(metaclass=DeviceMeta):
         merged_ip_dict = deepcopy(self.ip_dict)
         if type(parser) is HWH:
             for k in merged_ip_dict.copy():
-                if k.startswith(hier):
+                if k == hier or k.startswith(hier + "/"):
                     merged_ip_dict.pop(k)
             for k, v in parser.ip_dict.items():
                 merged_ip_dict[v['fullpath']] = v


### PR DESCRIPTION
Assume that the static area contains the following modules.
- processor(DFX)
- processor_enable
- xyz

When I reconfigured the "processor", the "processor_enable" module disappeared.
It should be correct that it doesn't disappear, so I'll fix it that way.