### PR TITLE
Remote GPIO Fix

### DIFF
--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
@@ -13,6 +13,8 @@ SRC_URI = "file://cpp/CMakeLists.txt \
            file://cpp/mmio.h \
            file://cpp/buffer.cc \
            file://cpp/buffer.h \
+           file://cpp/gpio.cc \
+           file://cpp/gpio.h \
            file://protos/buffer.proto \
            file://protos/mmio.proto \
            file://protos/remote_device.proto \


### PR DESCRIPTION
Fixed missing `SRC_URI` GPIO entries  in `pynq-cpp.bb` that were causing remote image build to fail.