### PR TITLE
Allow to read mac address from spi flash

### DIFF
--- a/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0004-allow-to-read-mac-address-from-SPI-flash.patch
+++ b/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/files/0004-allow-to-read-mac-address-from-SPI-flash.patch
@@ -1,0 +1,107 @@
+diff --git a/arch/arm/mach-zynq/include/mach/sys_proto.h b/arch/arm/mach-zynq/include/mach/sys_proto.h
+index 268ec50ad84..1dc16d479ea 100644
+--- a/arch/arm/mach-zynq/include/mach/sys_proto.h
++++ b/arch/arm/mach-zynq/include/mach/sys_proto.h
+@@ -17,4 +17,6 @@ extern int zynq_slcr_get_mio_pin_status(const char *periph);
+ extern void zynq_ddrc_init(void);
+ extern unsigned int zynq_get_silicon_version(void);
+ 
++int zynq_board_read_rom_ethaddr(unsigned char *ethaddr);
++
+ #endif /* _SYS_PROTO_H_ */
+diff --git a/arch/arm/mach-zynqmp/include/mach/sys_proto.h b/arch/arm/mach-zynqmp/include/mach/sys_proto.h
+index 15b69e77712..02ae59aa69e 100644
+--- a/arch/arm/mach-zynqmp/include/mach/sys_proto.h
++++ b/arch/arm/mach-zynqmp/include/mach/sys_proto.h
+@@ -46,6 +46,7 @@ enum {
+ 	TCM_SPLIT,
+ };
+ 
++int zynq_board_read_rom_ethaddr(unsigned char *ethaddr);
+ unsigned int zynqmp_get_silicon_version(void);
+ 
+ void initialize_tcm(bool mode);
+diff --git a/board/xilinx/common/board.c b/board/xilinx/common/board.c
+index 9641ed307b7..316ce1c8f48 100644
+--- a/board/xilinx/common/board.c
++++ b/board/xilinx/common/board.c
+@@ -18,6 +18,8 @@
+ #include <asm/sections.h>
+ #include <dm/uclass.h>
+ #include <i2c.h>
++#include <spi.h>
++#include <spi_flash.h>
+ #include <linux/sizes.h>
+ #include <malloc.h>
+ #include "board.h"
+@@ -59,6 +61,36 @@ struct efi_capsule_update_info update_info = {
+ 
+ #endif /* EFI_HAVE_CAPSULE_SUPPORT */
+ 
++int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
++{
++	int ret = -EINVAL;
++
++#if defined(CONFIG_ZYNQ_QSPI) && defined(CONFIG_ZYNQ_GEM_SPI_MAC_OFFSET)
++#define CMD_OTPREAD_ARRAY_FAST		0x4b
++	struct spi_flash *flash;
++	flash = spi_flash_probe(CONFIG_SF_DEFAULT_BUS,
++				CONFIG_SF_DEFAULT_CS,
++				CONFIG_SF_DEFAULT_SPEED,
++				CONFIG_SF_DEFAULT_MODE);
++	if (!flash) {
++		printf("SPI(bus:%u cs:%u) probe failed\n",
++			CONFIG_SF_DEFAULT_BUS,
++			CONFIG_SF_DEFAULT_CS);
++		return -ENODEV;
++	}
++	flash->read_opcode = CMD_OTPREAD_ARRAY_FAST;
++	ret = spi_flash_read(flash, CONFIG_ZYNQ_GEM_SPI_MAC_OFFSET, 6, ethaddr);
++	if (ret)
++		debug("%s: SPI EEPROM MAC address read failed\n", __func__);
++	else
++		debug("%s: SPI EEPROM MAC %pM\n", __func__, ethaddr);
++
++	if (flash)
++		spi_flash_free(flash);
++#endif
++	return ret;
++}
++
+ #define EEPROM_HEADER_MAGIC		0xdaaddeed
+ #define EEPROM_HDR_MANUFACTURER_LEN	16
+ #define EEPROM_HDR_NAME_LEN		16
+diff --git a/drivers/net/zynq_gem.c b/drivers/net/zynq_gem.c
+index 7c57d32614f..6342c0b9417 100644
+--- a/drivers/net/zynq_gem.c
++++ b/drivers/net/zynq_gem.c
+@@ -734,6 +734,21 @@ static void zynq_gem_halt(struct udevice *dev)
+ 						ZYNQ_GEM_NWCTRL_TXEN_MASK, 0);
+ }
+ 
++__weak int zynq_board_read_rom_ethaddr(unsigned char *ethaddr)
++{
++	return -ENOSYS;
++}
++
++static int zynq_gem_read_rom_mac(struct udevice *dev)
++{
++	struct eth_pdata *pdata = dev_get_plat(dev);
++
++	if (!pdata)
++		return -ENOSYS;
++
++	return zynq_board_read_rom_ethaddr(pdata->enetaddr);
++}
++
+ static int zynq_gem_miiphy_read(struct mii_dev *bus, int addr,
+ 				int devad, int reg)
+ {
+@@ -949,6 +964,7 @@ static const struct eth_ops zynq_gem_ops = {
+ 	.free_pkt		= zynq_gem_free_pkt,
+ 	.stop			= zynq_gem_halt,
+ 	.write_hwaddr		= zynq_gem_setup_mac,
++	.read_rom_hwaddr	= zynq_gem_read_rom_mac,
+ };
+ 
+ static int zynq_gem_of_to_plat(struct udevice *dev)

--- a/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
+++ b/boards/Pynq-Z2/petalinux_bsp/meta-user/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
@@ -2,6 +2,7 @@ SRC_URI:append = " file://platform-top.h"
 SRC_URI += " file://0001-add-support-for-artyz.patch"
 SRC_URI += " file://0002-add-pynqz1-support.patch"
 SRC_URI += " file://0003-add-pynqz2-support.patch"
+SRC_URI += " file://0004-allow-to-read-mac-address-from-SPI-flash.patch"
 SRC_URI += " file://ethernet_spi.cfg"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"


### PR DESCRIPTION
I noticed that since version 3.1 (when petalinux 2024.1 is used) on the Pynq z2 board the MAC address is not retrieved from the flash memory.

This pull request contains patch which again allows the MAC address to be read from SPI. This patch reverts commit ba74bcf from /Xilinx/u-boot-xlnx/ repo and adds changes which was present in patch until version 3.0.1 (commit d75f95a from PYNQ repo)