### PR TITLE
Disable unconfigured isc-dhcp-server units in the shared rootfs

### DIFF
--- a/sdbuild/packages/usbgadget/qemu.sh
+++ b/sdbuild/packages/usbgadget/qemu.sh
@@ -6,13 +6,14 @@ set -e
 for f in /etc/profile.d/*.sh; do source $f; done
 
 if [ -f /etc/default/isc-dhcp-server ] && \
-	grep -q "INTERFACES=" /etc/default/isc-dhcp-server; then
+	grep -q "^INTERFACESv4=" /etc/default/isc-dhcp-server; then
 	if ! grep -q "usb0" /etc/default/isc-dhcp-server; then
-		sed -i 's/\(INTERFACES=\)"\(.*\)"/\1"\2 usb0"/g' \
-		/etc/default/isc-dhcp-server
+		sed -i -e 's/^INTERFACESv4="\([^"]\+\)"/INTERFACESv4="\1 usb0"/' \
+			-e 's/^INTERFACESv4=""/INTERFACESv4="usb0"/' \
+			/etc/default/isc-dhcp-server
 	fi
 else
-	echo 'INTERFACES="usb0"' > /etc/default/isc-dhcp-server
+	echo 'INTERFACESv4="usb0"' >> /etc/default/isc-dhcp-server
 fi
 
 cat - > /etc/dhcp/dhcpd.conf <<EOT
@@ -28,6 +29,6 @@ subnet 192.168.3.0 netmask 255.255.255.0 {
 }
 EOT
 
-systemctl disable isc-dhcp-server6
+systemctl enable isc-dhcp-server
 systemctl enable usbgadget
 systemctl enable serial-getty@ttyGS0

--- a/sdbuild/packages/wpa_ap/qemu.sh
+++ b/sdbuild/packages/wpa_ap/qemu.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 if [ -f /etc/default/isc-dhcp-server ] && \
-	grep -q "INTERFACES=" /etc/default/isc-dhcp-server; then
+	grep -q "^INTERFACESv4=" /etc/default/isc-dhcp-server; then
 	if ! grep -q "wlan1" /etc/default/isc-dhcp-server; then
-		sed -i 's/\(INTERFACES=\)"\(.*\)"/\1"\2 wlan1"/g' \
-		/etc/default/isc-dhcp-server
+		sed -i -e 's/^INTERFACESv4="\([^"]\+\)"/INTERFACESv4="\1 wlan1"/' \
+			-e 's/^INTERFACESv4=""/INTERFACESv4="wlan1"/' \
+			/etc/default/isc-dhcp-server
 	fi
 else
-	echo 'INTERFACES="wlan1"' > /etc/default/isc-dhcp-server
+	echo 'INTERFACESv4="wlan1"' >> /etc/default/isc-dhcp-server
 fi
 
 cat - >> /etc/dhcp/dhcpd.conf <<EOT
@@ -27,5 +28,6 @@ iface wlan0 inet dhcp
 	wpa-conf /etc/wpa_supplicant.conf
 EOT
 
-# Uncomment the following line to enable wireless access point by default
+# Uncomment the following lines to enable wireless access point by default
 # systemctl enable wpa_ap.service
+# systemctl enable isc-dhcp-server

--- a/sdbuild/scripts/create_rootfs.sh
+++ b/sdbuild/scripts/create_rootfs.sh
@@ -100,6 +100,9 @@ systemctl mask ua-auto-attach.service
 # Disable apport crash reporter (unused on the appliance; its oneshot fails)
 systemctl mask apport.service
 
+# Disable the DHCP servers; dhcpd exits unless a board configures a subnet
+systemctl disable isc-dhcp-server isc-dhcp-server6
+
 # Disable default graphical environment
 systemctl set-default multi-user
 


### PR DESCRIPTION
 The IPv4 and IPv6 DHCP server units fail on boards that do not serve DHCP. Turn them off in create_rootfs.sh and have usbgadget re-enable the IPv4 unit it configures, writing INTERFACESv4 instead of the unused INTERFACES.