### PR TITLE
removed device.close() call in Overlay.free()

### DIFF
--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -393,7 +393,6 @@ class Overlay(Bitstream):
     def free(self):
         if self.dtbo:
             self.remove_dtbo()
-        self.device.close()
 
     def gen_cache(self):
         """ Generate a pickled cache of the metadata even if a download has not occurred """


### PR DESCRIPTION
[This commit](https://github.com/Xilinx/PYNQ/commit/45bfb55a2578294ca67dfde8570abbaf9b8de156) removed `device.close()` calls, but missed one in `Overlay.free()`, which was causing a deprecation warning to show when a user freed the overlay.