### PR TITLE
Base DTBO File Copy

### DIFF
--- a/sdbuild/packages/pynq/pre.sh
+++ b/sdbuild/packages/pynq/pre.sh
@@ -43,8 +43,8 @@ if [ "$BOARDDIR" != "$DEFAULT_BOARDDIR" ] && [ "$PYNQ_BOARD" != "Unknown" ]; the
     for ol in $overlays ; do
 	ol_name=`basename $ol`
 	sudo mkdir -p $pynqoverlays_dir/$ol_name
-	sudo cp -fL $ol/*.bit $ol/*.hwh $ol/*.py $pynqoverlays_dir/$ol_name
-	
+	sudo cp -fL $ol/*.bit $ol/*.hwh $ol/*.py $ol/*.dtbo $pynqoverlays_dir/$ol_name
+
 	if [ -e $ol_name/notebooks ]; then
 		sudo mkdir -p $target/home/xilinx/pynq_git/notebooks/$ol_name
 		sudo cp -fLr $ol_name/notebooks/* $target/home/xilinx/pynq_git/notebooks/$ol_name


### PR DESCRIPTION
During the image creation when the base.bit, base.hwh, and base.py are added to the image, the AUP-ZU3 needs to also include the DTBO for the the I2C device for the MIPI camera.  Including it here allows the mipi_displayport notebook for the AUP-ZU3 to load the base.bit and run without requiring the user to copy over the dtbo separately/manually.