### PR TITLE
fix: register binfmts for arm/aarch64 in dockerfile

### DIFF
--- a/sdbuild/Dockerfile
+++ b/sdbuild/Dockerfile
@@ -88,6 +88,10 @@ RUN useradd -m ${USERNAME} \
 ENV PATH="/opt/qemu/bin:/opt/crosstool-ng/bin:${PATH}"
 ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libudev.so.1
 
+# Register binfmt to allow run ARM elf on x86
+RUN update-binfmts --enable qemu-arm
+RUN update-binfmts --enable qemu-aarch64
+
 # Switch to non-root user
 USER ${USERNAME}
 WORKDIR /workspace


### PR DESCRIPTION
When the package `qemu-user-static` is installed, the ARM ISA support `qemu-arm/aarch64` may not be registered automatically. This will cause a runtime error (`Format Error`) when `install_packages.sh` invokes `.... bash qemu.sh`.

 So register them explicitly in Dockerfile.