### PR TITLE
Make EDF repo init and sync non-interactive for detached builds

### DIFF
--- a/sdbuild/scripts/build_edf_boot.sh
+++ b/sdbuild/scripts/build_edf_boot.sh
@@ -78,11 +78,16 @@ step_init_edf() {
     cd "${EDF_DIR}"
     if [ ! -d ".repo" ]; then
         repo init -q -u "${EDF_MANIFEST_URL}" -b "refs/tags/${EDF_MANIFEST_TAG}" \
-            -m "${EDF_MANIFEST_FILE}" --depth=1
+            -m "${EDF_MANIFEST_FILE}" --depth=1 </dev/null
+        if [ ! -d ".repo" ]; then
+            echo "ERROR: repo init did not create ${EDF_DIR}/.repo." >&2
+            echo "       Remove any stray .repo directory in a parent of EDF_DIR." >&2
+            exit 1
+        fi
     fi
     local sync_jobs; sync_jobs=$(nproc)
     if [ "${sync_jobs}" -gt 8 ]; then sync_jobs=8; fi
-    repo sync -j"${sync_jobs}" --force-sync
+    repo sync -q -j"${sync_jobs}" --force-sync
 }
 
 # Step 2: source the EDF build env, configure caches, add the meta-pynq layer.

--- a/sdbuild/scripts/build_edf_remote_rootfs.sh
+++ b/sdbuild/scripts/build_edf_remote_rootfs.sh
@@ -56,10 +56,15 @@ mkdir -p "${EDF_DIR}"
 cd "${EDF_DIR}"
 if [ ! -d ".repo" ]; then
     repo init -q -u "${EDF_MANIFEST_URL}" -b "refs/tags/${EDF_MANIFEST_TAG}" \
-        -m "${EDF_MANIFEST_FILE}" --depth=1
+        -m "${EDF_MANIFEST_FILE}" --depth=1 </dev/null
+    if [ ! -d ".repo" ]; then
+        echo "ERROR: repo init did not create ${EDF_DIR}/.repo." >&2
+        echo "       Remove any stray .repo directory in a parent of EDF_DIR." >&2
+        exit 1
+    fi
 fi
 sync_jobs=$(nproc); [ "${sync_jobs}" -gt 8 ] && sync_jobs=8
-repo sync -j"${sync_jobs}" --force-sync
+repo sync -q -j"${sync_jobs}" --force-sync
 
 # Step 2: source the EDF build env, configure caches, add the meta-pynq layer.
 set +u


### PR DESCRIPTION
Redirect repo init stdin and pass -q to repo sync so tmux/detached sdbuild builds do not stall on the color prompt