### PR TITLE
fix: update load_ip_data to pull address from base_address instead of addr_range

### DIFF
--- a/pynq/pl_server/device.py
+++ b/pynq/pl_server/device.py
@@ -233,7 +233,7 @@ class Device(metaclass=DeviceMeta):
         ip_dict = self.ip_dict
         mem_dict = self.mem_dict
         if ip_name in ip_dict:
-            address = ip_dict[ip_name]["addr_range"]
+            address = ip_dict[ip_name]["base_address"]
             target_size = ip_dict[ip_name]["addr_range"]
         elif ip_name in mem_dict:
             address = mem_dict[ip_name]["base_address"]


### PR DESCRIPTION
Currently in load_ip_data, if the IP exists in the ip_dict the address is invalid as it's made equal to the "addr_range" instead of "base_address"