### PR TITLE
x11: only start the X server where a display output exists

### DIFF
--- a/sdbuild/packages/x11/pynq-x11.service
+++ b/sdbuild/packages/x11/pynq-x11.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = PYNQ X11 Server
 After = bootpy.service systemd-user-sessions.service network.target sound.target
+# Only start X where a DRM connector exists (zocl registers a card with none)
+ConditionPathExistsGlob = /sys/class/drm/card*-*
 
 [Service]
 Type = simple


### PR DESCRIPTION
pynq-x11.service starts unconditionally, so on any board without a display output it fails at boot and leaves a failed unit in systemctl --failed.

The presence of a DRM device is not enough to gate on: zocl, XRT's accelerator DRM driver, registers /dev/dri/card0 on every PYNQ image and has no CRTC at all. xorg.conf points the modesetting driver straight at it with

    Option "kmsdev" "/dev/dri/card0"

so X opens a card with no usable screen and exits 1.

DRM connector directories (card0-DP-1, card0-HDMI-A-1, ...) are created only for a card that has real outputs, so ConditionPathExistsGlob on them starts X exactly where there is something to draw on, and reports the unit as inactive rather than failed everywhere else.

sdbuild/packages/x11/pynq-x11.service, one ConditionPathExistsGlob.

On a board with no display output:

systemctl status pynq-x11
ls /sys/class/drm/

Before: failed. A DRM device does exist — zocl, XRT's accelerator DRM driver, registers /dev/dri/card0 on every PYNQ image and has no CRTC — and xorg.conf points the modesetting driver straight at it with Option "kmsdev" "/dev/dri/card0", so X finds no usable screen and exits 1.

After: inactive (dead), and

systemctl show pynq-x11 -p ConditionResult

reports no. Connector directories (card0-DP-1, card0-HDMI-A-1, ...) are created only for a card with real outputs.

On a board with a display, X still starts:

ls -d /sys/class/drm/card*-*
systemctl is-active pynq-x11