### PR TITLE
Devcontainer support for SD build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/devcontainers/base:focal
+RUN dpkg --add-architecture i386
+RUN \
+    apt update && \
+    apt install -y \
+    libxtst6 libx11-6 libtinfo-dev libxrender-dev libfreetype6 libxi6
+
+RUN \
+    apt install -y \
+    libncurses5 wget git xterm \
+    libncurses5-dev libncursesw5-dev \
+    lib32ncurses6 autoconf libtool\
+    texinfo gcc-multilib nano
+RUN locale-gen en_US.utf8 && update-locale
+RUN \
+    apt install -y \
+    software-properties-common lsb-core
+WORKDIR /tmp/work
+COPY ./sdbuild/scripts/setup_host.sh .
+RUN chmod +x setup_host.sh
+RUN /bin/sh -c /tmp/work/setup_host.sh
+RUN rm -r /tmp/work/*
+LABEL reference="https://superuser.com/questions/715722/how-to-do-dpkg-reconfigure-dash-as-bash-automatically"
+RUN echo "dash dash/sh boolean false" | debconf-set-selections
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:focal",
+	"build" : {
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
+	
+	"features": {
+		// "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {
+		// 	"clean_ppas": true,
+		// 	"preserve_apt_list": true,
+		// 	"packages": "build-essential",
+		// 	"ppas": "ppa:deadsnakes/ppa"
+		// },
+		// "ghcr.io/devcontainers-contrib/features/apt-packages:1": {
+		// 	"clean_ppas": true,
+		// 	"preserve_apt_list": true,
+		// 	"packages": "build-essential",
+		// 	"ppas": "ppa:deadsnakes/ppa"
+		// },
+		// "ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	"privileged": true,
+	// "capAdd": ["SYS_ADMIN"],
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	"mounts": [
+		"source=/tools/Xilinx,target=/tools/Xilinx,readonly,type=bind,consistency=cached"
+	]
+}


### PR DESCRIPTION
It would be really nice to have docker container environment for SD build flow. 
Since it will be more lighter than pure virtual machine and get benefit from prebuilt image.

This configuration expects the Xilinx tools all installed in default location `tools/Xilinx` in host. But users can change path if they want to.