### PR TITLE
sdbuild/pynq-cpp: PYNQ.remote RF recipes + librfdc rename

### DIFF
--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/CMakeLists.txt
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/CMakeLists.txt
@@ -142,16 +142,13 @@ if(USE_LOCAL_XRT)
     set(XRT_LIBRARIES "/usr/lib/libxrt_core.so")
     set(XRT_ADDITIONAL_LIBRARIES "/usr/lib/libxrt_coreutil.so")
 else()
-    # Hard code default XRT paths
-    # Explicitly set the paths for XRT
-    set(XRT_INCLUDE_DIRS "${BASE_DIR}/build/tmp/sysroots-components/cortexa72-cortexa53/xrt/usr/include")
-    set(XRT_LIBRARIES "${BASE_DIR}/build/tmp/sysroots-components/cortexa72-cortexa53/xrt/usr/lib/libxrt_core.so")
-
-    # Additional XRT libraries (if needed)
-    set(XRT_ADDITIONAL_LIBRARIES "${BASE_DIR}/build/tmp/sysroots-components/cortexa72-cortexa53/xrt/usr/lib/libxrt_coreutil.so")
+    # XRT from the bitbake recipe sysroot.
+    set(XRT_INCLUDE_DIRS "${CMAKE_SYSROOT}/usr/include")
+    set(XRT_LIBRARIES "${CMAKE_SYSROOT}/usr/lib/libxrt_core.so")
+    set(XRT_ADDITIONAL_LIBRARIES "${CMAKE_SYSROOT}/usr/lib/libxrt_coreutil.so")
 endif()
 
-if(EXISTS "${XRT_INCLUDE_DIRS}/xrt/xrt.h" AND EXISTS "${XRT_LIBRARIES}")
+if(EXISTS "${XRT_INCLUDE_DIRS}/xrt/xrt_bo.h" AND EXISTS "${XRT_LIBRARIES}")
     message(STATUS "Found XRT: includes in ${XRT_INCLUDE_DIRS}, libs in ${XRT_LIBRARIES}")
 else()
     message(FATAL_ERROR "Could not find XRT")

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/buffer.h
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/buffer.h
@@ -14,8 +14,6 @@
 #include <cstring>
 #include <sys/mman.h>
 
-#include <xrt/xclhal2.h>
-#include <xrt/xrt.h>
 #include <xrt/xrt_bo.h>
 #include <xrt/xrt_device.h>
 

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/pynq-remote.cc
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/pynq-remote.cc
@@ -40,8 +40,6 @@
 #include "xrfdc.h"
 #endif
 
-#include <xrt/xclhal2.h>
-#include <xrt/xrt.h>
 #include <xrt/xrt_bo.h>
 #include <xrt/xrt_device.h>
 

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/xrfdc.cc
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/cpp/xrfdc.cc
@@ -96,12 +96,9 @@ void libxrfdcManager::loadLibrary() {
     std::cout << "Loading librfdc.so..." << std::endl;
 #endif
 
-    handle_ = dlopen("librfdc.so.3", RTLD_LAZY);
+    handle_ = dlopen("librfdc.so", RTLD_LAZY);
     if (!handle_) {
-        handle_ = dlopen("librfdc.so", RTLD_LAZY);
-        if (!handle_) {
-            throw std::runtime_error(std::string("Failed to load librfdc.so: ") + dlerror());
-        }
+        throw std::runtime_error(std::string("Failed to load librfdc.so: ") + dlerror());
     }
 
     // Load function pointers

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/pynq-remote.service
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/files/pynq-remote.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=PYNQ Remote Server Application
 After=network.target
+StartLimitIntervalSec=0
 
 [Service]
 ExecStart=/usr/bin/pynq-remote
 Restart=always
+RestartSec=5
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=pynq-remote

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-cpp/pynq-cpp.bb
@@ -9,7 +9,7 @@ DEPENDS = "protobuf grpc protobuf-native grpc-native xrt"
 # The PYNQ Makefile writes a per-project bbappend that appends "rfsoc" to
 # PACKAGECONFIG when RFSoC_<board>=1.
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[rfsoc] = "-DRFSOC=ON,-DRFSOC=OFF,rfdc libmetal,rfdc libmetal"
+PACKAGECONFIG[rfsoc] = "-DRFSOC=ON,-DRFSOC=OFF,librfdc libmetal,librfdc libmetal"
 
 SRC_URI = "file://cpp/CMakeLists.txt \
            file://cpp/pynq-remote.cc \

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/README.md
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/README.md
@@ -1,0 +1,45 @@
+# PYNQ.remote tests
+
+Two tests for the PYNQ.remote appliance image, one on each side of the link.
+
+## On-target (`pynq-remote-selftest`)
+
+Baked into the remote image (installed to `/usr/bin` by `pynq-remote-selftest.bb`,
+pulled in via `pynq-remote-image.bb`). Log in on the board and run:
+
+```sh
+pynq-remote-selftest
+```
+
+Checks that the board is ready to serve a remote host — no host connection
+needed: `pynq-remote.service` active and listening on gRPC :7967, `zocl` + XRT
+render node, the FPGA manager, `eth0` address, the `pynq_board` device-tree id,
+and no failed systemd units.
+
+## Off-board (`pynq-remote-hosttest.py`)
+
+Runs on a **host** with the `pynq` package installed and network access to the
+board. It uses the normal PYNQ API (routed to the target via
+`PYNQ_REMOTE_DEVICES`) to exercise the host<->target data paths in both
+directions:
+
+```sh
+python3 pynq-remote-hosttest.py --ip <board-ip>            # core checks
+python3 pynq-remote-hosttest.py --ip <board-ip> --bitstream base.xsa
+```
+
+- **Connect + identity** — open the gRPC channel; read arch/board id (target->host).
+- **File round-trip** — `write_file` then `read_file` (host->target->host).
+- **Buffer round-trip** — `allocate` + `sync_to_device` (host->target) +
+  `sync_from_device` (target->host), verifying data and `physical_address`.
+- **Overlay download** *(with `--bitstream`)* — program the PL (host->target).
+- **MMIO round-trip** *(with `--bitstream`)* — write then read back an AXI GPIO
+  (host->target, target->host).
+
+### Installing the client (host)
+
+The client is the `pynq` package installed in "remote" mode (no C extensions):
+
+```sh
+PYNQ_REMOTE=1 pip install "pynq @ git+https://github.com/Xilinx/PYNQ.git"
+```

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/files/pynq-remote-selftest
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/files/pynq-remote-selftest
@@ -1,0 +1,99 @@
+#!/bin/sh
+# PYNQ.remote on-target self-test. Run on the booted remote appliance.
+
+PORT="${PYNQ_REMOTE_PORT:-7967}"
+
+pass=0; fail=0
+ok()  { echo "  [PASS] $1"; pass=$((pass+1)); }
+bad() { echo "  [FAIL] $1"; fail=$((fail+1)); }
+
+echo "======================================================"
+echo " PYNQ.remote appliance self-test"
+echo " host: $(hostname)   kernel: $(uname -r)"
+echo "======================================================"
+
+echo "[1] pynq-remote service"
+if systemctl is-active --quiet pynq-remote 2>/dev/null; then
+    ok "pynq-remote.service active"
+else
+    bad "pynq-remote.service not active"
+fi
+
+echo "[2] gRPC server listening on :${PORT}"
+hexport=$(printf ':%04X' "${PORT}")
+if command -v ss >/dev/null 2>&1 && ss -ltn 2>/dev/null | grep -q ":${PORT}\b"; then
+    ok "listening on :${PORT} (ss)"
+elif grep -qi "$hexport" /proc/net/tcp /proc/net/tcp6 2>/dev/null; then
+    ok "listening on :${PORT} (/proc/net/tcp)"
+else
+    bad "nothing listening on :${PORT}"
+fi
+
+echo "[3] XRT / zocl (PL access)"
+if lsmod 2>/dev/null | grep -q '^zocl'; then
+    ok "zocl kernel module loaded"
+else
+    bad "zocl kernel module not loaded"
+fi
+if ls /dev/dri/renderD* >/dev/null 2>&1; then
+    ok "XRT render node present ($(ls -d /dev/dri/renderD* 2>/dev/null | tr '\n' ' '))"
+else
+    bad "no /dev/dri/renderD* (zocl device node missing)"
+fi
+if [ -e /usr/bin/xbutil ] || ls /usr/lib/libxrt_core.so* >/dev/null 2>&1; then
+    ok "XRT userspace present"
+else
+    bad "XRT userspace missing"
+fi
+
+echo "[4] FPGA manager (bitstream download)"
+if [ -d /sys/class/fpga_manager/fpga0 ]; then
+    ok "fpga_manager present ($(cat /sys/class/fpga_manager/fpga0/state 2>/dev/null))"
+else
+    bad "/sys/class/fpga_manager/fpga0 missing"
+fi
+
+echo "[5] Networking"
+netinfo=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $2" "$4}' | head -1)
+if [ -n "$netinfo" ]; then ok "network up: $netinfo"; else bad "no interface has a global IPv4 address"; fi
+
+echo "[6] Static MAC from EEPROM (not random/locally-administered)"
+# A random/fallback MAC has the locally-administered bit (0x02) set in the first
+# octet; a real factory MAC (read from the board EEPROM by u-boot) has it clear.
+mac_if=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $2}' | head -1)
+if [ -z "$mac_if" ]; then
+    for n in /sys/class/net/*; do
+        name=${n##*/}
+        case "$name" in lo|usb*|docker*|veth*|sit*) continue ;; esac
+        mac_if=$name; break
+    done
+fi
+mac=$(cat "/sys/class/net/${mac_if}/address" 2>/dev/null)
+if [ -z "$mac" ]; then
+    bad "no ethernet interface with a MAC found"
+else
+    first=$(printf '%d' "0x${mac%%:*}" 2>/dev/null)
+    if [ $((first & 1)) -ne 0 ]; then
+        bad "${mac_if} MAC ${mac} is multicast (invalid unicast address)"
+    elif [ $((first & 2)) -ne 0 ]; then
+        bad "${mac_if} MAC ${mac} is locally-administered (random/fallback, not from EEPROM)"
+    else
+        ok "${mac_if} MAC ${mac} is globally-administered (factory MAC from EEPROM)"
+    fi
+fi
+
+echo "[7] Board identity (read by the remote host client)"
+if [ -e /proc/device-tree/chosen/pynq_board ]; then
+    ok "pynq_board = $(tr -d '\0' < /proc/device-tree/chosen/pynq_board)"
+else
+    bad "/proc/device-tree/chosen/pynq_board missing (host get_board_name() -> Unknown)"
+fi
+
+echo "[8] systemd failed units"
+failed=$(systemctl --failed --no-legend --plain 2>/dev/null | awk '{print $1}' | tr '\n' ' ')
+if [ -z "$failed" ]; then ok "no failed units"; else bad "failed units: $failed"; fi
+
+echo "------------------------------------------------------"
+echo " summary: ${pass} passed, ${fail} failed"
+echo "======================================================"
+[ "$fail" -eq 0 ]

--- a/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/pynq-remote-selftest.bb
+++ b/sdbuild/boot/meta-pynq/recipes-apps/pynq-remote-selftest/pynq-remote-selftest.bb
@@ -1,0 +1,15 @@
+SUMMARY = "PYNQ.remote on-target self-test"
+SECTION = "PETALINUX/apps"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://pynq-remote-selftest"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/pynq-remote-selftest ${D}${bindir}/pynq-remote-selftest
+}
+
+FILES:${PN} += "${bindir}/pynq-remote-selftest"

--- a/sdbuild/boot/meta-pynq/recipes-core/images/pynq-remote-image.bb
+++ b/sdbuild/boot/meta-pynq/recipes-core/images/pynq-remote-image.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Minimal PYNQ.remote appliance image (gRPC PL server)"
+LICENSE = "MIT"
+
+IMAGE_INSTALL = "packagegroup-core-boot kernel-modules xrt zocl pynq-cpp pynq-remote-selftest pynq-remote-network ${CORE_IMAGE_EXTRA_INSTALL}"
+IMAGE_FEATURES += "ssh-server-dropbear"
+IMAGE_LINGUAS = " "
+IMAGE_FSTYPES = "tar.gz"
+IMAGE_ROOTFS_EXTRA_SPACE = "51200"
+
+inherit core-image

--- a/sdbuild/boot/meta-pynq/recipes-core/pynq-remote-network/files/80-wired.network
+++ b/sdbuild/boot/meta-pynq/recipes-core/pynq-remote-network/files/80-wired.network
@@ -1,0 +1,10 @@
+[Match]
+Name=en* eth* end*
+
+[Network]
+DHCP=yes
+# Fixed fallback address for direct host<->board links.
+Address=192.168.2.99/24
+
+[DHCPv4]
+RouteMetric=10

--- a/sdbuild/boot/meta-pynq/recipes-core/pynq-remote-network/pynq-remote-network.bb
+++ b/sdbuild/boot/meta-pynq/recipes-core/pynq-remote-network/pynq-remote-network.bb
@@ -1,0 +1,31 @@
+SUMMARY = "PYNQ.remote appliance networking (systemd-networkd DHCP)"
+SECTION = "PETALINUX/apps"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://80-wired.network"
+S = "${WORKDIR}"
+
+RDEPENDS:${PN} = "systemd"
+
+do_install() {
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${WORKDIR}/80-wired.network ${D}${sysconfdir}/systemd/network/80-wired.network
+
+    # Enable systemd-networkd (and its socket) + resolved at boot.
+    install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants
+    ln -sf ${systemd_system_unitdir}/systemd-networkd.service \
+        ${D}${sysconfdir}/systemd/system/multi-user.target.wants/systemd-networkd.service
+    ln -sf ${systemd_system_unitdir}/systemd-resolved.service \
+        ${D}${sysconfdir}/systemd/system/multi-user.target.wants/systemd-resolved.service
+    install -d ${D}${sysconfdir}/systemd/system/sockets.target.wants
+    ln -sf ${systemd_system_unitdir}/systemd-networkd.socket \
+        ${D}${sysconfdir}/systemd/system/sockets.target.wants/systemd-networkd.socket
+}
+
+FILES:${PN} += " \
+    ${sysconfdir}/systemd/network/80-wired.network \
+    ${sysconfdir}/systemd/system/multi-user.target.wants/systemd-networkd.service \
+    ${sysconfdir}/systemd/system/multi-user.target.wants/systemd-resolved.service \
+    ${sysconfdir}/systemd/system/sockets.target.wants/systemd-networkd.socket \
+"


### PR DESCRIPTION
Adds pynq-remote-network/pynq-remote-image and an on-target pynq-remote-selftest
recipe, hardens the librfdc dlopen fallback, and renames the pynq-cpp
PACKAGECONFIG dependency from rfdc to librfdc. 
