### PR TITLE
docs: update SD card and board docs for PYNQ 4.0 EDF and add VCK190 guides

### DIFF
--- a/docs/source/appendix/sdcard.rst
+++ b/docs/source/appendix/sdcard.rst
@@ -15,7 +15,7 @@ Windows
 * Extract the *Win32DiskImager* executable from the zip file and run the
   Win32DiskImager utility as administrator. (Right-click on the file, and select
   Run as administrator.)
-* Select the PYNQ-Z1 image file (.img).
+* Select the downloaded PYNQ image file (.img).
 * Select the drive letter of the SD card. Be careful to select the correct
   drive. If you select the wrong drive you can overwrite data on that
   drive. This could be another USB stick, or memory card connected to your
@@ -32,7 +32,7 @@ Micro SD card.
 
    .. code-block:: console
 
-      unzip pynq_z1_image_2016_09_14.zip -d ./
+      unzip <pynq-image>.zip -d ./
       
 ImageWriter
 -----------
@@ -94,8 +94,11 @@ Command Line
    
       sudo dd bs=1m if=image.img of=/dev/rdisk<disk# from diskutil>
 
-   where disk is your BSD name e.g. sudo dd bs=1m
-   if=pynq_z1_image_2016_09_07.img of=/dev/rdisk4
+   where disk is your BSD name, for example:
+
+   .. code-block:: console
+
+      sudo dd bs=1m if=pynq_image.img of=/dev/rdisk4
 
 This may result in a dd: invalid number '1m' error if you have GNU coreutils
 installed. In that case, you need to use a block size of 1M in the bs= section,
@@ -112,7 +115,7 @@ If this command still fails, try using disk instead of rdisk, for example:
 
    .. code-block:: console
       
-      sudo dd bs=1m if=pynq_z1_image_2016_09_07.img of=/dev/disk4
+      sudo dd bs=1m if=pynq_image.img of=/dev/disk4
 
 
 Linux

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -47,20 +47,12 @@ I can't connect to my board
    * If you are using a docking station, when your laptop is docked, the
      Ethernet port on the PC may be disabled.
    
-My Pynq-Z1/Z2 board is not powering on (No Red LED)
----------------------------------------------------
-
-The board can be powered by USB cable, or power adapter (7 - 15V V 2.1mm
-centre-positive barrel jack). Make sure Jumper JP5 is set to USB or REG (for
-power adapter). If powering the board via USB, make sure the USB port is fully
-powered. Laptops in low power mode may reduce the available power to a USB port.
-
-The bitstream is not loading (No Green LED)
--------------------------------------------
+The board is not booting
+------------------------
 
 * Check the Micro-SD card is inserted correctly (the socket is spring loaded, so
   push it in until you feel it click into place).
-* Check jumper JP4 is set to SD (board boots from Micro SD card).
+* Check that the board is configured to boot from the Micro-SD card.
 * Connect a terminal and verify that the Linux boot starts.
 
 If the Linux boot does not start, or fails, you may need to (re)flash the PYNQ
@@ -203,8 +195,8 @@ the WiFi dongle.
 How do I set/change the static IP address on the board?
 -------------------------------------------------------
 
-You can usually modify ``/etc/network/interfaces.d/eth0``.
-For example, on Pynq-Z1/Z2, the default address shown there is
+You can usually modify ``/etc/network/interfaces.d/eth0``. The default static
+address is:
 
    .. code-block:: console
 
@@ -232,9 +224,8 @@ host names.  You can change the hostname by using a script on PYNQ image:
 What is the user account and password?
 --------------------------------------
 
-The username for all Linux, Jupyter and Samba logins is ``xilinx``. 
-The password is ``xilinx``. For vagrant Ubuntu VM, both the username and 
-password are ``vagrant``.
+The username for all Linux, Jupyter and Samba logins is ``xilinx``.
+The password is ``xilinx``.
 
 How do I enable/disable the Jupyter notebook password?
 ------------------------------------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -10,13 +10,14 @@ SoMs, you can install PYNQ onto your host Operating System.
 If you have one of the following boards, you can follow the quick start guide.
 Go to the `PYNQ support forum <https://discuss.pynq.io/>`_ for help.
 
-Zynq, Zynq Ultrascale+ and Zynq RFSoC
-=====================================
+Zynq Ultrascale+ and Versal
+===========================
 
 .. toctree::
     :maxdepth: 1
        
     getting_started/zcu104_setup.rst
+    getting_started/vck190_setup.rst
 
 * `AUP-ZU3 <https://xilinx.github.io/AUP-ZU3/getting_started.html>`_
 

--- a/docs/source/getting_started/network_connection.rst
+++ b/docs/source/getting_started/network_connection.rst
@@ -37,7 +37,7 @@ Connect to a Router/Network (DHCP):
 
   1. Connect the Ethernet port on your board to a router/switch
   2. Connect your computer to Ethernet or WiFi on the router/switch
-  3. Browse to http://<board IP address>
+  3. Browse to ``http://<board IP address>``
   4. Jump to the :ref:`connecting-to-jupyter` section.
   5. Optional: see *Change the Hostname* below
   6. Optional: see *Configure Proxy Settings* below

--- a/docs/source/getting_started/vck190_setup.rst
+++ b/docs/source/getting_started/vck190_setup.rst
@@ -1,0 +1,38 @@
+.. _VCK190-setup:
+
+*******************
+VCK190 Setup Guide
+*******************
+
+Prerequisites
+=============
+
+  * `VCK190 board <https://www.amd.com/en/products/adaptive-socs-and-fpgas/evaluation-boards/vck190.html>`_
+  * Computer with compatible browser (`Supported Browsers
+    <https://jupyter-notebook.readthedocs.io/en/latest/notebook.html#browser-compatibility>`_)
+  * Ethernet cable
+  * USB cable (optional)
+  * Micro-SD card with preloaded image, or blank card (Minimum 8GB recommended)
+
+.. _VCK190-board-setup:
+
+Board Setup
+===========
+
+  1. Configure the board to boot from the Micro-SD card.
+
+  2. Connect the power cable.
+
+  3. Insert the Micro-SD card loaded with the VCK190 PYNQ image.
+
+  4. (Optional) Connect the USB cable to the board and your computer for a
+     serial terminal.
+
+  5. Connect the Ethernet port by following the instructions below.
+
+  6. Turn on the board.
+
+.. include:: network_connection.rst
+
+After connecting the board to the network, follow
+:ref:`connecting-to-jupyter`.

--- a/docs/source/overlay_design_methodology/board_settings.rst
+++ b/docs/source/overlay_design_methodology/board_settings.rst
@@ -14,45 +14,39 @@ here:
       
 The base design can be used as a starting point to create a new design.
 
+The VCK190 uses segmented configuration. Build
+``boards/VCK190/golden`` before ``boards/VCK190/base`` so that the overlay is
+compatible with the boot image.
+
 
 Vivado board files
 ------------------
 
-Vivado board files contain the configuration for a board that is required when
-creating a new project in Vivado. For most of the Xilinx boards (for example,
-ZCU104), the board files have already been included in Vivado; users can 
-simply choose the corresponding board when they create a new project. 
-For some other boards (for example, Pynq-Z1 and Pynq-Z2), 
-the corresponding board files can be downloaded as shown below.
+Vivado board files contain the configuration required when creating a project
+for a board. The ZCU104 and VCK190 board files are included with Vivado and can
+be selected when creating a project.
 
-* `Download the Pynq-Z1 board files
-  <https://github.com/cathalmccabe/pynq-z1_board_files/raw/master/pynq-z1.zip>`_
-* `Download the Pynq-Z2 board files (see Downloads section)
-  <https://www.tulembedded.com/FPGA/ProductsPYNQ-Z2.html#:~:text=Z2%20Board%20File>`_
-  
-Installing these files in Vivado allows the board to be selected when creating
-a new project. This will configure the Zynq PS settings.
-
-To install the board files, extract, and copy the board files folder to:
+Boards that are not shipped with Vivado, for example the RFSoC 4x2 used by
+RFSoC-PYNQ, supply their own board files. Extract them and copy the board files
+folder to:
 
    .. code-block:: console
 
       <Xilinx installation directory>/Vivado/<version>/data/xhub/boards/XilinxBoardStore/boards/Xilinx/
 
-If Vivado is open, it must be restart to load in the new project files before a
-new project can be created.
+Installing the files allows the board to be selected when creating a new
+project, which applies the processing system settings for that board. If Vivado
+is already open it must be restarted before the new board files can be used.
 
 
 XDC constraints file
 --------------------
 
-Please see below for a list of constraint files.
-
-* `Download the Pynq-Z1 Master XDC constraints
-  <https://reference.digilentinc.com/_media/reference/programmable-logic/pynq-z1/pynq-z1_c.zip>`_
-
-* `Download the Pynq-Z2 Master XDC constraints
-  <https://dpoauwgwqsy2x.cloudfront.net/Download/pynq-z2_v1.0.xdc.zip>`_
+Constraint files and board documentation are available from the
+`ZCU104 <https://www.amd.com/en/products/adaptive-socs-and-fpgas/evaluation-boards/zcu104.html>`_
+and
+`VCK190 <https://www.amd.com/en/products/adaptive-socs-and-fpgas/evaluation-boards/vck190.html>`_
+board pages.
 
 
 

--- a/docs/source/overlay_design_methodology/pynq_and_asyncio.rst
+++ b/docs/source/overlay_design_methodology/pynq_and_asyncio.rst
@@ -286,7 +286,7 @@ ensures that an interrupt isn't seen multiple times.
 Examples
 --------
 
-For more examples, see the AsyncIO Buttons Notebook in the on the Pynq-Z1 in the
+For more examples, see the AsyncIO Buttons Notebook on the ZCU104 in the
 following directory:
 
 .. code-block:: console

--- a/docs/source/overlay_design_methodology/pynq_microblaze_subsystem.rst
+++ b/docs/source/overlay_design_methodology/pynq_microblaze_subsystem.rst
@@ -32,7 +32,8 @@ The PYNQ MicroBlaze data memory, either in local memory, or in DDR memory,
 can be used as a mailbox for communication and data exchanges between the 
 ARM processor and the PYNQ MicroBlaze.
 
-DDR memory is managed by the Linux kernel running on the Cortex-A9s.  Therefore,
+DDR memory is managed by the Linux kernel running on the application processor.
+Therefore,
 the PYNQ MicroBlaze must first be allocated memory regions to access DRAM. The 
 PYNQ  ``allocate`` function is used to allocate memory in Linux. It also provides
 the  physical address of the memory. A PYNQ applications can send the physical 
@@ -94,8 +95,6 @@ The corresponding Python constants are defined here:
 .. code-block:: console
 
    <PYNQ repository>/pynq/lib/pmod/constants.py
-   <PYNQ repository>/pynq/lib/arduino/constants.py
-   <PYNQ repository>/pynq/lib/rpi/constants.py
 
 The following example explains how Python could initiate a read from a 
 peripheral connected to a PYNQ MicroBlaze. 
@@ -167,21 +166,21 @@ MicroBlaze Processors
 
 As described in the previous section, a PYNQ MicroBlaze can be used as a 
 flexible controller for different types of external peripherals. The 
-ARM® Cortex®-A9 is an application processor, which runs PYNQ and Jupyter 
-notebook on a Linux OS. This scenario is not well suited to real-time 
+The ARM® application processor runs PYNQ and Jupyter notebooks on Linux. This
+scenario is not well suited to real-time
 applications, which is a common requirement for an embedded systems. 
-In the base overlay there are three PYNQ MicroBlazes. As well as acting as a 
-flexible controller, a PYNQ MicroBlaze can be used as dedicated real-time 
-controller.
+The ZCU104 base overlay contains two Pmod PYNQ MicroBlazes. As well as acting
+as a flexible controller, a PYNQ MicroBlaze can be used as a dedicated
+real-time controller.
+
+The VCK190 base overlay does not include a PYNQ MicroBlaze subsystem.
 
 PYNQ MicroBlazes can also be used standalone to offload some processing from 
 the main processor. However, note that the MicroBlaze processor inside a PYNQ 
-MicroBlaze in the base overlay is running at 100 MHz, compared to the Dual-Core 
-ARM Cortex-A9 running at 650 MHz. The clock speed, and different processor 
-architectures and features should be taken into account when offloading pure 
-application code. e.g. Vector processing on the ARM Cortex-A9 Neon processing 
-unit will be much more efficient than running on the MicroBlaze. The MicroBlaze 
-is most appropriate for low-level, background, or real-time applications.
+MicroBlaze in the base overlay runs at 100 MHz. The clock speed and different
+processor architectures and features should be taken into account when
+offloading application code. The MicroBlaze is most appropriate for low-level,
+background, or real-time applications.
 
      
 Software Requirements
@@ -253,15 +252,8 @@ project.
 Board Support Package
 ^^^^^^^^^^^^^^^^^^^^^
 
-A Board Support Package (BSP) includes software libraries for peripherals in 
-the system. For example, the Vitis projects for Pmod and Arduino peripherals 
-require the following 2 BSPs:
-
-BSP for the Arduino PYNQ MicroBlaze:
-
-    ``<PYNQ repository>/pynq/lib/arduino/bsp_iop_arduino/``
-    
-BSP for the Pmod PYNQ MicroBlaze:
+A Board Support Package (BSP) includes software libraries for peripherals in
+the system. The BSP for the Pmod PYNQ MicroBlaze is:
 
     ``<PYNQ repository>/pynq/lib/pmod/bsp_iop_pmod``
 
@@ -274,21 +266,16 @@ An application for the Pmod PYNQ MicroBlaze will be linked to the Pmod PYNQ
 MicroBlaze BSP. As the two Pmod PYNQ MicroBlazes are identical, an application 
 written for one Pmod PYNQ MicroBlaze can run on the other Pmod PYNQ MicroBlaze. 
 
-An Arduino application will be linked to the Arduino PYNQ MicroBlaze BSP.
-
 Building the Projects
 ^^^^^^^^^^^^^^^^^^^^^
 
 To build all the software projects, for example,
 you can run the corresponding makefile:
 
-    ``<PYNQ repository>/pynq/lib/arduino/makefile``
-    
     ``<PYNQ repository>/pynq/lib/pmod/makefile``
 
-Application projects for peripherals that ship with PYNQ (e.g. Pmod and Arduino
-peripherals) can also be found in the same location. Each project is contained
-in a separate folder.
+Application projects for Pmod peripherals can also be found in the same
+location. Each project is contained in a separate folder.
    
 The makefile compiles the application projects based on the BSP provided 
 in the correct location.
@@ -330,9 +317,6 @@ If you want to add your own custom project to the build process, you need to
 add the project name to the *BIN_PMOD* variable, and save the project in the 
 same location as the other application projects.
 
-Similarly, you have to follow the same steps to build Arduino application 
-projects.
-
 In addition, individual projects can be built by navigating to the 
 ``<project_directory>/Debug`` and running ``make``.
 
@@ -365,15 +349,15 @@ For example, if your C code is ``my_peripheral.c``, the generated .elf and .bin
 will be ``my_peripheral.elf`` and ``my_peripheral.bin``.
 
 The naming convention recommended for peripheral applications is
-``<pmod|arduino>_<peripheral>``.
+``pmod_<peripheral>``.
 
 You will need to update references from the old project name to your new 
 project name in ``<project_directory>/Debug/makefile`` and 
 ``<project_directory>/Debug/src/subdir.mk``.
 
 If you want your project to build in the main makefile, you should also append
-the .bin name of your project to the *BIN_PMOD* (or *BIN_ARDUINO*) variable at 
-the top of the makefile.
+the .bin name of your project to the *BIN_PMOD* variable at the top of the
+makefile.
 
 If you are using the Vitis GUI, you can import the fixed Hardware Platform, BSP, and 
 any application projects into your Vitis workspace. Select MicroBlaze as the target 
@@ -534,10 +518,9 @@ IO Switch Modes and Pin Mapping
 -------------------------------
 Note that the IO switch IP is a customizable IP can be configured by users 
 inside a Vivado project (by double clicking the IP icon of the IO switch). 
-There are 4 pre-defined modes (`pmod`, `dual pmod`, `arduino`, `raspberrypi`) 
-and 1 fully-customizable mode (`custom`) for users to choose. 
-In the base overlay, we have only used `pmod` and `arduino` as the IO switch 
-modes.
+There are 4 pre-defined modes (`pmod`, `dual pmod`, `arduino`, `raspberrypi`)
+and 1 fully-customizable mode (`custom`) for users to choose. The ZCU104 base
+overlay uses the `pmod` mode.
 
 Switch mappings used for Pmod:
 

--- a/docs/source/pynq_libraries/axigpio.rst
+++ b/docs/source/pynq_libraries/axigpio.rst
@@ -92,7 +92,7 @@ and waiting for interrupts can be found in the :ref:`pynq-lib-axigpio`
 sections.
 
 For more examples see the "Buttons and LEDs demonstration" notebook for the
-PYNQ-Z1/PYNQ-Z2 board at:
+ZCU104 board at:
 
 .. code-block:: console
 

--- a/docs/source/pynq_libraries/pmod.rst
+++ b/docs/source/pynq_libraries/pmod.rst
@@ -105,6 +105,8 @@ Examples
 In the :ref:`zcu104-base-overlay`, two Pmod instances are available: PMODA and
 PMODB. After the overlay is loaded these instances can be accessed as follows:
 
+The VCK190 base overlay does not include Pmod interfaces.
+
 .. code-block:: Python
 
    from pynq.overlays.base import BaseOverlay

--- a/docs/source/pynq_libraries/pynq_microblaze_subsystem.rst
+++ b/docs/source/pynq_libraries/pynq_microblaze_subsystem.rst
@@ -24,13 +24,13 @@ interrupt requester, and external interface.
 
 * The Interrupt Controller is the interface for other communication or
   behavioral controllers connected to the MicroBlaze Processor.
-* The Interrupt Requester sends interrupt requests to the Zynq Processing System.
+* The Interrupt Requester sends interrupt requests to the Processing System.
 * The External Interface allows the MicroBlaze subsystem to communicate with
   other communication, behavioral controllers, or DDR Memory.
 * The Block RAM holds MicroBlaze Instructions and Data.
 
 The Block RAM is dual-ported: One port connected to the MicroBlaze Instruction
-and Data ports; The other port is connected to the ARM® Cortex®-A9 processor for
+and Data ports; The other port is connected to the ARM® processor for
 communication.
 
 If the External Interface is connected to DDR Memory, DDR can be used to
@@ -50,12 +50,17 @@ is loaded these can be accessed as follows:
 
    from pynq.overlays.base import BaseOverlay
    from pynq.lib import PynqMicroblaze
+   from pynq.lib.pmod.constants import BIN_LOCATION
 
    base = BaseOverlay('base.bit')
 
-   mb = PynqMicroblaze(base.iop1.mb_info,
-                       "/home/xilinx/pynq/lib/pmod/pmod_timer.bin")
+   mb = PynqMicroblaze(base.PMODA, BIN_LOCATION + "pmod_timer.bin")
    mb.reset()
+
+``base.PMODA`` is the Microblaze information dictionary for the first Pmod
+subsystem, and ``BIN_LOCATION`` is the directory the Pmod executables are
+installed in. The VCK190 base overlay does not include a PYNQ MicroBlaze
+subsystem.
 
 More information about the PynqMicroblaze class, and its API can be found in the
 :ref:`pynq-lib-pynqmicroblaze` section.

--- a/docs/source/pynq_libraries/video.rst
+++ b/docs/source/pynq_libraries/video.rst
@@ -42,18 +42,12 @@ The HDMI-Out is similar to HDMI-In. It has a Pixel Pack block (instead of the
 Video Front-ends
 ----------------
 
-The video library supports two different video front-ends. The front-end is
-responsible for converting the signals at the pins of the device into a
+The front-end converts the signals at the pins of the device into a
 24-bit-per-pixel, BGR formatted AXI stream that can be used by the rest of the
-pipeline. For the Pynq-Z1 and Pynq-Z2 a DVI-based front-end provides for
-resolutions of up to 1080p although due to the speed ratings of the
-differential pins only up to 720p is officially supported. This front-end is a
-drop-in IP included in the PYNQ IP library. For the ZCU104 the Xilinx HDMI
-subsystems are used to support full 4k support however recreating this
-bitstream will require a license. The HDMI subsystems also require connecting
-to a HDMI PHY responsible for driving the transceivers. This code can be seen
-in the ZCU104's `base.py`. All custom overlays needing to use the video
-subsystem should use this setup code.
+pipeline. The ZCU104 uses the AMD HDMI subsystems to support 4K video; rebuilding
+this bitstream requires an HDMI IP licence. The HDMI subsystems also connect to
+an HDMI PHY that drives the transceivers. This setup can be seen in the
+ZCU104's ``base.py``. The VCK190 base overlay does not include a video pipeline.
 
 Processing Options
 ------------------
@@ -98,11 +92,8 @@ HDMI-In block, or before the pixel_unpack block on the HDMI-Out side. This gives
 flexibility to use the video subsystem color space conversion blocks before and
 after the custom IP.
 
-The video pipelines of the Pynq-Z1 and Pynq-Z2 boards run at 142 MHz with one
-pixel-per-clock, slightly below the 148.5 MHz pixel clock for 1080p60 video but
-sufficient once blanking intervals are taken into account. for the ZCU104 board
-the pipeline runs at 300 MHz and two pixels-per-clock to support 4k60 (2160p)
-video.
+The ZCU104 pipeline runs at 300 MHz and two pixels-per-clock to support 4K60
+(2160p) video.
 
 Batch Processing
 ^^^^^^^^^^^^^^^^
@@ -115,10 +106,7 @@ Note that the DRAM is likely to be a bottleneck for video processing. The Video
 data is written to DRAM, then read from DRAM and send to the custom IP and is
 written back to DRAM, where it is read by the HDMI out.
 
-For the Pynq-Z1 which has a 16-bit DRAM, up to 1080p cwgraysc (8-bits per pixel)
-can be processed at ~60fps alongside the framebuffer memory bandwidth, but this
-is very close to the total memory bandwidth of the system. The ZCU104 with its
-much larger memory bandwidth can support 4k video at 60 FPS at 24-bit colour.
+The ZCU104 can support 4K video at 60 FPS at 24-bit colour.
 
 Examples
 --------
@@ -126,8 +114,8 @@ Examples
 More information about the Video subpackage, its components, and its their APIs
 can be found in the :ref:`pynq-lib-video` section.
 
-For more examples, see the Video Notebooks folder on the Pynq-Z1, Pynq-Z2 or
-ZCU104 board in the following directory:
+For more examples, see the Video Notebooks folder on the ZCU104 board in the
+following directory:
 
 .. code-block:: console
 

--- a/docs/source/pynq_overlays.rst
+++ b/docs/source/pynq_overlays.rst
@@ -4,12 +4,10 @@
 PYNQ Overlays
 *************
 
-The AMD-Xilinx® Zynq® All Programmable device is an SOC based on a dual-core ARM®
-Cortex®-A9 processor (referred to as the *Processing System* or **PS**),
-integrated with FPGA fabric (referred to as *Programmable Logic* or **PL**). The
-*PS* subsystem includes a number of dedicated peripherals (memory controllers,
-USB, Uart, IIC, SPI etc) and can be extended with additional hardware IP in a
-*PL* Overlay.
+AMD adaptive SoCs combine an application processor (referred to as the
+*Processing System* or **PS**) with programmable logic (**PL**). The *PS*
+subsystem includes dedicated peripherals and can be extended with additional
+hardware IP in a *PL* overlay.
 
 .. image:: images/zynq_block_diagram.jpg
    :align: center
@@ -42,3 +40,4 @@ by many other software developers working at the application level.
    
     pynq_overlays/loading_an_overlay.ipynb
     pynq_overlays/zcu104
+    pynq_overlays/vck190

--- a/docs/source/pynq_overlays/vck190.rst
+++ b/docs/source/pynq_overlays/vck190.rst
@@ -1,0 +1,21 @@
+.. _VCK190-overlays:
+
+***************
+VCK190 Overlays
+***************
+
+The VCK190 is based on the Versal AI Core Series. For board details, including
+the reference manual and schematics, see the
+`AMD VCK190 webpage <https://www.amd.com/en/products/adaptive-socs-and-fpgas/evaluation-boards/vck190.html>`_.
+
+The following overlay is included by default in the PYNQ image for the VCK190
+board:
+
+.. toctree::
+    :maxdepth: 1
+
+    vck190/vck190_base_overlay
+
+Other third party overlays may also be available for this board. See the
+`PYNQ community webpage <http://www.pynq.io/community.html>`_ for details of
+third party overlays and other resources.

--- a/docs/source/pynq_overlays/vck190/vck190_base_overlay.rst
+++ b/docs/source/pynq_overlays/vck190/vck190_base_overlay.rst
@@ -1,0 +1,75 @@
+.. _vck190-base-overlay:
+
+Base Overlay
+============
+
+The purpose of the *base* overlay design for any PYNQ supported board is to
+allow peripherals on a board to be used out-of-the-box.
+
+The VCK190 uses Versal segmented configuration. The golden reference design
+configures the processors, NoC and DDR during boot. The ``base.pdi`` overlay
+configures the programmable logic at runtime without re-initializing the
+processor.
+
+The base overlay can also be used as a reference design for creating new
+customized overlays.
+
+VCK190 Base Design
+------------------
+
+The base overlay on VCK190 includes the following hardware:
+
+    * Four user LEDs, four DIP switches and four push buttons
+    * AXI DMA loopback through an AXI Stream FIFO
+    * 8 KB block RAM
+    * Two AXI timers and an interrupt controller
+
+User IO
+-------
+
+The four user LEDs, four DIP switches and four push buttons are each controlled
+by an AXI GPIO controller, and are available as the ``leds``, ``switches`` and
+``buttons`` attributes of the overlay.
+
+DMA
+---
+
+The AXI DMA memory-to-stream and stream-to-memory channels are connected in
+loopback through an AXI Stream FIFO. The DMA reaches DDR through the Versal
+NoC.
+
+Python API
+----------
+
+The VCK190 base overlay is loaded from its PDI:
+
+.. code-block:: Python
+
+   from pynq.overlays.base import BaseOverlay
+
+   base = BaseOverlay("base.pdi")
+
+Examples for LEDs, buttons, DIP switches, DMA, block RAM and interrupts are
+provided in ``/home/xilinx/jupyter_notebooks/getting_started.ipynb``.
+
+Rebuilding the Overlay
+----------------------
+
+The project files for the overlay can be found here:
+
+.. code-block:: console
+
+   <PYNQ repository>/boards/VCK190/base
+
+The VCK190 image and overlays share a golden reference design. Build the golden
+design before rebuilding the base overlay:
+
+.. code-block:: console
+
+   cd <PYNQ repository>/boards/VCK190/golden
+   make
+   cd ../base
+   make
+
+Both designs must be built with Vivado 2025.2. The base overlay checks that its
+segmented PDI is compatible with the golden boot image.

--- a/docs/source/pynq_remote/image_build.rst
+++ b/docs/source/pynq_remote/image_build.rst
@@ -6,15 +6,15 @@ Remote Image Build Guide
 Unlike Classic PYNQ, there are no pre-built PYNQ.remote SD card images available, so you'll need to build your own. This can be done in one of two ways:
 
 #. **Using the Docker-based build flow**: This is the recommended method for most users, as it simplifies the build process and ensures a consistent environment.
-#. **Integrating the PYNQ metalayer into a custom Petalinux build**: This is for advanced users who want to customize their Petalinux projects with PYNQ features
+#. **Integrating the PYNQ metalayer into a custom EDF build**: This is for advanced users who want to customize their Yocto projects with PYNQ features.
 
 **Prerequisites:**
 
-- Host machine with Ubuntu 2022.4 OS installed
-- AMD Tools: `Vivado and Vitis version 2025.2 <https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools/2025-2.html>`_ (Petalinux is no longer required)
+- Host machine capable of running the Ubuntu 24.04 (Noble) Docker container
+- AMD tools: Vivado and Vitis version 2025.2
 - `Docker installation <https://docs.docker.com/engine/install/>`_
 
-**Using the Docker-base build flow:**
+**Using the Docker-based build flow:**
 
 #. Clone the PYNQ repository:
 
@@ -22,7 +22,9 @@ Unlike Classic PYNQ, there are no pre-built PYNQ.remote SD card images available
 
         git clone --recursive https://github.com/Xilinx/PYNQ.git
 
-#. Follow the Docker-based build instructions in the `sdbuild/README.md <https://github.com/Xilinx/PYNQ/blob/master/sdbuild/README.md>`_ file to set up the build environment.
+#. Set up the build environment by following :ref:`pynq-sd-card`. This includes
+   setting ``XILINX_TOOLS`` and ``XILINXD_LICENSE_FILE`` before starting the
+   container.
 
 #. Build the remote image for your target board:
 
@@ -32,12 +34,18 @@ Unlike Classic PYNQ, there are no pre-built PYNQ.remote SD card images available
         cd PYNQ/sdbuild
         make pynqremote BOARDS=<board_name>
 
-   Replace ``<board_name>`` with your target board (e.g., ``ZCU104``, ``Pynq-Z2``).
+   Replace ``<board_name>`` with your target board (``ZCU104`` or ``VCK190``).
+   The remote image target does not require the prebuilt classic PYNQ root
+   filesystem or source distribution.
 
-#. Flash the generated image from ``sdbuild/output/`` to an SD card and boot your device (See :doc:`../appendix/sdcard` for more details).
+#. Flash the generated ``sdbuild/output/<BOARD>-4.0.0-remote.img`` image to an
+   SD card and boot your device (See :doc:`../appendix/sdcard` for more
+   details).
 
 #. After booting, the ``pynq-remote`` server will start automatically, allowing you to connect to the device (see :doc:`quickstart` for more details).
 
-**Alternative: Using PYNQ Metalayer in Custom Petalinux Build**
+**Alternative: Using PYNQ Metalayer in Custom EDF Build**
 
-Advanced users can integrate the ``meta-pynq`` metalayer into their own Yocto projects built on AMD's EDF (Extensible Device Framework). The layer lives at ``sdbuild/boot/meta-pynq/`` and declares Scarthgap / Styhead compatibility.
+Advanced users can integrate the ``meta-pynq`` metalayer into their own Yocto
+projects built on AMD's EDF (Extensible Device Framework). The layer lives at
+``sdbuild/boot/meta-pynq/`` and declares Scarthgap compatibility.

--- a/docs/source/pynq_remote/quickstart.rst
+++ b/docs/source/pynq_remote/quickstart.rst
@@ -99,9 +99,7 @@ After installation, the notebooks will be available in the current folder under 
 Modifying the Notebook for PYNQ.remote
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you open the ``resizer_pl.ipynb`` notebook, you need to make two changes to make it compatible with PYNQ.remote:
-
-**1. Add the environment variable setting**
+When you open the ``resizer_pl.ipynb`` notebook, you need to make one change to make it compatible with PYNQ.remote.
 
 Find the cell with the imports and modify it to include the ``PYNQ_REMOTE_DEVICES`` environment variable:
 
@@ -127,24 +125,7 @@ Change it to:
    os.environ['PYNQ_REMOTE_DEVICES'] = "192.168.2.99"  # Replace with your board's IP
    from pynq import allocate, Overlay
 
-**2. Fix the image display for RemoteBuffer**
+The rest of the notebook runs unmodified. ``RemoteBuffer`` is a ``numpy.ndarray``
+subclass, so ``Image.fromarray(out_buffer)`` reads the resized image directly.
 
-Find the cell that creates the PIL Image from the output buffer and modify it to work with PYNQ.remote's RemoteBuffer:
-
-.. code-block:: python
-
-   # Original cell:
-   run_kernel()
-   resized_image = Image.fromarray(out_buffer)
-
-Change it to:
-
-.. code-block:: python
-
-   # Modified cell:
-   run_kernel()
-   resized_image = Image.fromarray(out_buffer[:])
-
-The ``[:]`` slice is necessary because PYNQ.remote's RemoteBuffer works slightly differently than PYNQ's PynqBuffer, and PIL won't be able to read the data correctly otherwise.
-
-Once these changes are made, you should be able to run through the entire notebook and resize images completely remotely using PYNQ.remote!
+Once this change is made, you should be able to run through the entire notebook and resize images completely remotely using PYNQ.remote!

--- a/docs/source/pynq_sd_card.rst
+++ b/docs/source/pynq_sd_card.rst
@@ -4,16 +4,16 @@
 PYNQ SD Card image
 ******************
 
-This page will explain how SD card images can be built for PYNQ
-embedded platforms (Zynq, Zynq Ultrascale+, Zynq RFSoC). 
+This page explains how SD card images can be built for PYNQ embedded
+platforms.
 
 Note: the PYNQ images for supported boards are provided as precompiled 
 `downloadable SD card images <https://www.pynq.io/boards.html>`_ and do 
 not need rebuilt.  The SD card build flow is
 only required to modify SD cards' contents or target a new board.
 
-Specifically, The SD card build flow will create the BOOT.bin, the u-boot
-bootloader, the Linux Device tree blob, the Linux kernel and the
+Specifically, the SD card build flow creates ``BOOT.BIN``, the U-Boot
+bootloader, the Linux device tree blob, the Linux kernel and the
 PYNQ-Linux root filesystem.
 
 The source files for the PYNQ image flow build can be found here:
@@ -22,34 +22,28 @@ The source files for the PYNQ image flow build can be found here:
     
    <PYNQ repository>/sdbuild
 
-More details on configuring the root filesystem can be found in the README file
-in the folder above.
 
 Prepare the Building Environment
 ================================
 
-It is recommended to use a Ubuntu OS to build the image. The currently supported
-Ubuntu OS are listed below:
+The image build runs in a Docker container based on the following Ubuntu
+release:
 
 ================  ==================
 Supported OS      Code name
 ================  ==================   
-Ubuntu 22.04       Jammy
+Ubuntu 24.04       Noble
 ================  ==================
 
 Use Docker to prepare the build environment
 -------------------------------------------
-Starting with the PYNQ v3.1 release, Docker is the recommended way to build PYNQ images. 
-Docker simplifies setup by managing dependencies and environment configuration within an 
-isolated container.
-
-If you do not have a supported Ubuntu machine, you can use Docker to create an isolated 
-build environment on your host OS using the following steps:
+Docker manages the image build dependencies and environment. AMD tools remain
+on the host and are mounted into the container.
 
   1. Install Docker on your host OS by following the 
      `official Docker installation instructions <https://docs.docker.com/engine/install/>`_.
 
-  2. Install the required AMD tools on your host OS (not inside Docker):
+  2. Install the required AMD tools on the host:
      
      * **Vivado** and **Vitis**, version 2025.2 (Petalinux is no longer required)
      * Ensure your host OS is supported by the AMD tools (see 
@@ -58,7 +52,7 @@ build environment on your host OS using the following steps:
      .. note::
         AMD tools must be installed on the host system, not inside the Docker container.
 
-  3. Clone the PYNQ repository and in a bash shell, build the Docker image:
+  3. Clone the PYNQ repository and build the Docker image:
 
      .. code-block:: console
     
@@ -70,135 +64,63 @@ build environment on your host OS using the following steps:
           --build-arg USER_GID=$(id -g) \
           -t pynqdock:latest .
 
-     If you are in a csh-like shell, switch to Bash by typing: ``bash``.
-
      The ``--build-arg`` values ensure that files created inside the container 
      will be owned by your user on the host system, avoiding permission issues.
 
-  4. Run the Docker container, mounting your AMD tools and PYNQ repository:
+  4. From the top of the PYNQ repository, set the paths to the AMD tools and
+     licence, then run the container:
 
      .. code-block:: console
-    
-        docker run \
-          --init \
-          --rm \
-          -it \
-          -v /tools/Xilinx:/tools/Xilinx:ro \
-          -v /home/user/petalinux:/home/user/petalinux:ro \
-          -v $(pwd):/workspace \
-          --name pynq-sdbuild-env \
+
+        export XILINX_TOOLS=/tools/Xilinx/2025.2
+        export XILINXD_LICENSE_FILE="$HOME/.Xilinx"
+
+        docker run --init --rm \
+          --network host \
+          -e XILINX_TOOLS -e XILINXD_LICENSE_FILE \
+          -v "$XILINX_TOOLS:$XILINX_TOOLS:ro" \
+          -v "$XILINXD_LICENSE_FILE:$XILINXD_LICENSE_FILE" \
+          -v "$PWD:/workspace" \
           --privileged \
           pynqdock:latest \
-          /bin/bash
+          bash -lc 'cd /workspace/sdbuild && make BOARDS=ZCU104 REBUILD_PYNQ_SDIST=1 REBUILD_PYNQ_ROOTFS=1'
 
-     Replace ``/tools/Xilinx`` and ``/home/user/petalinux`` with the actual paths 
-     to your Xilinx installations on the host system. The ``:ro`` option mounts 
-     tool directories as read-only, and ``--privileged`` is required for parts of 
-     the build process.
+     Set ``BOARDS=VCK190`` to build a VCK190 image. Multiple board names can be
+     supplied at once.
 
-  5. Inside the container, set up the tool environment:
+Building the Image
+==================
 
-     .. code-block:: console
-    
-        source /tools/Xilinx/Vivado/2025.2/settings64.sh
+The build flow expects a prebuilt board-agnostic root filesystem and PYNQ source
+distribution unless they are rebuilt from source. Place prebuilt files in the
+``sdbuild/prebuilt`` folder:
 
-     Adjust the paths to match your actual Xilinx tool installation paths.
+.. code-block:: console
 
-  6. You are now ready to build PYNQ images inside the Docker container. 
-     Navigate to the sdbuild directory and follow the building instructions 
-     in the next section.
+   cp pynq_rootfs.aarch64.tar.gz <PYNQ repository>/sdbuild/prebuilt/
+   cp pynq-<version>.tar.gz <PYNQ repository>/sdbuild/prebuilt/pynq_sdist.tar.gz
 
+To build one of the supported images using the prebuilt files:
 
-Use an existing Ubuntu OS
--------------------------
-If you're not able to use Docker, you can still build PYNQ images on a supported Ubuntu OS.
+.. code-block:: console
 
-If you already have a Ubuntu OS, and it is listed in the beginning of
-this section, you can simply do the following:
+   cd <PYNQ repository>/sdbuild/
+   make BOARDS=ZCU104
+   make BOARDS=VCK190
 
-  1. Install dependencies using the following script. This is necessary 
-     if you are not using our vagrant file to prepare the environment.
+To build the PYNQ source distribution and root filesystem from source:
 
-     .. code-block:: console
-    
-        <PYNQ repository>/sdbuild/scripts/setup_host.sh
+.. code-block:: console
 
-  2. Install correct version of the Xilinx tools, including 
-     PetaLinux, Vivado, and Vitis. See the table below for the correct version 
-     of each release.
+   make BOARDS=ZCU104 REBUILD_PYNQ_SDIST=1 REBUILD_PYNQ_ROOTFS=1
 
-     Starting from image v2.5, SDx is no longer needed.
-
-     ================  ================
-     Release version    Xilinx Tool Version
-     ================  ================
-     v1.4               2015.4
-     v2.0               2016.1
-     v2.1               2017.4
-     v2.2               2017.4
-     v2.3               2018.2
-     v2.4               2018.3
-     v2.5               2019.1
-     v2.6               2020.1
-     v2.7               2020.2
-     v3.0               2022.1
-     v3.1               2024.1
-     v4.0               2025.2
-     ================  ================
-
-Building the Image From Source
-==============================
-
-Once you have the build environment ready, you can build an SD card image 
-following the steps below. You don't have to rerun the `setup_host.sh`.
-
-  1. Source the Vitis settings for Xilinx 2025.2 tools (Petalinux is
-     no longer required — the EDF build container sources Vivado
-     automatically from ``VIVADO_PATH``):
-
-     .. code-block:: console
-
-        source <path-to-vitis>/Vitis/2025.2/settings64.sh
-
-  2. Depending on the overlays being rebuilt, make sure you have the appropriate
-     Vivado licenses to build for your target board, especially the
-     `HDMI IP <https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/hdmi.html>`_
-     for the ZCU104 or the `CMAC IP <https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/cmac.html>`_
-     for the RFSoC4x2.   
-
-  3. Collect a prebuilt board-agnostic root filesystem tarball and a prebuilt PYNQ
-     source distribution.  Starting in PYNQ v3.0, by default the SD card build
-     flow expects a prebuilt root filesystem and a PYNQ source distribution to
-     speedup and simplify user rebuilds of SD card images.  These binaries can be
-     found at `the PYNQ boards page <https://www.pynq.io/boards.html>`_ and
-     copied into the sdbuild prebuilt folder
-
-     .. code-block:: console
-
-	# For rebuilding all SD cards, both arm and aarch64 root filesystems
-	# may be required depending on boards being targetted.
-        cp pynq_rootfs.<arm|aarch64>.tar.gz <PYNQ repository>/sdbuild/prebuilt/pynq_rootfs.<arm|aarch64>.tar.gz
-	cp pynq-<version>.tar.gz            <PYNQ repository>/sdbuild/prebuilt/pynq_sdist.tar.gz
-        
-
-     
-  4. Navigate to the following directory and run make
-
-     .. code-block:: console
-    
-        cd <PYNQ repository>/sdbuild/
-        make
-
-The build flow can take several hours and will rebuild SD cards for the Pynq-Z1, Pynq-Z2
-and ZCU104 platforms. 
+The image is written to ``sdbuild/output/<BOARD>-4.0.0.img`` and its boot
+artefacts are written to ``sdbuild/output/boot/<BOARD>/``.
 
 Rebuilding the prebuilt board-agnostic image
 --------------------------------------------
-In order to simplify and speed-up the image building process, users should re-use the 
-prebuilt board-agnostic image appropriate to the architecture - arm for Zynq-7000 
-and aarch64 for Zynq UltraScale+, downloadable at the 
-`boards page <https://www.pynq.io/boards.html>`_ of our website. This will allow 
-you to completely skip the board-agnostic stage.
+ZCU104 and VCK190 use the ``aarch64`` root filesystem. Reusing the prebuilt
+root filesystem skips the board-agnostic stage.
 
 You can force a root filesystem build by setting the ``REBUILD_PYNQ_ROOTFS`` variable
 when invoking make:
@@ -206,13 +128,12 @@ when invoking make:
 .. code-block:: console
     
    cd <PYNQ repository>/sdbuild/
-   make REBUILD_PYNQ_ROOTFS=True BOARDS=<board>
+   make REBUILD_PYNQ_ROOTFS=1 BOARDS=<board>
 
 Rebuilding the PYNQ source distribution tarball
 -----------------------------------------------
-To avoid rebuilding the PYNQ source distribution package, and consequently bypass
-the need to build bitstreams for the PYNQ-Z1, PYNQ-Z2 and the
-ZCU104, a prebuilt PYNQ sdist tarball should be reused as described in steps listed above.
+Reuse the prebuilt PYNQ source distribution package unless the package or
+included overlays have changed.
 
 You can force a PYNQ source distribution rebuild by setting the ``REBUILD_PYNQ_SDIST`` variable
 when invoking make
@@ -220,118 +141,172 @@ when invoking make
 .. code-block:: console
     
    cd <PYNQ repository>/sdbuild/
-   make REBUILD_PYNQ_SDIST=True
+   make REBUILD_PYNQ_SDIST=1 BOARDS=<board>
 
+Cleaning image build output
+---------------------------
 
-Please also refer to the 
-`sdbuild readme <https://github.com/Xilinx/PYNQ/blob/master/sdbuild/README.md>`_
-on our GitHub repository for more info regarding the image-build flow.
-
-Unmount images before building again
-------------------------------------
-Sometimes the SD image building process can error out, leaving mounted images
-in your host OS. You need to unmount these images before trying the make
-process again. Starting from image v2.6, users can do the following to
-unmount the images.
-
-.. code-block:: console
-    
-   cd <PYNQ repository>/sdbuild/
-   make delete
-
-The above command not only unmounts all the images, but also deletes the
-failed images. This makes sure the users do not use the failed images when
-continuing the SD build process.
-
-To unmount images but not delete them, use the following command instead.
-
-.. code-block:: console
-    
-   cd <PYNQ repository>/sdbuild/
-   make unmount
-
-If you want to ignore all the previous staged or cached SD build
-artifacts and start from scratch again, you can use the following command.
-This will unmount and delete the failed images, and remove all the previously
-built images at different stages.
+To remove the build and output directories while retaining the EDF cache:
 
 .. code-block:: console
     
    cd <PYNQ repository>/sdbuild/
    make clean
 
+The first EDF build creates an ``sdbuild/edf-cache`` directory of approximately
+30 GB. Set ``EDF_CACHE=/path/to/edf-cache`` to share it between checkouts or
+store it on another filesystem.
+
 
 Retargeting to a Different Board
 ================================
 
-Additional boards are supported through external *board repositories*. A board
-repository consists of a directory for each board consisting of a spec file and
-any other files. The board repository is treated the same way as the ``<PYNQ
-repository>/boards`` directory.
+Additional boards can be supplied through an external board directory. Each
+board is a directory containing a ``<BOARD>.spec`` file and an ``edf.env`` file.
+Those two are the only required files; everything else is added as the board
+needs it. The external directory is treated like the
+``<PYNQ repository>/boards`` directory.
+
+Board directory layout
+----------------------
+
+.. code-block:: console
+
+   Myboard/
+   ├── Myboard.spec          # required: make variables for the board
+   ├── edf.env               # required: boot artefact configuration
+   ├── edf_bsp/              # optional
+   │   ├── board.dtsi        # optional: device tree nodes for the board
+   │   ├── kernel.cfg        # optional: kernel config fragment
+   │   └── u-boot/           # optional: u-boot patches and config fragments
+   ├── base/                 # required if BITSTREAM_<BOARD> is set: overlay
+   │                         # sources and a Makefile that builds them
+   ├── notebooks/            # optional: notebooks, delivered to the image
+   └── packages/             # optional: extra packages for the root filesystem
+
+The directory name is the board name. It must match the ``.spec`` file name and
+the ``<BOARD>`` suffix of the variables inside it, and it becomes the ``BOARD``
+environment variable in the image.
 
 Elements of the specification file
 ----------------------------------
 
-The specification file should be name ``<BOARD>.spec`` where BOARD is the name
-of the board directory. A minimal spec file contains the following information
+The specification file should be named ``<BOARD>.spec``, where BOARD is the name
+of the board directory. All paths in it are relative to the board directory.
+
+=========================== ============ ======================================
+Variable                                 Meaning
+=========================== ============ ======================================
+``ARCH_<BOARD>``            required     ``aarch64``
+``BITSTREAM_<BOARD>``       optional     Overlay loaded at boot, for example
+                                         ``base/base.bit`` or ``base/base.pdi``.
+                                         Leave unset for a board with no boot
+                                         overlay
+``FPGA_MANAGER_<BOARD>``    optional     ``1`` to program the PL through the
+                                         FPGA manager. Defaults to ``1``, and
+                                         selects which zocl device tree nodes
+                                         are used
+``STAGE4_PACKAGES_<BOARD>`` optional     Packages installed into the board's
+                                         root filesystem. Without ``pynq`` here
+                                         the image has no PYNQ in it
+``REMOTE_PACKAGES_<BOARD>`` optional     Extra packages for a PYNQ.remote root
+                                         filesystem
+=========================== ============ ======================================
 
 .. code-block:: makefile
 
-   ARCH_${BOARD} := arm
-   BSP_${BOARD} := mybsp.bsp
-   BITSTREAM_${BOARD} := mybitstream.bsp
-   FPGA_MANAGER_${BOARD} := 1
+   ARCH_Myboard := aarch64
+   BITSTREAM_Myboard := base/base.bit
+   FPGA_MANAGER_Myboard := 1
+   STAGE4_PACKAGES_Myboard := xrt pynq ethernet selftest
 
-where ``${BOARD}`` is also the name of the board. The ARCH should be *arm* for
-Zynq-7000 or *aarch64* for Zynq UltraScale+. If no bitstream is provided then the
-one included in the BSP will be used by default. All paths in this file
-should be relative to the board directory.
+Boot artefacts: ``edf.env``
+---------------------------
 
-To customise the BSP a ``petalinux_bsp`` folder can be included in the board
-directory the contents of which will be added to the provided BSP before the
-project is created. See the ZCU104 for an example of this in action. This is
-designed to allow for additional drivers, kernel or boot-file patches and
-device tree configuration that are helpful to support elements of PYNQ to be
-added to a pre-existing BSP.
+``BOOT.BIN``, the kernel ``Image``, ``system.dtb``, the kernel modules and
+``zocl.ko`` are built with AMD's EDF (Yocto/bitbake) flow. ``edf.env`` selects
+the Yocto machine to build them for.
 
-If a suitable PetaLinux BSP is unavailable for the board then ``BSP_${BOARD}``
-can be left blank; in this case, users have two options:
+========================== ============ =======================================
+Key                                     Meaning
+========================== ============ =======================================
+``EDF_BOOT_MACHINE``       required     Machine used for ``BOOT.BIN`` and the
+                                        device tree
+``EDF_MODE``               optional     ``prebuilt`` to use a machine from
+                                        AMD's layers, ``custom`` to generate
+                                        one from an XSA. Defaults to
+                                        ``prebuilt``
+``EDF_LINUX_MACHINE``      optional     Machine used for the kernel. Defaults
+                                        to ``EDF_BOOT_MACHINE``
+``EDF_MANIFEST_TAG``       optional     EDF manifest tag to sync. Defaults to
+                                        the tag used by the build scripts
+``BSP_XSA_PATH``           custom mode  The XSA to generate the machine from.
+                                        Without it, ``base/base.xsa`` is used
+                                        if present
+``EDF_BOARD_DTS``          optional     Custom mode only: board DTS to pass to
+                                        ``sdtgen``. Omit to use the generic SoC
+                                        device tree and put everything
+                                        board-specific in ``board.dtsi``
+``EDF_DDR_HIGH_BANK_REG``  optional     ``reg`` value trimming the high DDR
+                                        bank to the board's real size
+========================== ============ =======================================
 
- 1. Place a *<design_name>.xsa* file in the ``petalinux_bsp/hardware_project``
-    folder. As part of the build flow, a new BSP will be created from
-    this XSA file.
- 2. Place a makefile along with tcl files which can generate the hardware
-    design in the ``petalinux_bsp/hardware_project`` folder.
-    As part of the build flow, the hardware design along with the XSA file
-    will be generated, then a new BSP will be created from this XSA file.
+Use prebuilt mode when AMD's layers already contain a machine for the board, as
+for the ZCU104:
 
-Starting from image v2.6, we allow users to disable FPGA manager by setting
-``FPGA_MANAGER_${BOARD}`` to 0. This may have many use cases. For example,
-users may want the bitstream to be downloaded at boot to enable some
-board components as early as possible. Another use case is that users want
-to enable interrupt for XRT. The side effect of this, is that users
-may not be able to reload a bitstream after boot.
+.. code-block:: shell
 
-If ``FPGA_MANAGER_${BOARD}`` is set to 1 or ``FPGA_MANAGER_${BOARD}`` is
-not defined at all, FPGA manager will be enabled. In this case, the bitstream
-will be downloaded later in user applications; and users can only use XRT
-in polling mode. This is the default behavior of PYNQ since we want users
-to be able to download any bitstream after boot.
+   EDF_MANIFEST_TAG=amd-edf-rel-v25.11.1
+   EDF_MODE=prebuilt
+   EDF_BOOT_MACHINE=zynqmp-zcu104-sdt-full
+   EDF_LINUX_MACHINE=zynqmp-zcu104-sdt-full
+
+Use custom mode when the boot image has to match a design built here, as on
+Versal, where ``BOOT.BIN`` carries the golden reference design that runtime
+overlays are segmented children of. The build runs ``sdtgen`` on
+``BSP_XSA_PATH`` to produce a system device tree, then ``gen-machine-conf`` to
+turn that into a machine layer, so Vivado must be available. The VCK190:
+
+.. code-block:: shell
+
+   EDF_MANIFEST_TAG=amd-edf-rel-v25.11.1
+   EDF_MODE=custom
+   EDF_BOOT_MACHINE=versal-vck190-pynq-seg
+   EDF_LINUX_MACHINE=amd-cortexa72-common
+   EDF_BOARD_DTS=versal-vck190-reva
+   BSP_XSA_PATH=golden/golden.xsa
+
+In custom mode ``EDF_BOOT_MACHINE`` must not match a machine name in AMD's
+layers, or bitbake resolves theirs and ignores the generated one.
+
+Kernel, device tree and U-Boot: ``edf_bsp``
+-------------------------------------------
+
+All three are optional, and a board that needs none of them can omit
+``edf_bsp`` entirely.
+
+ 1. ``board.dtsi`` is appended to the machine's device tree. Board-specific
+    nodes belong here: memory, PHYs, I2C devices, pin settings.
+ 2. ``kernel.cfg`` is added to the kernel's sources as a config fragment when
+    present, and merged into its ``.config``.
+ 3. ``u-boot/`` is added to U-Boot's sources when present. ``.patch`` and
+    ``.diff`` files are applied, and ``.cfg`` fragments are merged into U-Boot's
+    ``.config``.
+
+Editing ``board.dtsi`` invalidates the device tree's shared state, so the change
+is picked up on the next build.
 
 Board-specific packages
 -----------------------
 
-A ``packages`` directory can be included in board directory with the same
-layout as the ``<PYNQ repository>/sdbuild/packages`` directory. Each
-subdirectory is a package that can optionally be installed as part of image
-creation. See ``<PYNQ repository>/sdbuild/packages/README.md`` for a
-description of the format of a PYNQ sdbuild package.
-
-To add a package to the image you must also define a
-``STAGE4_PACKAGE_${BOARD}`` variable in your spec file. These can either
-packages in the standard sdbuild library or ones contained within the board
-package. It is often useful to add the ``pynq`` package to this list which will
-ensure that a customised PYNQ installation is included in your final image.
+A ``packages`` directory can be included in the board directory with the same
+layout as the ``<PYNQ repository>/sdbuild/packages`` directory. A directory
+under it becomes installable by naming it in ``STAGE4_PACKAGES_<BOARD>``, and
+packages from the standard sdbuild library can be named there too. A package
+consists of up to four optional files: a ``Makefile`` for work done on the host,
+``pre.sh`` and ``post.sh`` which run outside the target root filesystem and are
+passed its path, and ``qemu.sh`` which runs inside it under QEMU. Scripts should
+write temporary files to ``$BUILD_ROOT``.
 
 Leveraging ``boot.py`` to modify SD card boot behavior
 ------------------------------------------------------
@@ -349,9 +324,9 @@ boot partition of the board and no other files should be modified.
 
 If you see some existing code running inside the boot.py file, it probably came
 from a PYNQ sdbuild package that modified that file.  To see an example of an
-sdbuild package writing the boot.py file see the ZCU104's `boot_leds package 
-<https://github.com/Xilinx/PYNQ/tree/image_v2.6.0/boards/ZCU104/packages/boot_leds>`_
-which simply flashes the boards LEDs to signify Linux has booted on the board.
+sdbuild package writing the boot.py file see the ZCU104's ``boot_leds`` package
+in ``<PYNQ repository>/boards/ZCU104/packages/boot_leds``, which simply flashes
+the boards LEDs to signify Linux has booted on the board.
 
 Using the PYNQ package
 ----------------------
@@ -362,7 +337,7 @@ officially supported boards. This means, in particular, that:
  1. A ``notebooks`` folder, if it exists, will be copied into the
     ``jupyter_notebooks`` folder in the image. Notebooks here will overwrite any of
     the default ones.
- 2. Any directory containing a bitstream will be treated as an overlay and
+ 2. Any directory containing a ``.bit`` or ``.pdi`` file will be treated as an overlay and
     copied into the overlays folder of the PYNQ installation. Any notebooks will
     likewise by installed in an overlay-specific subdirectory.
 


### PR DESCRIPTION
Updates PYNQ 4.0 documentation for the EDF/Noble SD card build flow, adds VCK190 setup and base overlay pages, and removes stale Pynq-Z1/Z2 references from FAQs, appendix, and library guides. Also fixes PYNQ.remote image_build and quickstart (drops the obsolete out_buffer[:] workaround).