### PR TITLE
Fixing versal remote clocks from defaulting to Zynq Ultrascale class `_ClocksUltrascale`

### DIFF
--- a/pynq/pl_server/hwh_parser.py
+++ b/pynq/pl_server/hwh_parser.py
@@ -13,7 +13,7 @@ from pynq.ps import (
     CPU_ARCH_IS_SUPPORTED,
     ZU_ARCH,
     ZYNQ_ARCH,
-    _is_versal_host,
+    _is_versal,
 )
 
 
@@ -760,7 +760,7 @@ class _HWHVersal(_HWHABC):
 
 if CPU_ARCH == ZU_ARCH:
     # Versal is also aarch64, so pick the parser from the device tree.
-    HWH = _HWHVersal if _is_versal_host() else _HWHUltrascale
+    HWH = _HWHVersal if _is_versal() else _HWHUltrascale
 elif CPU_ARCH == ZYNQ_ARCH:
     HWH = _HWHZynq
 else:

--- a/pynq/pl_server/versal_device.py
+++ b/pynq/pl_server/versal_device.py
@@ -3,7 +3,7 @@
 
 import os
 
-from pynq.ps import _is_versal_host
+from pynq.ps import _is_versal
 
 from .embedded_device import EmbeddedDevice
 
@@ -25,7 +25,7 @@ class VersalDevice(EmbeddedDevice):
 
     @classmethod
     def _probe_(cls):
-        if _is_versal_host():
+        if _is_versal():
             return [VersalDevice()]
         else:
             return []

--- a/pynq/ps.py
+++ b/pynq/ps.py
@@ -25,18 +25,26 @@ _VERSAL_DT_MARKERS = (
 )
 
 
-def _is_versal_host():
+def _is_versal(device=None):
     """Return True when the device tree identifies the SoC as Versal.
 
     ZynqMP and Versal both report `aarch64`, so `CPU_ARCH` cannot tell
-    them apart.
+    them apart. A remote device is a different machine from the one running
+    this code, so its device tree is read over the connection instead.
 
     """
+    remote = device is not None and device.has_capability('REMOTE')
     for path, marker in _VERSAL_DT_MARKERS:
         try:
-            with open(path, 'rb') as f:
-                if marker in f.read():
+            if remote:
+                if not device.exists_file(path).exists:
+                    continue
+                if marker in device.read_file(path):
                     return True
+            else:
+                with open(path, 'rb') as f:
+                    if marker in f.read():
+                        return True
         except OSError:
             continue
     return False
@@ -401,7 +409,7 @@ class _ClocksMeta(type):
                 cls._real_instance = _ClocksZynq(device=cls.device)
             elif cls.device.arch == ZU_ARCH:
                 # Versal is also aarch64, but has no CRL_APB/CRF_APB.
-                if _is_versal_host():
+                if _is_versal(cls.device):
                     cls._real_instance = _ClocksVersal(device=cls.device)
                 else:
                     cls._real_instance = _ClocksUltrascale(device=cls.device)


### PR DESCRIPTION
Fixing bug where `_is_versal_host()` fails for PYNQ.remote running on x86. This is because the original `_is_versal_host()` function looks into the Linux device tree of the machine running the code, which for a remote device is the host rather than the board. This was causing versal devices to default to the Ultrascale clocks class `_ClocksUltrascale`, and forcing the device to use incorrect registers for clock updates.

The name of `_is_versal_host()` was updated to `_is_versal()` to be more explicit about its functionality in the context of remote devices. It now takes the device it is being asked about, and reads it's device tree over the existing connection when it is remote, falling back to the local filesystem otherwise. All instances of the function call throughout the repository have been adjusted.