### PR TITLE
Update qemu download source

### DIFF
--- a/sdbuild/scripts/setup_host.sh
+++ b/sdbuild/scripts/setup_host.sh
@@ -91,7 +91,7 @@ sudo make install
 cd ..
 
 qemuver="5.2.0"
-wget http://wiki.qemu-project.org/download/qemu-$qemuver.tar.bz2
+wget http://download.qemu.org/qemu-$qemuver.tar.bz2
 tar -xf qemu-$qemuver.tar.bz2
 cd qemu-$qemuver
 ./configure --target-list=arm-linux-user,aarch64-linux-user \


### PR DESCRIPTION
When running `setup_host.sh` I found that I cannot access `wiki.qemu-project.org` when downloading qemu 5.2.0 source. The official qemu download source has been changed to `download.qemu.org`. 