### PR TITLE
add ubuntu-keyring sources needed when rebuilding rootfs

### DIFF
--- a/sdbuild/Dockerfile
+++ b/sdbuild/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /tmp
 
-# Enable source repo for ubuntu-keyring
+# Enable source repo for ubuntu-keyring (needed for rootfs multistrap)
 RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ jammy main" > /etc/apt/sources.list.d/multistrap.list
 
 # Enable i386 architecture and install core dependencies
@@ -35,8 +35,6 @@ RUN dpkg --add-architecture i386 \
     rsync python3-pip gcc-multilib xterm net-tools ninja-build python3-testresources \
     libncurses5-dev libncursesw5-dev vim nano tmux zip dnsutils sudo binfmt-support \
     dbus-x11 libswt-glx-gtk-4-jni libgtk2.0-0 xvfb lsb-core \
- # Install ubuntu-keyring sources needed for multistrap
- && apt-get source -y ubuntu-keyring \
  # Locale for Vivado
  && locale-gen en_US.utf8 && update-locale \
  # Clean up APT

--- a/sdbuild/Dockerfile
+++ b/sdbuild/Dockerfile
@@ -13,6 +13,9 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /tmp
 
+# Enable source repo for ubuntu-keyring
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ jammy main" > /etc/apt/sources.list.d/multistrap.list
+
 # Enable i386 architecture and install core dependencies
 RUN dpkg --add-architecture i386 \
  && apt-get update && apt-get upgrade -y \
@@ -20,6 +23,8 @@ RUN dpkg --add-architecture i386 \
  # Add toolchain PPA
  && add-apt-repository -y ppa:ubuntu-toolchain-r/ppa \
  && apt-get update \
+ # Configures timezone interactively (2: Americas, 37: Central)
+ && echo -e '2\n37\n' | apt-get install -y tzdata \
  # Install build and host packages
  && apt-get install -y \
     bc libtool-bin gperf bison flex texi2html texinfo help2man gawk libtool \
@@ -29,9 +34,9 @@ RUN dpkg --add-architecture i386 \
     libsdl1.2-dev libpixman-1-dev libc6-dev chrpath socat zlib1g-dev unzip \
     rsync python3-pip gcc-multilib xterm net-tools ninja-build python3-testresources \
     libncurses5-dev libncursesw5-dev vim nano tmux zip dnsutils sudo binfmt-support \
-    dbus-x11 libswt-glx-gtk-4-jni libgtk2.0-0 xvfb \
- # Configures timezone interactively (2: Americas, 37: Central)
- && echo -e '2\n37\n' | apt-get install -y lsb-core \
+    dbus-x11 libswt-glx-gtk-4-jni libgtk2.0-0 xvfb lsb-core \
+ # Install ubuntu-keyring sources needed for multistrap
+ && apt-get source -y ubuntu-keyring \
  # Locale for Vivado
  && locale-gen en_US.utf8 && update-locale \
  # Clean up APT

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -22,6 +22,8 @@ if [ -n "$PYNQ_UBUNTU_REPO" ]; then
   multistrap_conf=$tmpfile
   multistrap_opt=--no-auth
   trap "rm -f $tmpfile" EXIT
+else
+    sudo apt-get update
 fi
 
 # Perform the basic bootstrapping of the image


### PR DESCRIPTION
When building a ZCU208 image with `REBUILD_PYNQ_ROOTFS=1`, multistrap was giving me the same error (`E: Can't find a source to download version '2021.03.26' of 'ubuntu-keyring:amd64'`) reported by https://discuss.pynq.io/t/pynq-image-v3-1-for-pynq-z1-build-fails-during-rootfs-multistrap-ubuntu-keyring-error/8691.

It looks like this error is related to secure apt (https://manpages.ubuntu.com/manpages/jammy/man1/multistrap.1.html#secure-apt) and the fix is to either use `--no-auth` or add the APT repository with the ubuntu-keyring sources before running multistrap. Here I tweak the Dockerfile and create_rootfs.sh to do the latter.

I'm also moving the tzdata configuration into its own command, for ease of understanding - this isn't strictly necessary, it's just something that confused me during debugging.