### PR TITLE
Removed check for neg. address and changed offset calculation in mmio.cc, as it limits ZYNQ-7 boards

### DIFF
--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/mmio.cc
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/mmio.cc
@@ -5,9 +5,9 @@
 MMIO::MMIO(off_t base_address, size_t length_p)
     : mem_fd(-1), virt_base(0), virt_offset(0), length(0), mapped_base(nullptr)
 {
-    if (base_address < 0 || length_p < 0)
+    if (length_p < 0)
     {
-        std::cerr << "Error: Base address or length cannot be negative." << std::endl;
+        std::cerr << "Error: Length cannot be negative." << std::endl;
         return;
     }
     mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
@@ -17,7 +17,7 @@ MMIO::MMIO(off_t base_address, size_t length_p)
         return;
     }
     virt_base = base_address & ~(4096 - 1);
-    virt_offset = base_address - virt_base;
+    virt_offset = base_address & (4096 - 1);
     length = length_p;
 
     mapped_base = mmap(nullptr, length + virt_offset, PROT_READ | PROT_WRITE, MAP_SHARED, mem_fd, virt_base);


### PR DESCRIPTION
The check for negative addresses when allocating the MMIO disables half the address space of the ZYNQ-7000 boards, as all 32-bit are required to map the higher half (for example MAXI_GP1) (off_t is a 32bit integer for arm32).

In addition, the check for negative base addresses still leaves plenty of illegal addresses for the Zynq US+, as the maximum valid address is 40 bit wide.

I would suggest removing the negative base address check and changing the calculation of the virt_off to use a bitwise operation to avoid any overflows.

Signed-off-by: Dirk Stober <dirk.stober@tum.de>