### PR TITLE
pyxrt close() fix

### DIFF
--- a/pynq/pl_server/xrt_device.py
+++ b/pynq/pl_server/xrt_device.py
@@ -388,8 +388,6 @@ class XrtDevice(Device):
 
 
     def close(self):
-        if self.handle:
-            self.handle.close()
         self.handle = None
 
     def get_memory(self, desc):


### PR DESCRIPTION
Fixes #1496 

The old `xrt` Python bindings required explicit cleanup of handles. This is no longer the case in the new `pyxrt`, which does not have the same functionality. This was causing issues with PYNQ code where `device.close()` was called.