### PR TITLE
Fix to avoid versal XSAs being treated exclusively as ZU XSAs

### DIFF
--- a/pynq/pl_server/embedded_device.py
+++ b/pynq/pl_server/embedded_device.py
@@ -273,7 +273,7 @@ class BitstreamHandler:
             xclbin_parser = XclBin(xclbin_data=xclbin_data)
             _unify_dictionaries(parser, xclbin_parser)
             parser.refresh_hierarchy_dict()
-            self._xsa_bitstream_file = parser.xsa.bitstreamPaths[0]
+            self._xsa_bitstream_file = parser.xsa._primaryProgrammableImagePath()
         else:
             return None
         parser.bin_data = self.get_bin_data()
@@ -317,7 +317,7 @@ class XsafileHandler(BitstreamHandler):
         if self._xsa_bitstream_file is None:
             raise RuntimeError("Could not find bitstream file in XSA")
         else:
-            return bit2bin(Path(self._xsa_bitstream_file).read_bytes())
+            return _get_bitstream_handler(self._xsa_bitstream_file).get_bin_data()
 
 
 class PdifileHandler(BitstreamHandler):

--- a/pynq/pl_server/remote_device.py
+++ b/pynq/pl_server/remote_device.py
@@ -115,7 +115,7 @@ class RemoteBitstreamHandler(BitstreamHandler):
             xclbin_parser = XclBin(xclbin_data=xclbin_data)
             _unify_dictionaries(parser, xclbin_parser)
             parser.refresh_hierarchy_dict()
-            self._xsa_bitstream_file = parser.xsa.bitstreamPaths[0]
+            self._xsa_bitstream_file = parser.xsa._primaryProgrammableImagePath()
         else:
             return None
         parser.bin_data = self.get_bin_data()
@@ -140,7 +140,7 @@ class RemoteXsafileHandler(RemoteBitstreamHandler):
         if self._xsa_bitstream_file is None:
             raise RuntimeError("Could not find bitstream file in XSA")
         else:
-            return bit2bin(Path(self._xsa_bitstream_file).read_bytes())
+            return _get_bitstream_handler(self._xsa_bitstream_file).get_bin_data()
 
 _bitstream_handlers = {
     ".bit": RemoteBitfileHandler,


### PR DESCRIPTION
`_primaryProgrammableImagePath()` from `pynqutils` is utilised here to resolve either classical `bitstreamPaths[0]` or PDI `deviceImagePaths[0]` from an XSA  — previously `self._xsa_bitstream_file` was set straight to `bitstreamPaths[0]`, so every XSA was treated as ZU and Versal XSA designs hit an error.

A second change stops the PDI extracted from the XSA container being run through `bit2bin` — as PDIs are already in the format the FPGA manager expects. The change allows the bitfile (.bit or .pdi) extracted from the XSA to be re-associated with its respective handler, so that their `get_bin_data()` methods can be used to pass the correct data format to the FPGA manager.