### PR TITLE
fixed dtbo copy issue with pynq package

### DIFF
--- a/sdbuild/packages/pynq/pre.sh
+++ b/sdbuild/packages/pynq/pre.sh
@@ -43,7 +43,12 @@ if [ "$BOARDDIR" != "$DEFAULT_BOARDDIR" ] && [ "$PYNQ_BOARD" != "Unknown" ]; the
     for ol in $overlays ; do
 	ol_name=`basename $ol`
 	sudo mkdir -p $pynqoverlays_dir/$ol_name
-	sudo cp -fL $ol/*.bit $ol/*.hwh $ol/*.py $ol/*.dtbo $pynqoverlays_dir/$ol_name
+	sudo cp -fL $ol/*.bit $ol/*.hwh $ol/*.py $pynqoverlays_dir/$ol_name
+
+    # Copy device tree overlays if they exist
+    if [ -f $ol/*.dtbo ]; then
+        sudo cp -fL $ol/*.dtbo $pynqoverlays_dir/$ol_name
+    fi
 
 	if [ -e $ol_name/notebooks ]; then
 		sudo mkdir -p $target/home/xilinx/pynq_git/notebooks/$ol_name


### PR DESCRIPTION
Fixed issue in pynq package where if dtbo files didn't exist in the repo the image build process would fail.