### PR TITLE
Update Alveo support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,7 @@ In Linux, you can rebuild the overlay by running *make* in the corresponding ove
 
 ## Alveo support
 
-Starting from PYNQ version `2.5.1`, Alveo support has also been introduced. It is now possible to use PYNQ to tap into the potential of hardware acceleration in the data center space.
-
-To get PYNQ on an Alveo-enabled system, simply install it through PIP:
-
-```console
-pip install pynq
-```
-
-For Alveo cards, PYNQ currently requires a <a href="https://github.com/Xilinx/XRT" target="_blank">Xilinx Runtime (XRT)</a> version above or equal to `2.3` to be installed in the system. In terms of Operating System, any XRT-supported version of either RedHat/CentOS or Ubuntu can be used.
-
-For more information, please see the Alveo <a href="https://pynq.readthedocs.io/en/latest/getting_started/alveo_getting_started.html" target="_blank">getting started guide</a>.
+This version of PYNQ **does not** support Alveo.  Alveo is supported from PYNQ version `2.5.1` to `3.0.1`. For more information, check the [documentation](https://pynq.readthedocs.io/en/v3.0.0/getting_started/alveo_getting_started.html) for these versions.
 
 ## Contribute
 

--- a/docs/source/appendix/glossary.rst
+++ b/docs/source/appendix/glossary.rst
@@ -6,7 +6,7 @@ A-G
 ===
   
   Alveo
-   `Xilinx Alveo™ Data Center accelerator cards <https://www.xilinx.com/products/boards-and-kits/alveo.html>`_ with their ready to go applications deliver a much-needed increase in compute capability, at lowest Total Cost of Ownership (TCO), for the broadest range of workloads.
+   `Xilinx Alveo™ Data Center accelerator cards <https://www.amd.com/en/products/accelerators/alveo.html>`_ with their ready to go applications deliver a much-needed increase in compute capability, at lowest Total Cost of Ownership (TCO), for the broadest range of workloads.
 
   APSOC
    All Programmable System on Chip

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -4,7 +4,7 @@ Getting Started
 
 You need a supported AMD-Xilinx platform to get started. How you get PYNQ depends
 on your platform. For some Zynq|Zynq Ultrascale+ platforms you can download 
-an SD card image to boot the board. For other platforms, including Alveo and Kria
+an SD card image to boot the board. For other platforms, including Kria
 SoMs, you can install PYNQ onto your host Operating System. 
 
 If you have one of the following boards, you can follow the quick start guide.
@@ -34,6 +34,8 @@ Kria SoMs
 
 Alveo and XRT supported platforms
 =================================
+
+This version of PYNQ **does not** support Alveo.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/getting_started/alveo_getting_started.rst
+++ b/docs/source/getting_started/alveo_getting_started.rst
@@ -4,14 +4,17 @@
 Alveo Getting Started Guide
 ***************************
 
+This version of PYNQ **does not** support Alveo.
+
 Prerequisites
 =============
-
+  * PYNQ on Alveo is **only supported** by PYNQ versions ``2.5.1``, ``2.6.1``, 
+  ``2.7.0``, ``3.0.0`` and ``3.0.1``. PYNQ version ```3.1`` and newer do not support Alveo cards.
   * A version of the `Xilinx Runtime <https://github.com/Xilinx/XRT>`_ (XRT) 
-    above or equal ``2.3`` installed in the system. Previous versions of XRT 
-    might still work, but are not explicitly supported. Moreover, the  
-    functionalities offered by the Embedded Runtime Library (ERT) will not work 
-    with versions of XRT below ``2.3``.
+    above or equal ``2.3`` and less or equal to ``2.17`` installed in the system.
+    Previous versions of XRT  might still work, but are not explicitly supported. 
+    Moreover, the functionalities offered by the Embedded Runtime Library (ERT)
+    will not work with versions of XRT below ``2.3``.
   * Any XRT-supported version of either RedHat/CentOS or Ubuntu as Operating 
     System
   * Python and PIP must be installed. The minimum Python version is ``3.5.2``, 

--- a/docs/source/getting_started/pynq_alveo.rst
+++ b/docs/source/getting_started/pynq_alveo.rst
@@ -1,8 +1,10 @@
 PYNQ on XRT Platforms
 =====================
 
-Starting from version ``2.5.1`` PYNQ supports XRT-based platforms including 
-Amazon's AWS F1 and Alveo for cloud and on-premise deployment.
+This version of PYNQ **does not** support Alveo.
+
+Starting from version ``2.5.1`` and ending with version ``3.0.1`` PYNQ supports
+XRT-based platforms including Amazon's AWS F1 and Alveo for cloud and on-premise deployment.
 If you are new to PYNQ we recommend browsing the rest of the documentation to
 fully understand the core PYNQ concepts as these form the foundation of PYNQ
 on XRT platforms. Here we will explore the changes made to bring PYNQ into the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,8 +9,7 @@ PYNQ Introduction
 
 PYNQ is an open-source project from AMD. It provides a Jupyter-based 
 framework with Python APIs for using AMD Xilinx Adaptive Computing platforms. 
-PYNQ supports Zynq® and Zynq Ultrascale+™, Zynq RFSoC™, Kria™ SOMs, Alveo™ 
-and AWS-F1 instances. 
+PYNQ supports Zynq® and Zynq Ultrascale+™, Zynq RFSoC™ and Kria™ SOMs. 
 
 PYNQ enables architects, engineers
 and programmers who design embedded systems to use Adaptive Computing 
@@ -58,8 +57,7 @@ PYNQ Background
   operating system.  This goal is achieved by adopting a web-based architecture,
   which is also browser agnostic.  We incorporate the open-source Jupyter
   notebook infrastructure to run an Interactive Python (IPython) kernel and a
-  web server directly on the ARM processor of the Zynq device, or host processor
-  in the case of Alveo and AWS-F1.  The web server
+  web server directly on the ARM processor of the Zynq device. The web server
   brokers access to the kernel via a suite of browser-based tools that provide a
   dashboard, bash terminal, code editors and Jupyter notebooks.  The browser
   tools are implemented with a combination of JavaScript, HTML and CSS and run

--- a/docs/source/overlay_design_methodology.rst
+++ b/docs/source/overlay_design_methodology.rst
@@ -26,12 +26,11 @@ There are a number of components required in the process of creating an overlay:
   * Python Packaging
   
 While they are conceptually similar, there are differences in the process for 
-building Overlays for different platforms. i.e. Zynq vs. Zynq Ultrascale+ vs. 
-Kria SoM vs. Alveo platforms. Most of the differences relate to the configuration of the 
+building Overlays for different platforms. i.e., Zynq vs. Zynq Ultrascale+ vs. 
+Kria SoM. Most of the differences relate to the configuration of the 
 Zynq/Zynq Ultrascale+ PS, and the interfaces between the host processor and the
-programmable logic. E.g. AXI interfaces for ARM & Zynq/Zynq Ultrascale+/Kria SoM, and 
-PCIe for x86|IBM|ARM|etc. for Alveo. Most of the differences will be related to
-the hardware (Programmable logic) design.
+programmable logic. E.g., AXI interfaces for ARM & Zynq/Zynq Ultrascale+/Kria SoM.
+Most of the differences will be related to the hardware (Programmable logic) design.
 
 This section will give an overview of the process of creating an overlay and
 integrating it into PYNQ, but will not cover the hardware design process in

--- a/docs/source/overlay_design_methodology/python_packaging.rst
+++ b/docs/source/overlay_design_methodology/python_packaging.rst
@@ -50,19 +50,18 @@ device.
 Link File Processing
 --------------------
 
-In place of xclbin files for Alveo cards your repository can instead contain
-xclbin.link files which provide locations where xclbin files can be downloaded
-for particular shells. For more details on the link format see the 
-:ref:`pynq-utils` documentation. xclbin.link files alongside notebooks will be 
+In place of bit files your repository can instead contain
+bit.link files which provide locations where bit files can be downloaded
+for particular boards. For more details on the link format see the 
+:ref:`pynq-utils` documentation. bit.link files alongside notebooks will be 
 resolved when the ``pynq get-notebooks`` command is run. If you would prefer 
-to have the xclbin files downloaded at package install time, we provide a 
+to have the bit files downloaded at package install time, we provide a 
 ``download_overlays`` setuptools command that you can call as part of your 
 installation or the ``pynq.utils.build_py`` command which can be used in-place 
 of the regular ``build_py`` command to perform the downloading automatically.
 
-By default the ``download_overlays`` command will only download xclbin files
-for the boards installed in the machine. This can be overridden with
-the ``--download-all`` option.
+By default the ``download_overlays`` command will only download bit files
+for your board. This can be overridden with the ``--download-all`` option.
 
 Example Setup Script
 --------------------

--- a/docs/source/pynq_sd_card.rst
+++ b/docs/source/pynq_sd_card.rst
@@ -5,9 +5,7 @@ PYNQ SD Card image
 ******************
 
 This page will explain how SD card images can be built for PYNQ
-embedded platforms (Zynq, Zynq Ultrascale+, Zynq RFSoC). SD card images are
-not used with Alveo and other PCI-express connected platforms. For those
-datacenter platforms, only PYNQ software is installed on the host OS. 
+embedded platforms (Zynq, Zynq Ultrascale+, Zynq RFSoC).
 
 Note: the PYNQ images for supported boards are provided as precompiled 
 downloadable SD card images and do not need rebuilt.  The SD card build flow is


### PR DESCRIPTION
Update Alveo documentation, to indicate supported versions.

Addressing in part this https://discuss.pynq.io/t/pynq-xrt-version-compatibility/7832