### PR TITLE
restrict numpy requirement to <2.0 due to recent Numpy release issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ required = [
     "pynqmetadata>=0.0.1",
     "setuptools>=24.2.0",
     "cffi",
-    "numpy",
+    "numpy<2.0",
     "nest_asyncio",
 ]
 


### PR DESCRIPTION
Numpy 2.0 causes issues for various python packages, with this PR we restrict install to <2.0 until the ecosystem catches up.