### PR TITLE
It really looks like these were typos and thus dependencies are missed.

### DIFF
--- a/sdbuild/packages/xrfdc/package/Makefile
+++ b/sdbuild/packages/xrfdc/package/Makefile
@@ -31,7 +31,7 @@ $(EMBEDDEDSW_DIR):
 	git clone https://github.com/Xilinx/embeddedsw \
 		--depth 1 -b $(ESW_VERSION) $(EMBEDDEDSW_DIR)
 
-$(LIB_METAL_INC): $(EMBEDDED_DIR)
+$(LIB_METAL_INC): $(EMBEDDEDSW_DIR)
 	mkdir -p $(LIB_METAL_DIR)/build-libmetal;
 	cd $(LIB_METAL_DIR)/build-libmetal; \
 	cmake .. -Wno-deprecated \

--- a/sdbuild/packages/xsdfec/package/Makefile
+++ b/sdbuild/packages/xsdfec/package/Makefile
@@ -32,7 +32,7 @@ $(EMBEDDEDSW_DIR):
 	git clone https://github.com/Xilinx/embeddedsw \
 		--depth 1 -b $(ESW_VERSION) $(EMBEDDEDSW_DIR)
 
-$(LIB_METAL_INC): $(EMBEDDED_DIR)
+$(LIB_METAL_INC): $(EMBEDDEDSW_DIR)
 	mkdir -p $(LIB_METAL_DIR)/build-libmetal;
 	cd $(LIB_METAL_DIR)/build-libmetal; \
 	cmake .. -Wno-deprecated \


### PR DESCRIPTION
To be honest, I didn't do much more than just:
```
grep -r --include="*akefile" --include="*.mk" --include="*.sh" --include="*.cmake" EMBEDDED_DIR
# exactly two hits; both empty dependencies with no associated targets

grep -r --include="*akefile" --include="*.mk" --include="*.sh" --include="*.cmake" EMBEDDEDSW_DIR
# 23 hits including defining the variable and an associated recipe
```

I won't pretend to understand the full build system, so it's entirely possible that this is actually intentional and there's some meta-scripting magic making this all work.  Looks like a typo though.