### PR TITLE
Pin tar in sdbuild Dockerfile for EDF 2025.2 / pseudo 1.9.0

### DIFF
--- a/sdbuild/Dockerfile
+++ b/sdbuild/Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update \
     libfontconfig1 libfreetype6 libsm6 libice6 libglib2.0-0t64 libtinfo6 \
  # Locale for Vivado
  && locale-gen en_US.utf8 && update-locale \
+ # Pin tar before USN-8510 openat2 backport (EDF 2025.2 / pseudo 1.9.0)
+ && apt-get install -y --allow-downgrades tar=1.35+dfsg-3build1 \
+ && apt-mark hold tar \
  # Clean up APT
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fresh Docker builds on Ubuntu 24.04 pull a security-patched `tar` that breaks EDF 2025.2 packaging under pseudo 1.9.0. Pin `tar=1.35+dfsg-3build1` and hold it in the sdbuild Dockerfile.

[AMD AR 000040533](https://adaptivesupport.amd.com/s/article/000040533): USN-8510-1 backported CVE-2025-45582 into GNU tar, which uses `openat2()`. EDF ≤25.11.1 ships pseudo 1.9.0 without an openat2 wrapper, so `do_package` fails on new images that get the patched tar.