### PR TITLE
Update overlay_tutorial.ipynb

### DIFF
--- a/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
+++ b/docs/source/overlay_design_methodology/overlay_tutorial.ipynb
@@ -530,7 +530,7 @@
    "source": [
     "To mitigate this the overlay developer can provide a custom class for their overlay to expose the subsystems in a more user-friendly way.  The base overlay includes custom overlay class which performs the following functions:\n",
     " * Make the AXI GPIO devices better named and range/direction restricted\n",
-    " * Make the IOPs accessible through the `pmoda`, `pmodb` and `ardiuno` names\n",
+    " * Make the IOPs accessible through the `pmoda`, `pmodb` and `arduino` names\n",
     " * Create a special class to interact with RGB LEDs\n",
     " \n",
     "The result is that the LEDs can be accessed like:"


### PR DESCRIPTION
I found a spelling error in the phrase: 'Make the IOPs accessible through the pmoda, pmodb, and arduino names.