### PR TITLE
sdbuild: do not leave the DHCP server enabled on boards that never co…

### DIFF
--- a/sdbuild/packages/usbgadget/qemu.sh
+++ b/sdbuild/packages/usbgadget/qemu.sh
@@ -29,5 +29,6 @@ subnet 192.168.3.0 netmask 255.255.255.0 {
 EOT
 
 systemctl disable isc-dhcp-server6
+systemctl enable isc-dhcp-server
 systemctl enable usbgadget
 systemctl enable serial-getty@ttyGS0

--- a/sdbuild/packages/wpa_ap/qemu.sh
+++ b/sdbuild/packages/wpa_ap/qemu.sh
@@ -27,5 +27,6 @@ iface wlan0 inet dhcp
 	wpa-conf /etc/wpa_supplicant.conf
 EOT
 
-# Uncomment the following line to enable wireless access point by default
+# Uncomment the following lines to enable wireless access point by default
 # systemctl enable wpa_ap.service
+# systemctl enable isc-dhcp-server

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -100,6 +100,9 @@ systemctl mask ua-auto-attach.service
 # Disable apport crash reporter (unused on the appliance; its oneshot fails)
 systemctl mask apport.service
 
+# Disable the DHCP server (only usbgadget and wpa_ap configure it)
+systemctl disable isc-dhcp-server isc-dhcp-server6
+
 # Disable default graphical environment
 systemctl set-default multi-user
 


### PR DESCRIPTION
…nfigure it

multistrap pulls isc-dhcp-server into every image and Ubuntu's postinst leaves both units enabled, but /etc/default/isc-dhcp-server is only written by the usbgadget and wpa_ap packages. Any board whose package list has neither -- VRK160 and VCK190 among them -- boots with

    isc-dhcp-server.service   failed
    isc-dhcp-server6.service  failed

Disable both in create_rootfs.sh, alongside the wpa_supplicant, apport and sleep.target masks that are there for the same reason, and let usbgadget enable the v4 unit again after it has written INTERFACES="usb0".

9b2b0191 addressed half of this by disabling isc-dhcp-server6 inside usbgadget, which helps only boards that include usbgadget in the first place. That line is left as it is.

wpa_ap does not enable its own service by default, so it gets a matching commented-out line rather than an unconditional enable: uncommenting one without the other would give an access point that hands out no leases.

sdbuild/scripts/create_rootfs.sh, plus the two packages that do configure it.

On any built image without usbgadget or wpa_ap:

systemctl is-enabled isc-dhcp-server isc-dhcp-server6
systemctl --failed

Before: both enabled, and both fail at boot because nothing writes /etc/default/isc-dhcp-server. multistrap pulls isc-dhcp-server in as a dependency and Ubuntu's postinst enables both units.

After: both disabled, no failed units.

On a usbgadget image, confirm it is still enabled — the package re-enables the v4 unit after writing INTERFACES="usb0":

systemctl is-enabled isc-dhcp-server

This change is in stage1, so it needs a rootfs rebuild rather than an incremental one.