### PR TITLE
Three image-hygiene fixes: selftest DMA, unconfigured DHCP server, headless X11

### DIFF
--- a/sdbuild/packages/selftest/tests/python/dma_loopback.py
+++ b/sdbuild/packages/selftest/tests/python/dma_loopback.py
@@ -16,7 +16,9 @@ def run(p=None):
         dma = base.dma
     except AttributeError:
         raise FailError("dma not in overlay")
-    dma.reset()
+    # No dma.reset() here: pynq.lib.dma.DMA has no such method, and needs
+    # none -- DMA.__init__ runs set_up_tx_channel()/set_up_rx_channel(), so
+    # the channels are configured by the overlay download just above.
     n = 1024
     tx = allocate(shape=(n,), dtype=np.uint32)
     rx = allocate(shape=(n,), dtype=np.uint32)

--- a/sdbuild/packages/usbgadget/qemu.sh
+++ b/sdbuild/packages/usbgadget/qemu.sh
@@ -29,5 +29,9 @@ subnet 192.168.3.0 netmask 255.255.255.0 {
 EOT
 
 systemctl disable isc-dhcp-server6
+# create_rootfs.sh disables both units in the base image; this package has
+# just written INTERFACES="usb0" into /etc/default/isc-dhcp-server, so the
+# v4 one is wanted here.
+systemctl enable isc-dhcp-server
 systemctl enable usbgadget
 systemctl enable serial-getty@ttyGS0

--- a/sdbuild/packages/wpa_ap/qemu.sh
+++ b/sdbuild/packages/wpa_ap/qemu.sh
@@ -27,5 +27,8 @@ iface wlan0 inet dhcp
 	wpa-conf /etc/wpa_supplicant.conf
 EOT
 
-# Uncomment the following line to enable wireless access point by default
+# Uncomment the following lines to enable wireless access point by default.
+# isc-dhcp-server is disabled in the base image by create_rootfs.sh, and the
+# access point needs it to hand out leases on wlan1.
 # systemctl enable wpa_ap.service
+# systemctl enable isc-dhcp-server

--- a/sdbuild/packages/x11/pynq-x11.service
+++ b/sdbuild/packages/x11/pynq-x11.service
@@ -1,6 +1,14 @@
 [Unit]
 Description = PYNQ X11 Server
 After = systemd-user-sessions.service network.target sound.target
+# Only start X where a display actually exists. The presence of a DRM device
+# is not enough: zocl, XRT's accelerator DRM driver, registers /dev/dri/card0
+# on every PYNQ image and has no CRTC at all. xorg.conf names no BusID, so
+# armsoc opens card0 blindly, finds no usable screen and X exits 1 --
+# leaving a failed unit on any board without a display output. DRM connector
+# directories (card0-DP-1, card0-HDMI-A-1, ...) exist only for a card with
+# real outputs, so this starts X exactly where there is something to draw on.
+ConditionPathExistsGlob = /sys/class/drm/card*-*
 
 [Service]
 Type = simple

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -100,6 +100,13 @@ systemctl mask ua-auto-attach.service
 # Disable apport crash reporter (unused on the appliance; its oneshot fails)
 systemctl mask apport.service
 
+# Disable the DHCP server. multistrap pulls isc-dhcp-server in as a dependency
+# and Ubuntu's postinst leaves both units enabled, but nothing writes
+# /etc/default/isc-dhcp-server unless the usbgadget or wpa_ap package is in the
+# board's package list -- so on every other board they just fail at boot.
+# usbgadget re-enables the v4 unit after configuring it for usb0.
+systemctl disable isc-dhcp-server isc-dhcp-server6
+
 # Disable default graphical environment
 systemctl set-default multi-user
 


### PR DESCRIPTION
Independent of #1603 , no overlap.
Three independent, small defects found while validating a PYNQ 4.0 image.
None is Versal-specific; all three affect other boards.

### `dma.reset()` does not exist

`sdbuild/packages/selftest/tests/python/dma_loopback.py` calls `dma.reset()`
before transferring, which raises

    AttributeError: 'DMA' object has no attribute 'reset'

`pynq.lib.dma.DMA` has no `reset()` -- it exposes sendchannel/recvchannel
plus `set_up_tx_channel()`/`set_up_rx_channel()`, and there is no `reset()`
elsewhere in pynq that this could have meant. It is not needed either:
`DMA.__init__` runs both `set_up_*_channel()` methods, so the overlay
download the test performs immediately before already leaves the channels
configured. As far as I can tell this test cannot have passed on any board.

### The DHCP server is enabled but never configured

multistrap pulls `isc-dhcp-server` into every image and Ubuntu's postinst
leaves both units enabled, but `/etc/default/isc-dhcp-server` is only
written by the `usbgadget` and `wpa_ap` packages. Any board whose package
list has neither boots with

    isc-dhcp-server.service   failed
    isc-dhcp-server6.service  failed

Disabled both in `create_rootfs.sh`, alongside the `wpa_supplicant`,
`apport` and `sleep.target` masks that are there for the same reason, and
`usbgadget` re-enables the v4 unit after writing `INTERFACES="usb0"`.
9b2b0191 addressed half of this inside `usbgadget`, which only helps boards
that include `usbgadget` in the first place; that line is left as it is.

`wpa_ap` does not enable its own service by default, so it gets a matching
commented-out line rather than an unconditional enable -- uncommenting one
without the other would give an access point that hands out no leases.

### X11 starts where there is no display

`pynq-x11.service` is enabled unconditionally, so on a board with no display
output it fails at every boot.

The cause is not the driver. `zocl`, XRT's accelerator DRM driver, claims
`/dev/dri/card0` on every PYNQ image and has no CRTC, and `xorg.conf` names
no BusID, so armsoc opens card0 blindly:

    (II)    DriverName is [zocl]
    (II)    bus_id is [axi:zyxclmm_drm]
    (II) Screen:0,  CRTC:-1
    (EE) Screen(s) found, but none have a usable configuration.

Switching drivers would not help, and a condition on `/dev/dri/card*` would
pass on exactly the boards where it must not, since zocl always creates one.
Gated on a DRM connector instead: the kernel creates `card<N>-<CONNECTOR>`
directories only for a card with real outputs, so X starts where there is a
screen to draw on and the unit stays inactive rather than failed elsewhere.
Boards with a display are unaffected.