### PR TITLE
fix PuTTY link in terminal.rst

### DIFF
--- a/docs/source/getting_started/terminal.rst
+++ b/docs/source/getting_started/terminal.rst
@@ -5,7 +5,7 @@ If you can't access the terminal from Jupyter, you can connect the micro-USB
 cable from your computer to the board and open a terminal. You can use the
 terminal to check the network connection of the board. You will need to have
 terminal emulator software installed on your computer. `PuTTY
-<http://www.putty.org/>`_ is one application that can be used, and is available
+<http://putty.software/>`_ is one application that can be used, and is available
 for free on Windows. To open a terminal, you will need to know the COM port for
 the board.
 


### PR DESCRIPTION
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803