### PR TITLE
fix bug with caching of metadata/HWH

### DIFF
--- a/pynq/pl_server/embedded_device.py
+++ b/pynq/pl_server/embedded_device.py
@@ -646,6 +646,7 @@ class EmbeddedDevice(XrtDevice):
             
             if os.path.exists(bitstream.bitfile_name):
                 gs=GlobalState(bitfile_name=str(bitstream.bitfile_name),
+                                 bitfile_hash=bitstream_hash(bitstream.bitfile_name),
                                  timestamp=ts,
                                  active_name=self.name,
                                  psddr=parser.mem_dict.get("PSDDR", {}))

--- a/pynq/pl_server/global_state.py
+++ b/pynq/pl_server/global_state.py
@@ -46,7 +46,6 @@ class GlobalState(BaseModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.bitfile_hash = bitstream_hash(self.bitfile_name)
 
 def initial_global_state_file_boot_check(device_tag="")->None:
     """ Performs a check to see if this is a coldstart, if it is then clear the


### PR DESCRIPTION
Fixes #1409.

With this change, `GlobalState.bitfile_hash` is whatever is in the `global_pl_state.json` file if the state was loaded from JSON, and is passed in through the constructor otherwise.

Previously it was always freshly computed at instantiation; if loading from JSON this meant that the "hash of the cached bitfile" was being overwritten by "the hash of the bitfile at the location the cached bitfile was loaded from." The result was that in some situations the cached metadata would be reused even if the newly loaded bitfile was actually different.