### PR TITLE
Fix missing gpio.proto dependency in pynq-cpp.bb

### DIFF
--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
@@ -16,6 +16,7 @@ SRC_URI = "file://cpp/CMakeLists.txt \
            file://cpp/gpio.cc \
            file://cpp/gpio.h \
            file://protos/buffer.proto \
+           file://protos/gpio.proto \
            file://protos/mmio.proto \
            file://protos/remote_device.proto \
            file://cmake/common.cmake \


### PR DESCRIPTION
Added a missing dependency of gpio.proto in `pynq-cpp.bb` file that caused build process to fail.