### PR TITLE
selftest: drop the non-existent dma.reset() call

### DIFF
--- a/sdbuild/packages/selftest/tests/python/dma_loopback.py
+++ b/sdbuild/packages/selftest/tests/python/dma_loopback.py
@@ -16,7 +16,6 @@ def run(p=None):
         dma = base.dma
     except AttributeError:
         raise FailError("dma not in overlay")
-    dma.reset()
     n = 1024
     tx = allocate(shape=(n,), dtype=np.uint32)
     rx = allocate(shape=(n,), dtype=np.uint32)


### PR DESCRIPTION
The DMA loopback test called dma.reset() before transferring, which raises

    AttributeError: 'DMA' object has no attribute 'reset'

pynq.lib.dma.DMA has no reset() -- it exposes sendchannel/recvchannel plus set_up_tx_channel()/set_up_rx_channel(), and there is no reset() anywhere else in pynq that this could have meant. The call is not needed either: DMA.__init__ runs both set_up_*_channel() methods, so the overlay download the test performs immediately before already leaves the channels configured.

This affects every board, not just Versal; the test cannot have passed anywhere. It only surfaced on VRK160 now because the four Versal defects ahead of it stopped the test before it reached this line.

sdbuild/packages/selftest/tests/python/dma_loopback.py, one deleted line.

Validate anywhere, no board needed:

python3 -c 'from pynq.lib.dma import DMA; print(hasattr(DMA, "reset"))'

False. The test raises AttributeError before reaching the transfer, so it cannot have passed on any board. DMA.__init__ calls set_up_tx_channel()/set_up_rx_channel(), so the channels are already configured by the overlay download on the line above.