### PR TITLE
Update rgb2dvi_clocks.xdc

### DIFF
--- a/boards/ip/rgb2dvi_v1_2/src/rgb2dvi_clocks.xdc
+++ b/boards/ip/rgb2dvi_v1_2/src/rgb2dvi_clocks.xdc
@@ -1,2 +1,2 @@
 ### Clock constraints ###
-create_generated_clock -source [get_ports PixelClk] -multiply_by 5 [get_ports SerialClk]
+#create_generated_clock -source [get_ports PixelClk] -multiply_by 5 [get_ports SerialClk]


### PR DESCRIPTION
Fix "CRITICAL WARNING: [Timing 38-249] Generated clock base_i/video/hdmi_out/frontend/rgb2dvi_0/U0/SerialClk has no logical paths from master clock axi_dynclk_0_PXL_CLK_O."

Signed-off-by: Dzung Hoang <dthoang@yahoo.com>
