### PR TITLE
Pin pynqmetadata to pynq-next and move to pydantic 2

### DIFF
--- a/sdbuild/packages/python_packages_noble/requirements.txt
+++ b/sdbuild/packages/python_packages_noble/requirements.txt
@@ -84,7 +84,7 @@ ptyprocess==0.7.0
 pure_eval==0.2.3
 pybind11==2.11.1
 pycparser==2.23
-pydantic==1.9.1
+pydantic==2.9.2
 Pygments==2.20.0
 pyparsing==3.3.2
 python-dateutil==2.9.0.post0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,12 @@ from setuptools.command.build_ext import build_ext
 
 # Requirement
 required = [
-    'pynqmetadata',
+    # PYNQ's Versal support and pynq/metadata's shims both need APIs that
+    # exist only on PYNQ-Metadata's pynq-next branch (0.2.0):
+    # VersalProcSysCore, and pynqmetadata.views.runtime.*. The PyPI release
+    # is 0.1.x, so an unpinned dependency installs a package that makes
+    # `import pynq` fail with ImportError.
+    'pynqmetadata @ git+https://github.com/Xilinx/PYNQ-Metadata@pynq-next',
     'pynqutils',
     "setuptools>=24.2.0",
     "cffi",


### PR DESCRIPTION
`import pynq` fails on a freshly built image because the pynqmetadata dependency is unpinned and pip installs the PyPI release (0.1.x), which does not have what this branch needs.

Since #1591 migrated pynq/metadata to pynq-metadata, the shims here import from `pynqmetadata.views.runtime.*`, and PYNQ's Versal support imports `VersalProcSysCore`. Neither exists on PYNQ-Metadata's main branch or on PyPI -- both are on its pynq-next branch (0.2.0). With 0.1.x installed:

    ImportError: cannot import name 'VersalProcSysCore' from 'pynqmetadata'

pynqmetadata 0.2.0 in turn requires pydantic>=2.0, while python_packages_noble pins 1.9.1:

    ImportError: cannot import name 'ConfigDict' from 'pydantic'

so the two changes go together. PYNQ's own code uses only `Field` and `BaseModel`, which exist in both pydantic majors.

Pinning to a branch rather than a tag matches how PYNQ-Metadata is currently published; a released version would be preferable once one exists.

Found while bringing up a VRK160 (Versal Gen 2) board, but neither symptom is board specific.