### PR TITLE
Detect Versal from the SoC, not the board's compatible string

### DIFF
--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -16,6 +16,15 @@ ON_TARGET = os.path.isfile('/proc/device-tree/chosen/pynq_board')
 DEFAULT_PL_CLK_MHZ = 100.0
 
 
+# Ordered most to least reliable.
+_VERSAL_DT_MARKERS = (
+    ('/proc/device-tree/firmware/versal-firmware/compatible',
+     b'xlnx,versal-firmware'),
+    ('/proc/device-tree/compatible', b'xlnx,versal'),
+    ('/proc/device-tree/family', b'Versal'),
+)
+
+
 def _is_versal_host():
     """Return True when the device tree identifies the SoC as Versal.
 
@@ -23,11 +32,14 @@ def _is_versal_host():
     them apart.
 
     """
-    try:
-        with open('/proc/device-tree/compatible', 'rb') as f:
-            return b'xlnx,versal' in f.read()
-    except OSError:
-        return False
+    for path, marker in _VERSAL_DT_MARKERS:
+        try:
+            with open(path, 'rb') as f:
+                if marker in f.read():
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 ZYNQ_PLL_FIELDS = {


### PR DESCRIPTION
_is_versal_host() matched "xlnx,versal" in the root compatible. That is the *board* compatible, and only some boards spell the family into it. VCK190 gives "xlnx,versal-vck190-revA" and is detected. VRK160 gives plain "xlnx,vrk160" and is not, so Clocks falls through to _ClocksUltrascale and drives CRL_APB/CRF_APB registers Versal does not have. Every overlay download then fails with

    ValueError: Frequency divider 1 value out of range.

because _ClocksBase.set_pl_clk is reached with div1=None -- Versal has a single divisor stage, so the clock_dict has no divisor1 to pass.

Look for SoC-level markers instead, most reliable first: the PLM firmware node (compatible "xlnx,versal-firmware"), which every Versal device tree carries because the power/clock/reset drivers bind to it; then the old root compatible check; then the root "family" property that Xilinx's device-tree generator emits ("Versal").

This was latent until now. Before b5881e0e, PYNQ's own clock_dict_view gave Versal no divisor0, so the guard in Overlay.download() skipped the block and set_pl_clk was never called on any Versal board -- the wrong Clocks implementation did not matter. Verified against the VRK160 system.dtb: root compatible "xlnx,vrk160", family "Versal",
/firmware/versal-firmware compatible "xlnx,versal-firmware".

Validation
On a VCK190, confirming the new primary marker is present — this is not a regression on the board you have:


cat /proc/device-tree/firmware/versal-firmware/compatible; echo
cat /proc/device-tree/compatible; echo
cat /proc/device-tree/family; echo
python3 -c 'from pynq.ps import _is_versal_host; print(_is_versal_host())'
VCK190 returns True before and after, and matches on all three markers.

The case that fails today is a board whose root compatible does not spell the family, e.g. VRK160 with plain xlnx,vrk160:


python3 -c 'print(b"xlnx,versal" in b"xlnx,vrk160\0")'

False, so _ClocksMeta selects _ClocksUltrascale. Its __init__ maps CRL_APB at 0xFF5E0000 and CRF_APB at 0xFD1A0000, and set_pl_clk writes CLKACT and the divider fields there on every overlay download — registers the comment immediately above the check in _ClocksMeta notes Versal does not have.