### PR TITLE
[Debugbridge] hotfix for driver initialization

### DIFF
--- a/pynq/lib/debugbridge.py
+++ b/pynq/lib/debugbridge.py
@@ -206,7 +206,7 @@ class DebugBridge(DefaultIP):
         description : dict
             The entry in the IP dict describing the DMA engine
         """
-        if type(description) is not ReprDict:
+        if type(description) not in [dict, ReprDict]:
             raise RuntimeError('Description is not valid', str(description))
 
         # Insert register dict as they are not provided in the IP descriptor


### PR DESCRIPTION
Allows `description` to be a `dict` instead of `ReprDict`. Fixes https://github.com/Xilinx/PYNQ/issues/1429.