### PR TITLE
fixing <4KB buffer allocation issue

### DIFF
--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -335,8 +335,14 @@ class XrtDevice(Device):
         flags = pyxrt.bo.flags.normal
         if cacheable:
             flags = pyxrt.bo.flags.cacheable
+        
+        # Workaround for XRT v2.17 4KB threshold issue:
+        # Small buffers (<4KB) get 64-bit addresses, large buffers (>=4KB) get 32-bit addresses
+        # Force minimum allocation of 8KB to ensure 32-bit addresses for DMA compatibility
+        actual_size = max(size, 8192)  # 8KB minimum
+        
         try: 
-            bo = pyxrt.bo(self.handle, size, flags,idx)
+            bo = pyxrt.bo(self.handle, actual_size, flags, idx)
         except Exception as e:
             raise RuntimeError(f"BO allocation failed: {e}")
         if bo is None:


### PR DESCRIPTION
Fixed an issue seen on aarch64 devices where XRT 2.17 was allocating 64-bit addresses for any buffer under or equal to 4KB. Any allocation over 4KB always received a 32-bit addressed buffer. 

This was causing issues with DMAs that were configured with 32-bit address widths (e.g. the RFSoC4x2 CMAC loopback demo). 

This fix forces an 8KB minimum allocation to ensure all buffers get 32-bit addresses, while maintaining correct transfer sizes.

Tested with a DMA loopback overlay on RFSoC4x2 using PYNQ v3.1 with various buffer widths.

