### PR TITLE
Fix Versal overlay loading: four defects that only surface in sequence

### DIFF
--- a/pynq/gpio.py
+++ b/pynq/gpio.py
@@ -244,6 +244,10 @@ class GPIO:
         else:
             valid_labels.append('zynqmp_gpio')
             valid_labels.append('zynq_gpio')
+            # Versal's PS GPIO, the analogue of zynqmp_gpio. The PMC also
+            # exposes a 'pmc_gpio' controller; pass it as target_label if
+            # that is the one you want.
+            valid_labels.append('versal_gpio')
 
         for root, dirs, files in os.walk('/sys/class/gpio'):
             for name in dirs:

--- a/pynq/overlay.py
+++ b/pynq/overlay.py
@@ -424,7 +424,10 @@ class Overlay(Bitstream):
                 enable = self.clock_dict[i]["enable"]
                 if "divisor0" in self.clock_dict[i]:
                     div0 = self.clock_dict[i]["divisor0"]
-                    div1 = self.clock_dict[i]["divisor1"]
+                    # Versal has a single divisor stage, so PYNQ-Metadata's
+                    # clock_dict carries divisor0 but no divisor1 for a
+                    # VersalProcSysCore. set_pl_clk already accepts div1=None.
+                    div1 = self.clock_dict[i].get("divisor1")
                     if enable:
                         Clocks.set_pl_clk(i, div0, div1)
                     else:

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -16,18 +16,41 @@ ON_TARGET = os.path.isfile('/proc/device-tree/chosen/pynq_board')
 DEFAULT_PL_CLK_MHZ = 100.0
 
 
+# Ordered most to least reliable. The PLM firmware node is SoC-level and
+# present on every Versal device tree; the root `family` property comes from
+# Xilinx's device-tree generator.
+_VERSAL_DT_MARKERS = (
+    ('/proc/device-tree/firmware/versal-firmware/compatible',
+     b'xlnx,versal-firmware'),
+    ('/proc/device-tree/compatible', b'xlnx,versal'),
+    ('/proc/device-tree/family', b'Versal'),
+)
+
+
 def _is_versal_host():
     """Return True when the device tree identifies the SoC as Versal.
 
     ZynqMP and Versal both report `aarch64`, so `CPU_ARCH` cannot tell
     them apart.
 
+    The root `compatible` alone is not enough, because it carries the
+    *board* name and only some boards spell the family into it. VCK190
+    gives "xlnx,versal-vck190-revA" and is detected; VRK160 gives plain
+    "xlnx,vrk160" and is not, so it falls through to _ClocksUltrascale,
+    which drives CRL_APB/CRF_APB registers Versal does not have. The
+    first overlay download then fails with
+
+        ValueError: Frequency divider 1 value out of range.
+
     """
-    try:
-        with open('/proc/device-tree/compatible', 'rb') as f:
-            return b'xlnx,versal' in f.read()
-    except OSError:
-        return False
+    for path, marker in _VERSAL_DT_MARKERS:
+        try:
+            with open(path, 'rb') as f:
+                if marker in f.read():
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 ZYNQ_PLL_FIELDS = {

--- a/sdbuild/packages/pynq/qemu.sh
+++ b/sdbuild/packages/pynq/qemu.sh
@@ -14,7 +14,16 @@ cd /home/xilinx
 mkdir -p jupyter_notebooks
 
 # clone and then install extra packages
-python3 -m pip install --upgrade git+https://github.com/Xilinx/PYNQ-Metadata.git
+#
+# PYNQ-Metadata must come from pynq-next, not the default branch. main is
+# 0.1.9 and has no VersalProcSysCore, which pynq/metadata/clock_dict_view.py
+# imports, so `import pynq` fails outright on any Versal board:
+#   ImportError: cannot import name 'VersalProcSysCore' from 'pynqmetadata'
+# 0.1.9 also requires pydantic<2 and silently downgrades the 2.x pinned in
+# python_packages_noble/requirements.txt to 1.9.1. The pin in setup.py does
+# not help here: the sdist below is installed with --no-deps, so setup.py's
+# requirements are never resolved in this flow.
+python3 -m pip install --upgrade git+https://github.com/Xilinx/PYNQ-Metadata.git@pynq-next
 python3 -m pip install --upgrade git+https://github.com/Xilinx/PYNQ-Utils.git
 
 cd pynq_git

--- a/sdbuild/packages/selftest/tests/python/sysfs_gpio.py
+++ b/sdbuild/packages/selftest/tests/python/sysfs_gpio.py
@@ -5,11 +5,15 @@ from results import bad, ok, sh, main_entry
 
 
 def run(p=None):
+    # PS GPIO controller label by family: Zynq, ZynqMP, Versal.
+    ps_gpio_labels = ("zynq_gpio", "zynqmp_gpio", "versal_gpio")
     _, labels = sh("cat /sys/class/gpio/gpiochip*/label 2>/dev/null | tr '\\n' ' '")
-    if "zynqmp_gpio" in labels.split():
-        ok("zynqmp_gpio controller exposed (labels: %s)" % labels)
+    found = [l for l in labels.split() if l in ps_gpio_labels]
+    if found:
+        ok("PS GPIO controller exposed: %s (labels: %s)" % (found[0], labels))
     else:
-        bad("no zynqmp_gpio gpiochip label (labels: %s)" % (labels or "none"))
+        bad("no PS GPIO gpiochip label, expected one of %s (labels: %s)"
+            % ("/".join(ps_gpio_labels), labels or "none"))
     try:
         from pynq import GPIO
 


### PR DESCRIPTION
No Versal board can load an overlay from a PYNQ 4.0 image built from
`pynq-next`. This is four separate defects, and they hide one behind the
other: each one stops execution before the next becomes reachable, so
fixing any subset changes nothing observable. All four are needed.

Found while bringing up a VRK-160 (Versal Gen 2), but none of it is
board-specific -- VCK190 is affected identically, and I have tried to keep
every fix general rather than special-casing my board.

### 1. The image ships PYNQ-Metadata 0.1.9

`sdbuild/packages/pynq/qemu.sh` installs PYNQ-Metadata from the default
branch, which is `main` = 0.1.9. That release has no `VersalProcSysCore`,
which `pynq/metadata/clock_dict_view.py` imports, so `import pynq` fails:

    ImportError: cannot import name 'VersalProcSysCore' from 'pynqmetadata'

0.1.9 also declares `pydantic<2`, so pip silently downgrades the pydantic
2.10.6 pinned in `python_packages_noble/requirements.txt` to 1.9.1, leaving
`pydantic_core` 2.23.4 stranded beside it. Nothing in the build log looks
wrong -- pip reports a successful install.

Pinning `pynqmetadata` in `setup.py` does not help here: the sdist is
installed a few lines below with `--no-deps`, so setup.py's requirements are
never resolved in this flow.

### 2. `KeyError: 'divisor1'`

`Overlay.download()` guards on `"divisor0"` being present in `clock_dict`
and then reads `"divisor1"` unconditionally. Versal has a single divisor
stage where Ultrascale has two, so PYNQ-Metadata's `ClockDictView` emits
enable/frequency/divisor0/src_sel and no divisor1.

This is a regression from b5881e0e: PYNQ's own `clock_dict_view.py` gave
Versal neither divisor, so the guard was False and the block was skipped
entirely. The pynq-metadata view adds divisor0 without divisor1, so the
guard now passes and the next line raises.

### 3. Versal detected from the board, not the SoC

`_is_versal_host()` matches `xlnx,versal` in the root `compatible`, which is
the *board* string. VCK190 spells the family into it
("xlnx,versal-vck190-revA") and is detected. VRK-160 gives plain
"xlnx,vrk160" and is not, so `Clocks` falls through to `_ClocksUltrascale`
and drives CRL_APB/CRF_APB registers Versal does not have:

    ValueError: Frequency divider 1 value out of range.

Now checks SoC-level markers, most reliable first: the PLM firmware node
(compatible `xlnx,versal-firmware`, present on every Versal device tree),
then the old root compatible, then the root `family` property.

### 4. `GPIO.get_gpio_base()` returns None

`get_gpio_base_path()` searched for a gpiochip labelled `zynqmp_gpio` or
`zynq_gpio`. Versal labels its PS GPIO `versal_gpio`. Added it; `pmc_gpio`
is deliberately left out, since it is a different controller and
`target_label` already selects it explicitly.

### Verification

On a VRK-160 booting an image built from this branch, with no manual pip
install: `pynqmetadata` 0.2.0, `pydantic` 2.x, `import pynq` clean, and
`BaseOverlay('base.pdi')` loading with GPIO, AXI BRAM and AXI DMA loopback
all exercised through PYNQ.

Note that on Versal the clock call is a no-op by design:
`_ClocksVersal.set_pl_clk` warns that PL clocks are fixed by the boot PDI.
The point of fixes 2 and 3 is to reach that warning instead of an exception.
